### PR TITLE
Improved precharge and discharge process

### DIFF
--- a/include/cvc/cvc_control.h
+++ b/include/cvc/cvc_control.h
@@ -36,9 +36,10 @@
 
 #define MAX_SAG_PERCENT 0.60  // Threshold for bus voltage sag before forcing not ready to drive
 
-#define VOLTAGE_DROP_TIMEOUT 1000 // Time before voltage is considered invalid before leaving RTD
+#define VOLTAGE_DROP_TIMEOUT 500 // Time before voltage is considered invalid before leaving RTD
 
-#define PRECHARGE_TIME 5000  // Time in milliseconds for precharge to take place
+#define PRECHARGE_TIME 1500  // Time in milliseconds for precharge to take place
+#define PRECHARGE_HOLD_TIME 200  // Minimum time in milliseconds for the contactors to be closed before the vehicle can be discharged
 
 typedef enum {
     INITIAL,


### PR DESCRIPTION
Added a check for whether a dip in inverter voltage lasts at least 200ms before opening contactors in earlier stages of precharge process.

Reduced the time it takes for the contactors to open from ready-to-drive.

Reduced the time needed for precharge to complete.