### PR TITLE
Improve CAN receive code and RTOS behavior

### DIFF
--- a/STM32F767ZITX_FLASH.ld
+++ b/STM32F767ZITX_FLASH.ld
@@ -85,13 +85,15 @@ SECTIONS
     . = ALIGN(4);
   } >FLASH
 
-  .ARM.extab   : {
+  .ARM.extab : /* The "READONLY" keyword is only supported in GCC11 and later, remove it if using GCC10 or earlier. */
+  {
     . = ALIGN(4);
     *(.ARM.extab* .gnu.linkonce.armextab.*)
     . = ALIGN(4);
   } >FLASH
 
-  .ARM : {
+  .ARM : /* The "READONLY" keyword is only supported in GCC11 and later, remove it if using GCC10 or earlier. */
+  {
     . = ALIGN(4);
     __exidx_start = .;
     *(.ARM.exidx*)
@@ -99,7 +101,7 @@ SECTIONS
     . = ALIGN(4);
   } >FLASH
 
-  .preinit_array     :
+  .preinit_array : /* The "READONLY" keyword is only supported in GCC11 and later, remove it if using GCC10 or earlier. */
   {
     . = ALIGN(4);
     PROVIDE_HIDDEN (__preinit_array_start = .);
@@ -108,7 +110,7 @@ SECTIONS
     . = ALIGN(4);
   } >FLASH
 
-  .init_array :
+  .init_array : /* The "READONLY" keyword is only supported in GCC11 and later, remove it if using GCC10 or earlier. */
   {
     . = ALIGN(4);
     PROVIDE_HIDDEN (__init_array_start = .);
@@ -118,7 +120,7 @@ SECTIONS
     . = ALIGN(4);
   } >FLASH
 
-  .fini_array :
+  .fini_array : /* The "READONLY" keyword is only supported in GCC11 and later, remove it if using GCC10 or earlier. */
   {
     . = ALIGN(4);
     PROVIDE_HIDDEN (__fini_array_start = .);

--- a/STM32F767ZITX_RAM.ld
+++ b/STM32F767ZITX_RAM.ld
@@ -87,13 +87,15 @@ SECTIONS
     . = ALIGN(4);
   } >RAM
 
-  .ARM.extab   : {
+  .ARM.extab : /* The "READONLY" keyword is only supported in GCC11 and later, remove it if using GCC10 or earlier. */
+  {
     . = ALIGN(4);
     *(.ARM.extab* .gnu.linkonce.armextab.*)
     . = ALIGN(4);
   } >RAM
 
-  .ARM : {
+  .ARM : /* The "READONLY" keyword is only supported in GCC11 and later, remove it if using GCC10 or earlier. */
+  {
     . = ALIGN(4);
     __exidx_start = .;
     *(.ARM.exidx*)
@@ -101,7 +103,7 @@ SECTIONS
     . = ALIGN(4);
   } >RAM
 
-  .preinit_array     :
+  .preinit_array : /* The "READONLY" keyword is only supported in GCC11 and later, remove it if using GCC10 or earlier. */
   {
     . = ALIGN(4);
     PROVIDE_HIDDEN (__preinit_array_start = .);
@@ -110,7 +112,7 @@ SECTIONS
     . = ALIGN(4);
   } >RAM
 
-  .init_array :
+  .init_array : /* The "READONLY" keyword is only supported in GCC11 and later, remove it if using GCC10 or earlier. */
   {
     . = ALIGN(4);
     PROVIDE_HIDDEN (__init_array_start = .);
@@ -120,7 +122,7 @@ SECTIONS
     . = ALIGN(4);
   } >RAM
 
-  .fini_array :
+  .fini_array : /* The "READONLY" keyword is only supported in GCC11 and later, remove it if using GCC10 or earlier. */
   {
     . = ALIGN(4);
     PROVIDE_HIDDEN (__fini_array_start = .);

--- a/include/core/FreeRTOSConfig.h
+++ b/include/core/FreeRTOSConfig.h
@@ -52,7 +52,7 @@
   #include <stdint.h>
   extern uint32_t SystemCoreClock;
 #endif
-#define configENABLE_FPU                         0
+#define configENABLE_FPU                         1
 #define configENABLE_MPU                         0
 
 #define configUSE_PREEMPTION                     1

--- a/include/core/README
+++ b/include/core/README
@@ -1,0 +1,39 @@
+
+This directory is intended for project header files.
+
+A header file is a file containing C declarations and macro definitions
+to be shared between several project source files. You request the use of a
+header file in your project source file (C, C++, etc) located in `src` folder
+by including it, with the C preprocessing directive `#include'.
+
+```src/main.c
+
+#include "header.h"
+
+int main (void)
+{
+ ...
+}
+```
+
+Including a header file produces the same results as copying the header file
+into each source file that needs it. Such copying would be time-consuming
+and error-prone. With a header file, the related declarations appear
+in only one place. If they need to be changed, they can be changed in one
+place, and programs that include the header file will automatically use the
+new version when next recompiled. The header file eliminates the labor of
+finding and changing all the copies as well as the risk that a failure to
+find one copy will result in inconsistencies within a program.
+
+In C, the usual convention is to give header files names that end with `.h'.
+It is most portable to use only letters, digits, dashes, and underscores in
+header file names, and at most one dot.
+
+Read more about using header files in official GCC documentation:
+
+* Include Syntax
+* Include Operation
+* Once-Only Headers
+* Computed Includes
+
+https://gcc.gnu.org/onlinedocs/cpp/Header-Files.html

--- a/include/core/main.h
+++ b/include/core/main.h
@@ -57,6 +57,12 @@ void Error_Handler(void);
 /* USER CODE END EFP */
 
 /* Private defines -----------------------------------------------------------*/
+#define USER_Btn_Pin GPIO_PIN_13
+#define USER_Btn_GPIO_Port GPIOC
+#define V_LV_Pin GPIO_PIN_1
+#define V_LV_GPIO_Port GPIOA
+#define THROTTLE_POSITION_Pin GPIO_PIN_2
+#define THROTTLE_POSITION_GPIO_Port GPIOA
 #define IMD_STATE_Pin GPIO_PIN_0
 #define IMD_STATE_GPIO_Port GPIOB
 #define AMS_STATE_Pin GPIO_PIN_1

--- a/include/core/stm32_lock.h
+++ b/include/core/stm32_lock.h
@@ -1,0 +1,375 @@
+/**
+  ******************************************************************************
+  * @file      stm32_lock.h
+  * @author    STMicroelectronics
+  * @brief     STMicroelectronics lock mechanisms
+  *
+  * @details
+  * This implementation supports the following strategies for handling
+  * thread-safe locks. The strategy can be explicitly selected by
+  * defining <tt>\STM32_THREAD_SAFE_STRATEGY = \<number></tt> in the project.
+  * Please look at the '<toolchain/library>_lock_glue.c' file for more details.
+  *
+  * 1. User defined thread-safe implementation.
+  *    User defined solution for handling thread-safety.
+  *    <br>
+  *    <b>NOTE:</b> The stubs in stm32_lock_user.h needs to be implemented to gain
+  *    thread-safety.
+  *
+  * 2. [<b>DEFAULT</b>] Allow lock usage from interrupts.
+  *    This implementation will ensure thread-safety by disabling all interrupts
+  *    during e.g. calls to malloc.
+  *    <br>
+  *    <b>NOTE:</b> Disabling all interrupts creates interrupt latency which
+  *    might not be desired for this application!
+  *
+  * 3. Deny lock usage from interrupts.
+  *    This implementation assumes single thread of execution.
+  *    <br>
+  *    <b>NOTE:</b> Thread-safety dependent functions will enter an infinity loop
+  *    if used in interrupt context.
+  *
+  * 4. Allow lock usage from interrupts. Implemented using FreeRTOS locks.
+  *    This implementation will ensure thread-safety by entering RTOS ISR capable
+  *    critical sections during e.g. calls to malloc.
+  *    By default this implementation supports 2 levels of recursive locking.
+  *    Adding additional levels requires 4 bytes per lock per level of RAM.
+  *    <br>
+  *    <b>NOTE:</b> Interrupts with high priority are not disabled. This implies
+  *    that the lock is not thread-safe from high priority interrupts!
+  *
+  * 5. Deny lock usage from interrupts. Implemented using FreeRTOS locks.
+  *    This implementation will ensure thread-safety by suspending all tasks
+  *    during e.g. calls to malloc.
+  *    <br>
+  *    <b>NOTE:</b> Thread-safety dependent functions will enter an infinity loop
+  *    if used in interrupt context.
+  *
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2024 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
+  */
+
+#ifndef __STM32_LOCK_H__
+#define __STM32_LOCK_H__
+
+/* Includes ------------------------------------------------------------------*/
+#include <stdint.h>
+#include <stddef.h>
+#include <cmsis_compiler.h>
+
+#ifndef STM32_THREAD_SAFE_STRATEGY
+#define STM32_THREAD_SAFE_STRATEGY 2 /**< Assume strategy 2 if not specified */
+#endif /* STM32_THREAD_SAFE_STRATEGY */
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+/* Function prototypes -------------------------------------------------------*/
+void Error_Handler(void);
+
+/* Public macros -------------------------------------------------------------*/
+/** Blocks execution */
+#define STM32_LOCK_BLOCK()                      \
+  do                                            \
+  {                                             \
+    __disable_irq();                            \
+    Error_Handler();                            \
+    while (1);                                  \
+  } while (0)
+
+/** Blocks execution if argument is NULL */
+#define STM32_LOCK_BLOCK_IF_NULL_ARGUMENT(x)    \
+  do                                            \
+  {                                             \
+    if ((x) == NULL)                            \
+    {                                           \
+      STM32_LOCK_BLOCK();                       \
+    }                                           \
+  } while (0)
+
+/** Blocks execution if in interrupt context */
+#define STM32_LOCK_BLOCK_IF_INTERRUPT_CONTEXT() \
+  do                                            \
+  {                                             \
+    if (__get_IPSR())                           \
+    {                                           \
+      STM32_LOCK_BLOCK();                       \
+    }                                           \
+  } while (0)
+
+/** Hide unused parameter warning from compiler */
+#define STM32_LOCK_UNUSED(var) (void)var
+
+/** Size of array */
+#define STM32_LOCK_ARRAY_SIZE(array) (sizeof(array) / sizeof((array)[0]))
+
+#if STM32_THREAD_SAFE_STRATEGY == 1
+/*
+ * User defined thread-safe implementation.
+ */
+
+/* Includes ----------------------------------------------------------------*/
+/** STM32 lock API version */
+#define STM32_LOCK_API 1
+#include "stm32_lock_user.h"
+#undef STM32_LOCK_API
+
+#elif STM32_THREAD_SAFE_STRATEGY == 2
+/*
+ * Allow lock usage from interrupts.
+ */
+
+/* Private defines ---------------------------------------------------------*/
+/** Initialize members in instance of <code>LockingData_t</code> structure */
+#define LOCKING_DATA_INIT { 0, 0 }
+
+/* Private typedef ---------------------------------------------------------*/
+typedef struct
+{
+  uint8_t flag; /**< Backup of PRIMASK.PM at nesting level 0 */
+  uint8_t counter; /**< Nesting level */
+} LockingData_t;
+
+/* Private functions -------------------------------------------------------*/
+
+/**
+  * @brief Initialize STM32 lock
+  * @param lock The lock to init
+  */
+static inline void stm32_lock_init(LockingData_t *lock)
+{
+  STM32_LOCK_BLOCK_IF_NULL_ARGUMENT(lock);
+  lock->flag = 0;
+  lock->counter = 0;
+}
+
+/**
+  * @brief Acquire STM32 lock
+  * @param lock The lock to acquire
+  */
+static inline void stm32_lock_acquire(LockingData_t *lock)
+{
+  uint8_t flag = (uint8_t)(__get_PRIMASK() & 0x1); /* PRIMASK.PM */
+  __disable_irq();
+  __DSB();
+  __ISB();
+  STM32_LOCK_BLOCK_IF_NULL_ARGUMENT(lock);
+  if (lock->counter == 0)
+  {
+    lock->flag = flag;
+  }
+  else if (lock->counter == UINT8_MAX)
+  {
+    STM32_LOCK_BLOCK();
+  }
+  lock->counter++;
+}
+
+/**
+  * @brief Release STM32 lock
+  * @param lock The lock to release
+  */
+static inline void stm32_lock_release(LockingData_t *lock)
+{
+  STM32_LOCK_BLOCK_IF_NULL_ARGUMENT(lock);
+  if (lock->counter == 0)
+  {
+    STM32_LOCK_BLOCK();
+  }
+  lock->counter--;
+  if (lock->counter == 0 && lock->flag == 0)
+  {
+    __enable_irq();
+  }
+}
+
+#elif STM32_THREAD_SAFE_STRATEGY == 3
+/*
+ * Deny lock usage from interrupts.
+ */
+
+/* Private defines ---------------------------------------------------------*/
+/** Initialize members in instance of <code>LockingData_t</code> structure */
+#define LOCKING_DATA_INIT 0
+
+/* Private typedef ---------------------------------------------------------*/
+typedef uint8_t LockingData_t;  /**< Unused */
+
+/* Private functions -------------------------------------------------------*/
+
+/**
+  * @brief Initialize STM32 lock
+  * @param lock The lock to init
+  */
+static inline void stm32_lock_init(LockingData_t *lock)
+{
+  STM32_LOCK_BLOCK_IF_NULL_ARGUMENT(lock);
+}
+
+/**
+  * @brief Acquire STM32 lock
+  * @param lock The lock to acquire
+  */
+static inline void stm32_lock_acquire(LockingData_t *lock)
+{
+  STM32_LOCK_BLOCK_IF_NULL_ARGUMENT(lock);
+  STM32_LOCK_BLOCK_IF_INTERRUPT_CONTEXT();
+}
+
+/**
+  * @brief Release ST lock
+  * @param lock The lock to release
+  */
+static inline void stm32_lock_release(LockingData_t *lock)
+{
+  STM32_LOCK_BLOCK_IF_NULL_ARGUMENT(lock);
+  STM32_LOCK_BLOCK_IF_INTERRUPT_CONTEXT();
+}
+
+#elif STM32_THREAD_SAFE_STRATEGY == 4
+/*
+ * Allow lock usage from interrupts. Implemented using FreeRTOS locks.
+ */
+
+/* Includes ----------------------------------------------------------------*/
+#include <FreeRTOS.h>
+#include <task.h>
+
+#if defined (__GNUC__) && !defined (__CC_ARM) && configUSE_NEWLIB_REENTRANT == 0
+#warning Please set configUSE_NEWLIB_REENTRANT to 1 in FreeRTOSConfig.h, otherwise newlib will not be thread-safe
+#endif /* defined (__GNUC__) && !defined (__CC_ARM) && configUSE_NEWLIB_REENTRANT == 0 */
+
+/* Private defines ---------------------------------------------------------*/
+/** Initialize members in instance of <code>LockingData_t</code> structure */
+#define LOCKING_DATA_INIT { {0, 0}, 0 }
+#define STM32_LOCK_MAX_NESTED_LEVELS 2 /**< Max nesting level of interrupts */
+typedef struct
+{
+  uint32_t basepri[STM32_LOCK_MAX_NESTED_LEVELS];
+  uint8_t nesting_level;
+} LockingData_t;
+
+/* Private macros ----------------------------------------------------------*/
+/** Blocks execution if reached max nesting level */
+#define STM32_LOCK_ASSERT_VALID_NESTING_LEVEL(lock)                   \
+  do                                                                  \
+  {                                                                   \
+    if (lock->nesting_level >= STM32_LOCK_ARRAY_SIZE(lock->basepri))  \
+    {                                                                 \
+      STM32_LOCK_BLOCK();                                             \
+    }                                                                 \
+  } while (0)
+
+/* Private functions -------------------------------------------------------*/
+
+/**
+  * @brief Initialize STM32 lock
+  * @param lock The lock to init
+  */
+static inline void stm32_lock_init(LockingData_t *lock)
+{
+  STM32_LOCK_BLOCK_IF_NULL_ARGUMENT(lock);
+  for (size_t i = 0; i < STM32_LOCK_ARRAY_SIZE(lock->basepri); i++)
+  {
+    lock->basepri[i] = 0;
+  }
+  lock->nesting_level = 0;
+}
+
+/**
+  * @brief Acquire STM32 lock
+  * @param lock The lock to acquire
+  */
+static inline void stm32_lock_acquire(LockingData_t *lock)
+{
+  STM32_LOCK_BLOCK_IF_NULL_ARGUMENT(lock);
+  STM32_LOCK_ASSERT_VALID_NESTING_LEVEL(lock);
+  lock->basepri[lock->nesting_level++] = taskENTER_CRITICAL_FROM_ISR();
+}
+
+/**
+  * @brief Release STM32 lock
+  * @param lock The lock to release
+  */
+static inline void stm32_lock_release(LockingData_t *lock)
+{
+  STM32_LOCK_BLOCK_IF_NULL_ARGUMENT(lock);
+  lock->nesting_level--;
+  STM32_LOCK_ASSERT_VALID_NESTING_LEVEL(lock);
+  taskEXIT_CRITICAL_FROM_ISR(lock->basepri[lock->nesting_level]);
+}
+
+#undef STM32_LOCK_ASSERT_VALID_NESTING_LEVEL
+#undef STM32_LOCK_MAX_NESTED_LEVELS
+
+#elif STM32_THREAD_SAFE_STRATEGY == 5
+/*
+ * Deny lock usage from interrupts. Implemented using FreeRTOS locks.
+ */
+
+/* Includes ----------------------------------------------------------------*/
+#include <FreeRTOS.h>
+#include <task.h>
+#if defined (__GNUC__) && !defined (__CC_ARM) && configUSE_NEWLIB_REENTRANT == 0
+#warning Please set configUSE_NEWLIB_REENTRANT to 1 in FreeRTOSConfig.h, otherwise newlib will not be thread-safe
+#endif /* defined (__GNUC__) && !defined (__CC_ARM) && configUSE_NEWLIB_REENTRANT == 0 */
+
+/* Private defines ---------------------------------------------------------*/
+/** Initialize members in instance of <code>LockingData_t</code> structure */
+#define LOCKING_DATA_INIT 0
+
+/* Private typedef ---------------------------------------------------------*/
+typedef uint8_t LockingData_t;  /**< Unused */
+
+/* Private functions -------------------------------------------------------*/
+
+/**
+  * @brief Initialize STM32 lock
+  * @param lock The lock to init
+  */
+static inline void stm32_lock_init(LockingData_t *lock)
+{
+  STM32_LOCK_BLOCK_IF_NULL_ARGUMENT(lock);
+}
+
+/**
+  * @brief Acquire STM32 lock
+  * @param lock The lock to acquire
+  */
+static inline void stm32_lock_acquire(LockingData_t *lock)
+{
+  STM32_LOCK_BLOCK_IF_NULL_ARGUMENT(lock);
+  STM32_LOCK_BLOCK_IF_INTERRUPT_CONTEXT();
+  vTaskSuspendAll();
+}
+
+/**
+  * @brief Release STM32 lock
+  * @param lock The lock to release
+  */
+static inline void stm32_lock_release(LockingData_t *lock)
+{
+  STM32_LOCK_BLOCK_IF_NULL_ARGUMENT(lock);
+  STM32_LOCK_BLOCK_IF_INTERRUPT_CONTEXT();
+  xTaskResumeAll();
+}
+
+#else
+#error Invalid STM32_THREAD_SAFE_STRATEGY specified
+#endif /* STM32_THREAD_SAFE_STRATEGY */
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif /* __cplusplus */
+
+#endif /* __STM32_LOCK_H__ */

--- a/include/core/stm32f7xx_hal_conf.h
+++ b/include/core/stm32f7xx_hal_conf.h
@@ -58,7 +58,7 @@
 /* #define HAL_LTDC_MODULE_ENABLED */
 /* #define HAL_QSPI_MODULE_ENABLED */
 /* #define HAL_RNG_MODULE_ENABLED */
-/* #define HAL_RTC_MODULE_ENABLED */
+#define HAL_RTC_MODULE_ENABLED
 /* #define HAL_SAI_MODULE_ENABLED */
 /* #define HAL_SD_MODULE_ENABLED */
 /* #define HAL_MMC_MODULE_ENABLED */
@@ -94,7 +94,7 @@
   *        (when HSE is used as system clock source, directly or through the PLL).
   */
 #if !defined  (HSE_VALUE)
-  #define HSE_VALUE    ((uint32_t)25000000U) /*!< Value of the External oscillator in Hz */
+  #define HSE_VALUE    ((uint32_t)8000000U) /*!< Value of the External oscillator in Hz */
 #endif /* HSE_VALUE */
 
 #if !defined  (HSE_STARTUP_TIMEOUT)
@@ -145,7 +145,7 @@
 /**
   * @brief This is the HAL system configuration section
   */
-#define  VDD_VALUE                    3317U /*!< Value of VDD in mv */
+#define  VDD_VALUE                    3300U /*!< Value of VDD in mv */
 #define  TICK_INT_PRIORITY            ((uint32_t)1U) /*!< tick interrupt priority */
 #define  USE_RTOS                     0U
 #define  PREFETCH_ENABLE              0U
@@ -210,7 +210,7 @@
 #define MAC_ADDR5   0U
 
 /* Definition of the Ethernet driver buffers size and count */
-#define ETH_RX_BUF_SIZE                 /* buffer size for receive               */
+#define ETH_RX_BUF_SIZE                ETH_MAX_PACKET_SIZE /* buffer size for receive               */
 #define ETH_TX_BUF_SIZE                ETH_MAX_PACKET_SIZE /* buffer size for transmit              */
 #define ETH_RXBUFNB                    ((uint32_t)4U)       /* 4 Rx buffers of size ETH_RX_BUF_SIZE  */
 #define ETH_TXBUFNB                    ((uint32_t)4U)       /* 4 Tx buffers of size ETH_TX_BUF_SIZE  */

--- a/include/core/stm32f7xx_it.h
+++ b/include/core/stm32f7xx_it.h
@@ -13,7 +13,7 @@
   * in the root directory of this software component.
   * If no LICENSE file comes with this software, it is provided AS-IS.
   *
- ******************************************************************************
+  ******************************************************************************
   */
 /* USER CODE END Header */
 
@@ -52,6 +52,8 @@ void MemManage_Handler(void);
 void BusFault_Handler(void);
 void UsageFault_Handler(void);
 void DebugMon_Handler(void);
+void CAN1_RX0_IRQHandler(void);
+void CAN1_RX1_IRQHandler(void);
 void TIM1_UP_TIM10_IRQHandler(void);
 /* USER CODE BEGIN EFP */
 

--- a/include/cvc/cvc_control.h
+++ b/include/cvc/cvc_control.h
@@ -8,7 +8,7 @@
 #ifndef INC_CVC_CONTROL_H
 #define INC_CVC_CONTROL_H
 
-#define CONTROL_TASK_MS 50
+#define CONTROL_TASK_MS 10
 #define CONTROL_TORQUECOMMAND_MS CONTROL_TASK_MS
 
 #define THROTTLE_INVALID_TIMER 1000                 // Time before throttle is marked invalid
@@ -45,8 +45,9 @@ typedef enum {
     INITIAL,
     VOLTAGE_CHECK,
     WAIT_FOR_PRECHARGE,
-    PRECHARGE_START,
-    PRECHARGE_END,
+    PRECHARGE_STAGE1,
+    PRECHARGE_STAGE2,
+    PRECHARGE_STAGE3,
     NOT_READY_TO_DRIVE,
     BUZZER,
     READY_TO_DRIVE,

--- a/lib/CMSIS/Device/ST/STM32F7xx/Include/stm32f767xx.h
+++ b/lib/CMSIS/Device/ST/STM32F7xx/Include/stm32f767xx.h
@@ -6929,7 +6929,7 @@ typedef struct
 /*                                                                            */
 /******************************************************************************/
 /*
- * @brief Specific device feature definitions (not present on all devices in the STM32F7 serie)
+ * @brief Specific device feature definitions (not present on all devices in the STM32F7 series)
  */
 #define DMA2D_ALPHA_INV_RB_SWAP_SUPPORT
 /********************  Bit definition for DMA2D_CR register  ******************/
@@ -7986,7 +7986,7 @@ typedef struct
 #define FMC_BCR1_CBURSTRW          FMC_BCR1_CBURSTRW_Msk                       /*!<Write burst enable         */
 #define FMC_BCR1_CCLKEN_Pos        (20U)
 #define FMC_BCR1_CCLKEN_Msk        (0x1UL << FMC_BCR1_CCLKEN_Pos)               /*!< 0x00100000 */
-#define FMC_BCR1_CCLKEN            FMC_BCR1_CCLKEN_Msk                         /*!<Continous clock enable     */
+#define FMC_BCR1_CCLKEN            FMC_BCR1_CCLKEN_Msk                         /*!<Continuous clock enable     */
 #define FMC_BCR1_WFDIS_Pos         (21U)
 #define FMC_BCR1_WFDIS_Msk         (0x1UL << FMC_BCR1_WFDIS_Pos)                /*!< 0x00200000 */
 #define FMC_BCR1_WFDIS             FMC_BCR1_WFDIS_Msk                          /*!<Write FIFO Disable         */
@@ -8889,7 +8889,7 @@ typedef struct
 #define FMC_SDRTR_COUNT            FMC_SDRTR_COUNT_Msk                         /*!<COUNT[12:0] bits (Refresh timer count) */
 #define FMC_SDRTR_REIE_Pos         (14U)
 #define FMC_SDRTR_REIE_Msk         (0x1UL << FMC_SDRTR_REIE_Pos)                /*!< 0x00004000 */
-#define FMC_SDRTR_REIE             FMC_SDRTR_REIE_Msk                          /*!<RES interupt enable */
+#define FMC_SDRTR_REIE             FMC_SDRTR_REIE_Msk                          /*!<RES interrupt enable */
 
 /******************  Bit definition for FMC_SDSR register  ******************/
 #define FMC_SDSR_RE_Pos            (0U)
@@ -10091,7 +10091,7 @@ typedef struct
 
 #define LTDC_AWCR_AAH_Pos            (0U)
 #define LTDC_AWCR_AAH_Msk            (0x7FFUL << LTDC_AWCR_AAH_Pos)             /*!< 0x000007FF */
-#define LTDC_AWCR_AAH                LTDC_AWCR_AAH_Msk                         /*!< Accumulated Active heigh */
+#define LTDC_AWCR_AAH                LTDC_AWCR_AAH_Msk                         /*!< Accumulated Active height */
 #define LTDC_AWCR_AAW_Pos            (16U)
 #define LTDC_AWCR_AAW_Msk            (0xFFFUL << LTDC_AWCR_AAW_Pos)             /*!< 0x0FFF0000 */
 #define LTDC_AWCR_AAW                LTDC_AWCR_AAW_Msk                         /*!< Accumulated Active Width */
@@ -11976,7 +11976,7 @@ typedef struct
 #define RCC_DCKCFGR1_PLLSAIDIVR_1          (0x2UL << RCC_DCKCFGR1_PLLSAIDIVR_Pos) /*!< 0x00020000 */
 
 /*
- * @brief Specific device feature definitions (not present on all devices in the STM32F7 serie)
+ * @brief Specific device feature definitions (not present on all devices in the STM32F7 series)
  */
 #define  RCC_SAI1SEL_PLLSRC_SUPPORT
 #define RCC_DCKCFGR1_SAI1SEL_Pos           (20U)
@@ -11986,7 +11986,7 @@ typedef struct
 #define RCC_DCKCFGR1_SAI1SEL_1             (0x2UL << RCC_DCKCFGR1_SAI1SEL_Pos)  /*!< 0x00200000 */
 
 /*
- * @brief Specific device feature definitions (not present on all devices in the STM32F7 serie)
+ * @brief Specific device feature definitions (not present on all devices in the STM32F7 series)
  */
 #define  RCC_SAI2SEL_PLLSRC_SUPPORT
 #define RCC_DCKCFGR1_SAI2SEL_Pos           (22U)
@@ -13471,7 +13471,7 @@ typedef struct
 #define SDMMC_DCOUNT_DATACOUNT_Msk      (0x1FFFFFFUL << SDMMC_DCOUNT_DATACOUNT_Pos) /*!< 0x01FFFFFF */
 #define SDMMC_DCOUNT_DATACOUNT          SDMMC_DCOUNT_DATACOUNT_Msk             /*!<Data count value */
 
-/******************  Bit definition for SDMMC_STA registe  ********************/
+/******************  Bit definition for SDMMC_STA register  ********************/
 #define SDMMC_STA_CCRCFAIL_Pos          (0U)
 #define SDMMC_STA_CCRCFAIL_Msk          (0x1UL << SDMMC_STA_CCRCFAIL_Pos)       /*!< 0x00000001 */
 #define SDMMC_STA_CCRCFAIL              SDMMC_STA_CCRCFAIL_Msk                 /*!<Command response received (CRC check failed)  */
@@ -14223,7 +14223,7 @@ typedef struct
 /*                                                                            */
 /******************************************************************************/
 /*
- * @brief Specific device feature definitions (not present on all devices in the STM32F7 serie)
+ * @brief Specific device feature definitions (not present on all devices in the STM32F7 series)
  */
 #define TIM_BREAK_INPUT_SUPPORT                                 /*!<TIM Break input feature available on specific devices */
 /*******************  Bit definition for TIM_CR1 register  ********************/
@@ -14828,7 +14828,7 @@ typedef struct
 #define TIM_DMAR_DMAB_Msk         (0xFFFFUL << TIM_DMAR_DMAB_Pos)               /*!< 0x0000FFFF */
 #define TIM_DMAR_DMAB             TIM_DMAR_DMAB_Msk                            /*!<DMA register for burst accesses                    */
 
-/*******************  Bit definition for TIM_OR regiter  *********************/
+/*******************  Bit definition for TIM_OR register  *********************/
 #define TIM_OR_TI4_RMP_Pos        (6U)
 #define TIM_OR_TI4_RMP_Msk        (0x3UL << TIM_OR_TI4_RMP_Pos)                 /*!< 0x000000C0 */
 #define TIM_OR_TI4_RMP            TIM_OR_TI4_RMP_Msk                           /*!<TI4_RMP[1:0] bits (TIM5 Input 4 remap)             */
@@ -15660,6 +15660,9 @@ typedef struct
 /*                                                                            */
 /******************************************************************************/
 /* Bit definition for Ethernet MAC Control Register register */
+#define ETH_MACCR_CSTF_Pos                            (25U)
+#define ETH_MACCR_CSTF_Msk                            (0x1UL << ETH_MACCR_CSTF_Pos) /*!< 0x02000000 */
+#define ETH_MACCR_CSTF                                ETH_MACCR_CSTF_Msk       /* CRC stripping for Type frames */
 #define ETH_MACCR_WD_Pos                              (23U)
 #define ETH_MACCR_WD_Msk                              (0x1UL << ETH_MACCR_WD_Pos) /*!< 0x00800000 */
 #define ETH_MACCR_WD                                  ETH_MACCR_WD_Msk         /* Watchdog disable */
@@ -16082,7 +16085,7 @@ typedef struct
 /*                Ethernet MMC Registers bits definition                      */
 /******************************************************************************/
 
-/* Bit definition for Ethernet MMC Contol Register */
+/* Bit definition for Ethernet MMC Control Register */
 #define ETH_MMCCR_MCFHP_Pos                           (5U)
 #define ETH_MMCCR_MCFHP_Msk                           (0x1UL << ETH_MMCCR_MCFHP_Pos) /*!< 0x00000020 */
 #define ETH_MMCCR_MCFHP                               ETH_MMCCR_MCFHP_Msk      /* MMC counter Full-Half preset */
@@ -16166,7 +16169,7 @@ typedef struct
 #define ETH_MMCRFCECR_RFCEC_Msk                       (0xFFFFFFFFUL << ETH_MMCRFCECR_RFCEC_Pos) /*!< 0xFFFFFFFF */
 #define ETH_MMCRFCECR_RFCEC                           ETH_MMCRFCECR_RFCEC_Msk  /* Number of frames received with CRC error. */
 
-/* Bit definition for Ethernet MMC Received Frames with Alignement Error Counter Register */
+/* Bit definition for Ethernet MMC Received Frames with Alignment Error Counter Register */
 #define ETH_MMCRFAECR_RFAEC_Pos                       (0U)
 #define ETH_MMCRFAECR_RFAEC_Msk                       (0xFFFFFFFFUL << ETH_MMCRFAECR_RFAEC_Pos) /*!< 0xFFFFFFFF */
 #define ETH_MMCRFAECR_RFAEC                           ETH_MMCRFAECR_RFAEC_Msk  /* Number of frames received with alignment (dribble) error */
@@ -16180,7 +16183,7 @@ typedef struct
 /*               Ethernet PTP Registers bits definition                       */
 /******************************************************************************/
 
-/* Bit definition for Ethernet PTP Time Stamp Contol Register */
+/* Bit definition for Ethernet PTP Time Stamp Control Register */
 #define ETH_PTPTSCR_TSPFFMAE_Pos                      (18U)
 #define ETH_PTPTSCR_TSPFFMAE_Msk                      (0x1UL << ETH_PTPTSCR_TSPFFMAE_Pos) /*!< 0x00008000 */
 #define ETH_PTPTSCR_TSPFFMAE                          ETH_PTPTSCR_TSPFFMAE_Msk  /* Time stamp PTP frame filtering MAC address enable */
@@ -16440,7 +16443,7 @@ typedef struct
 #define ETH_DMASR_RPS_Closing                         ETH_DMASR_RPS_Closing_Msk /* Running - closing descriptor */
 #define ETH_DMASR_RPS_Queuing_Pos                     (17U)
 #define ETH_DMASR_RPS_Queuing_Msk                     (0x7UL << ETH_DMASR_RPS_Queuing_Pos) /*!< 0x000E0000 */
-#define ETH_DMASR_RPS_Queuing                         ETH_DMASR_RPS_Queuing_Msk /* Running - queuing the recieve frame into host memory */
+#define ETH_DMASR_RPS_Queuing                         ETH_DMASR_RPS_Queuing_Msk /* Running - queuing the receive frame into host memory */
 #define ETH_DMASR_NIS_Pos                             (16U)
 #define ETH_DMASR_NIS_Msk                             (0x1UL << ETH_DMASR_NIS_Pos) /*!< 0x00010000 */
 #define ETH_DMASR_NIS                                 ETH_DMASR_NIS_Msk        /* Normal interrupt summary */
@@ -18211,7 +18214,7 @@ typedef struct
 /********************  Bit definition for SR register  *******************/
 #define JPEG_SR_IFTF_Pos                (1U)
 #define JPEG_SR_IFTF_Msk                (0x1UL << JPEG_SR_IFTF_Pos)             /*!< 0x00000002 */
-#define JPEG_SR_IFTF                    JPEG_SR_IFTF_Msk                       /*!<Input FIFO is not full and is bellow its threshold flag */
+#define JPEG_SR_IFTF                    JPEG_SR_IFTF_Msk                       /*!<Input FIFO is not full and is below its threshold flag */
 #define JPEG_SR_IFNFF_Pos               (2U)
 #define JPEG_SR_IFNFF_Msk               (0x1UL << JPEG_SR_IFNFF_Pos)            /*!< 0x00000004 */
 #define JPEG_SR_IFNFF                   JPEG_SR_IFNFF_Msk                      /*!<Input FIFO Not Full Flag, a data can be written */

--- a/lib/CMSIS/Device/ST/STM32F7xx/Include/stm32f7xx.h
+++ b/lib/CMSIS/Device/ST/STM32F7xx/Include/stm32f7xx.h
@@ -96,11 +96,11 @@
 #endif /* USE_HAL_DRIVER */
 
 /**
-  * @brief CMSIS Device version number V1.2.8
+  * @brief CMSIS Device version number V1.2.9
   */
 #define __STM32F7_CMSIS_VERSION_MAIN   (0x01) /*!< [31:24] main version */
 #define __STM32F7_CMSIS_VERSION_SUB1   (0x02) /*!< [23:16] sub1 version */
-#define __STM32F7_CMSIS_VERSION_SUB2   (0x08) /*!< [15:8]  sub2 version */
+#define __STM32F7_CMSIS_VERSION_SUB2   (0x09) /*!< [15:8]  sub2 version */
 #define __STM32F7_CMSIS_VERSION_RC     (0x00) /*!< [7:0]  release candidate */
 #define __STM32F7_CMSIS_VERSION        ((__STM32F7_CMSIS_VERSION_MAIN << 24)\
                                        |(__STM32F7_CMSIS_VERSION_SUB1 << 16)\

--- a/lib/STM32F7xx_HAL_Driver/Inc/Legacy/stm32_hal_legacy.h
+++ b/lib/STM32F7xx_HAL_Driver/Inc/Legacy/stm32_hal_legacy.h
@@ -37,16 +37,12 @@ extern "C" {
 #define AES_CLEARFLAG_CCF               CRYP_CLEARFLAG_CCF
 #define AES_CLEARFLAG_RDERR             CRYP_CLEARFLAG_RDERR
 #define AES_CLEARFLAG_WRERR             CRYP_CLEARFLAG_WRERR
-#if defined(STM32U5) || defined(STM32H7) || defined(STM32MP1)
+#if defined(STM32H7) || defined(STM32MP1)
 #define CRYP_DATATYPE_32B               CRYP_NO_SWAP
 #define CRYP_DATATYPE_16B               CRYP_HALFWORD_SWAP
 #define CRYP_DATATYPE_8B                CRYP_BYTE_SWAP
 #define CRYP_DATATYPE_1B                CRYP_BIT_SWAP
-#if defined(STM32U5)
-#define CRYP_CCF_CLEAR                  CRYP_CLEAR_CCF
-#define CRYP_ERR_CLEAR                  CRYP_CLEAR_RWEIF
-#endif /* STM32U5 */
-#endif /* STM32U5 || STM32H7 || STM32MP1 */
+#endif /* STM32H7 || STM32MP1 */
 /**
   * @}
   */
@@ -113,6 +109,9 @@ extern "C" {
 #define ADC4_SAMPLETIME_160CYCLES_5     ADC4_SAMPLETIME_814CYCLES_5
 #endif /* STM32U5 */
 
+#if defined(STM32H5)
+#define ADC_CHANNEL_VCORE               ADC_CHANNEL_VDDCORE
+#endif /* STM32H5 */
 /**
   * @}
   */
@@ -140,7 +139,8 @@ extern "C" {
 #define COMP_EXTI_LINE_COMP6_EVENT     COMP_EXTI_LINE_COMP6
 #define COMP_EXTI_LINE_COMP7_EVENT     COMP_EXTI_LINE_COMP7
 #if defined(STM32L0)
-#define COMP_LPTIMCONNECTION_ENABLED   ((uint32_t)0x00000003U)    /*!< COMPX output generic naming: connected to LPTIM input 1 for COMP1, LPTIM input 2 for COMP2 */
+#define COMP_LPTIMCONNECTION_ENABLED   ((uint32_t)0x00000003U)    /*!< COMPX output generic naming: connected to LPTIM 
+                                                                       input 1 for COMP1, LPTIM input 2 for COMP2 */
 #endif
 #define COMP_OUTPUT_COMP6TIM2OCREFCLR  COMP_OUTPUT_COMP6_TIM2OCREFCLR
 #if defined(STM32F373xC) || defined(STM32F378xx)
@@ -214,6 +214,11 @@ extern "C" {
 #endif
 
 #endif
+
+#if defined(STM32U5)
+#define __HAL_COMP_COMP1_EXTI_CLEAR_RASING_FLAG __HAL_COMP_COMP1_EXTI_CLEAR_RISING_FLAG
+#endif
+
 /**
   * @}
   */
@@ -234,10 +239,12 @@ extern "C" {
 /** @defgroup CRC_Aliases CRC API aliases
   * @{
   */
-#if defined(STM32C0)
+#if defined(STM32H5) || defined(STM32C0)
 #else
-#define HAL_CRC_Input_Data_Reverse   HAL_CRCEx_Input_Data_Reverse    /*!< Aliased to HAL_CRCEx_Input_Data_Reverse for inter STM32 series compatibility  */
-#define HAL_CRC_Output_Data_Reverse  HAL_CRCEx_Output_Data_Reverse   /*!< Aliased to HAL_CRCEx_Output_Data_Reverse for inter STM32 series compatibility */
+#define HAL_CRC_Input_Data_Reverse   HAL_CRCEx_Input_Data_Reverse    /*!< Aliased to HAL_CRCEx_Input_Data_Reverse for 
+                                                                          inter STM32 series compatibility  */
+#define HAL_CRC_Output_Data_Reverse  HAL_CRCEx_Output_Data_Reverse   /*!< Aliased to HAL_CRCEx_Output_Data_Reverse for 
+                                                                          inter STM32 series compatibility */
 #endif
 /**
   * @}
@@ -280,7 +287,13 @@ extern "C" {
 #define DAC_TRIGGER_LPTIM3_OUT       DAC_TRIGGER_LPTIM3_CH1
 #endif
 
-#if defined(STM32L1) || defined(STM32L4) || defined(STM32G0) || defined(STM32L5) || defined(STM32H7) || defined(STM32F4) || defined(STM32G4)
+#if defined(STM32H5)
+#define DAC_TRIGGER_LPTIM1_OUT       DAC_TRIGGER_LPTIM1_CH1
+#define DAC_TRIGGER_LPTIM2_OUT       DAC_TRIGGER_LPTIM2_CH1
+#endif
+
+#if defined(STM32L1) || defined(STM32L4) || defined(STM32G0) || defined(STM32L5) || defined(STM32H7) || \
+    defined(STM32F4) || defined(STM32G4)
 #define HAL_DAC_MSP_INIT_CB_ID       HAL_DAC_MSPINIT_CB_ID
 #define HAL_DAC_MSP_DEINIT_CB_ID     HAL_DAC_MSPDEINIT_CB_ID
 #endif
@@ -345,7 +358,8 @@ extern "C" {
 #define HAL_DMAMUX_REQUEST_GEN_FALLING           HAL_DMAMUX_REQ_GEN_FALLING
 #define HAL_DMAMUX_REQUEST_GEN_RISING_FALLING    HAL_DMAMUX_REQ_GEN_RISING_FALLING
 
-#if defined(STM32L4R5xx) || defined(STM32L4R9xx) || defined(STM32L4R9xx) || defined(STM32L4S5xx) || defined(STM32L4S7xx) || defined(STM32L4S9xx)
+#if defined(STM32L4R5xx) || defined(STM32L4R9xx) || defined(STM32L4R9xx) || defined(STM32L4S5xx) || \
+    defined(STM32L4S7xx) || defined(STM32L4S9xx)
 #define DMA_REQUEST_DCMI_PSSI                    DMA_REQUEST_DCMI
 #endif
 
@@ -530,7 +544,20 @@ extern "C" {
 #define OB_USER_nBOOT0                OB_USER_NBOOT0
 #define OB_nBOOT0_RESET               OB_NBOOT0_RESET
 #define OB_nBOOT0_SET                 OB_NBOOT0_SET
+#define OB_USER_SRAM134_RST           OB_USER_SRAM_RST
+#define OB_SRAM134_RST_ERASE          OB_SRAM_RST_ERASE
+#define OB_SRAM134_RST_NOT_ERASE      OB_SRAM_RST_NOT_ERASE
 #endif /* STM32U5 */
+#if defined(STM32U0)
+#define OB_USER_nRST_STOP             OB_USER_NRST_STOP
+#define OB_USER_nRST_STDBY            OB_USER_NRST_STDBY
+#define OB_USER_nRST_SHDW             OB_USER_NRST_SHDW
+#define OB_USER_nBOOT_SEL             OB_USER_NBOOT_SEL
+#define OB_USER_nBOOT0                OB_USER_NBOOT0
+#define OB_USER_nBOOT1                OB_USER_NBOOT1
+#define OB_nBOOT0_RESET               OB_NBOOT0_RESET
+#define OB_nBOOT0_SET                 OB_NBOOT0_SET
+#endif /* STM32U0 */
 
 /**
   * @}
@@ -573,6 +600,106 @@ extern "C" {
 #define HAL_SYSCFG_EnableIOAnalogSwitchVDD        HAL_SYSCFG_EnableIOSwitchVDD
 #define HAL_SYSCFG_DisableIOAnalogSwitchVDD       HAL_SYSCFG_DisableIOSwitchVDD
 #endif /* STM32G4 */
+
+#if defined(STM32H5)
+#define SYSCFG_IT_FPU_IOC         SBS_IT_FPU_IOC
+#define SYSCFG_IT_FPU_DZC         SBS_IT_FPU_DZC
+#define SYSCFG_IT_FPU_UFC         SBS_IT_FPU_UFC
+#define SYSCFG_IT_FPU_OFC         SBS_IT_FPU_OFC
+#define SYSCFG_IT_FPU_IDC         SBS_IT_FPU_IDC
+#define SYSCFG_IT_FPU_IXC         SBS_IT_FPU_IXC
+
+#define SYSCFG_BREAK_FLASH_ECC    SBS_BREAK_FLASH_ECC
+#define SYSCFG_BREAK_PVD          SBS_BREAK_PVD
+#define SYSCFG_BREAK_SRAM_ECC     SBS_BREAK_SRAM_ECC
+#define SYSCFG_BREAK_LOCKUP       SBS_BREAK_LOCKUP
+
+#define SYSCFG_VREFBUF_VOLTAGE_SCALE0   VREFBUF_VOLTAGE_SCALE0
+#define SYSCFG_VREFBUF_VOLTAGE_SCALE1   VREFBUF_VOLTAGE_SCALE1
+#define SYSCFG_VREFBUF_VOLTAGE_SCALE2   VREFBUF_VOLTAGE_SCALE2
+#define SYSCFG_VREFBUF_VOLTAGE_SCALE3   VREFBUF_VOLTAGE_SCALE3
+
+#define SYSCFG_VREFBUF_HIGH_IMPEDANCE_DISABLE   VREFBUF_HIGH_IMPEDANCE_DISABLE
+#define SYSCFG_VREFBUF_HIGH_IMPEDANCE_ENABLE    VREFBUF_HIGH_IMPEDANCE_ENABLE
+
+#define SYSCFG_FASTMODEPLUS_PB6   SBS_FASTMODEPLUS_PB6
+#define SYSCFG_FASTMODEPLUS_PB7   SBS_FASTMODEPLUS_PB7
+#define SYSCFG_FASTMODEPLUS_PB8   SBS_FASTMODEPLUS_PB8
+#define SYSCFG_FASTMODEPLUS_PB9   SBS_FASTMODEPLUS_PB9
+
+#define SYSCFG_ETH_MII   SBS_ETH_MII
+#define SYSCFG_ETH_RMII  SBS_ETH_RMII
+#define IS_SYSCFG_ETHERNET_CONFIG  IS_SBS_ETHERNET_CONFIG
+
+#define SYSCFG_MEMORIES_ERASE_FLAG_IPMEE   SBS_MEMORIES_ERASE_FLAG_IPMEE
+#define SYSCFG_MEMORIES_ERASE_FLAG_MCLR    SBS_MEMORIES_ERASE_FLAG_MCLR
+#define IS_SYSCFG_MEMORIES_ERASE_FLAG      IS_SBS_MEMORIES_ERASE_FLAG
+
+#define IS_SYSCFG_CODE_CONFIG IS_SBS_CODE_CONFIG
+
+#define SYSCFG_MPU_NSEC   SBS_MPU_NSEC
+#define SYSCFG_VTOR_NSEC  SBS_VTOR_NSEC
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define SYSCFG_SAU              SBS_SAU
+#define SYSCFG_MPU_SEC          SBS_MPU_SEC
+#define SYSCFG_VTOR_AIRCR_SEC   SBS_VTOR_AIRCR_SEC
+#define SYSCFG_LOCK_ALL         SBS_LOCK_ALL
+#else
+#define SYSCFG_LOCK_ALL         SBS_LOCK_ALL
+#endif /* __ARM_FEATURE_CMSE */
+
+#define SYSCFG_CLK      SBS_CLK
+#define SYSCFG_CLASSB   SBS_CLASSB
+#define SYSCFG_FPU      SBS_FPU
+#define SYSCFG_ALL      SBS_ALL
+
+#define SYSCFG_SEC      SBS_SEC
+#define SYSCFG_NSEC     SBS_NSEC
+
+#define __HAL_SYSCFG_FPU_INTERRUPT_ENABLE   __HAL_SBS_FPU_INTERRUPT_ENABLE
+#define __HAL_SYSCFG_FPU_INTERRUPT_DISABLE  __HAL_SBS_FPU_INTERRUPT_DISABLE
+
+#define __HAL_SYSCFG_BREAK_ECC_LOCK        __HAL_SBS_BREAK_ECC_LOCK
+#define __HAL_SYSCFG_BREAK_LOCKUP_LOCK     __HAL_SBS_BREAK_LOCKUP_LOCK
+#define __HAL_SYSCFG_BREAK_PVD_LOCK        __HAL_SBS_BREAK_PVD_LOCK
+#define __HAL_SYSCFG_BREAK_SRAM_ECC_LOCK   __HAL_SBS_BREAK_SRAM_ECC_LOCK
+
+#define __HAL_SYSCFG_FASTMODEPLUS_ENABLE   __HAL_SBS_FASTMODEPLUS_ENABLE
+#define __HAL_SYSCFG_FASTMODEPLUS_DISABLE  __HAL_SBS_FASTMODEPLUS_DISABLE
+
+#define __HAL_SYSCFG_GET_MEMORIES_ERASE_STATUS    __HAL_SBS_GET_MEMORIES_ERASE_STATUS
+#define __HAL_SYSCFG_CLEAR_MEMORIES_ERASE_STATUS  __HAL_SBS_CLEAR_MEMORIES_ERASE_STATUS
+
+#define IS_SYSCFG_FPU_INTERRUPT    IS_SBS_FPU_INTERRUPT
+#define IS_SYSCFG_BREAK_CONFIG     IS_SBS_BREAK_CONFIG
+#define IS_SYSCFG_VREFBUF_VOLTAGE_SCALE     IS_VREFBUF_VOLTAGE_SCALE
+#define IS_SYSCFG_VREFBUF_HIGH_IMPEDANCE    IS_VREFBUF_HIGH_IMPEDANCE
+#define IS_SYSCFG_VREFBUF_TRIMMING  IS_VREFBUF_TRIMMING
+#define IS_SYSCFG_FASTMODEPLUS      IS_SBS_FASTMODEPLUS
+#define IS_SYSCFG_ITEMS_ATTRIBUTES  IS_SBS_ITEMS_ATTRIBUTES
+#define IS_SYSCFG_ATTRIBUTES        IS_SBS_ATTRIBUTES
+#define IS_SYSCFG_LOCK_ITEMS        IS_SBS_LOCK_ITEMS
+
+#define HAL_SYSCFG_VREFBUF_VoltageScalingConfig   HAL_VREFBUF_VoltageScalingConfig
+#define HAL_SYSCFG_VREFBUF_HighImpedanceConfig    HAL_VREFBUF_HighImpedanceConfig
+#define HAL_SYSCFG_VREFBUF_TrimmingConfig         HAL_VREFBUF_TrimmingConfig
+#define HAL_SYSCFG_EnableVREFBUF                  HAL_EnableVREFBUF
+#define HAL_SYSCFG_DisableVREFBUF                 HAL_DisableVREFBUF
+
+#define HAL_SYSCFG_EnableIOAnalogSwitchBooster    HAL_SBS_EnableIOAnalogSwitchBooster
+#define HAL_SYSCFG_DisableIOAnalogSwitchBooster   HAL_SBS_DisableIOAnalogSwitchBooster
+#define HAL_SYSCFG_ETHInterfaceSelect             HAL_SBS_ETHInterfaceSelect
+
+#define HAL_SYSCFG_Lock     HAL_SBS_Lock
+#define HAL_SYSCFG_GetLock  HAL_SBS_GetLock
+
+#if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+#define HAL_SYSCFG_ConfigAttributes     HAL_SBS_ConfigAttributes
+#define HAL_SYSCFG_GetConfigAttributes  HAL_SBS_GetConfigAttributes
+#endif /* __ARM_FEATURE_CMSE */
+
+#endif /* STM32H5 */
+
 
 /**
   * @}
@@ -641,14 +768,16 @@ extern "C" {
 #define GPIO_AF10_OTG2_HS  GPIO_AF10_OTG2_FS
 #define GPIO_AF10_OTG1_FS  GPIO_AF10_OTG1_HS
 #define GPIO_AF12_OTG2_FS  GPIO_AF12_OTG1_FS
-#endif /*STM32H743xx || STM32H753xx || STM32H750xx || STM32H742xx || STM32H745xx || STM32H755xx || STM32H747xx || STM32H757xx */
+#endif /*STM32H743xx || STM32H753xx || STM32H750xx || STM32H742xx || STM32H745xx || STM32H755xx || STM32H747xx || \
+         STM32H757xx */
 #endif /* STM32H7 */
 
 #define GPIO_AF0_LPTIM                            GPIO_AF0_LPTIM1
 #define GPIO_AF1_LPTIM                            GPIO_AF1_LPTIM1
 #define GPIO_AF2_LPTIM                            GPIO_AF2_LPTIM1
 
-#if defined(STM32L0) || defined(STM32L4) || defined(STM32F4) || defined(STM32F2) || defined(STM32F7) || defined(STM32G4) || defined(STM32H7) || defined(STM32WB) || defined(STM32U5)
+#if defined(STM32L0) || defined(STM32L4) || defined(STM32F4) || defined(STM32F2) || defined(STM32F7) || \
+    defined(STM32G4) || defined(STM32H7) || defined(STM32WB) || defined(STM32U5)
 #define  GPIO_SPEED_LOW                           GPIO_SPEED_FREQ_LOW
 #define  GPIO_SPEED_MEDIUM                        GPIO_SPEED_FREQ_MEDIUM
 #define  GPIO_SPEED_FAST                          GPIO_SPEED_FREQ_HIGH
@@ -670,9 +799,9 @@ extern "C" {
 
 #define GPIO_AF6_DFSDM                            GPIO_AF6_DFSDM1
 
-#if defined(STM32U5)
+#if defined(STM32U5) || defined(STM32H5)
 #define GPIO_AF0_RTC_50Hz                         GPIO_AF0_RTC_50HZ
-#endif /* STM32U5 */
+#endif /* STM32U5 || STM32H5 */
 #if defined(STM32U5)
 #define GPIO_AF0_S2DSTOP                          GPIO_AF0_SRDSTOP
 #define GPIO_AF11_LPGPIO                          GPIO_AF11_LPGPIO1
@@ -686,7 +815,25 @@ extern "C" {
   */
 #if defined(STM32U5)
 #define GTZC_PERIPH_DCMI                      GTZC_PERIPH_DCMI_PSSI
+#define GTZC_PERIPH_LTDC                      GTZC_PERIPH_LTDCUSB
 #endif /* STM32U5 */
+#if defined(STM32H5)
+#define GTZC_PERIPH_DAC12                     GTZC_PERIPH_DAC1
+#define GTZC_PERIPH_ADC12                     GTZC_PERIPH_ADC
+#define GTZC_PERIPH_USBFS                     GTZC_PERIPH_USB
+#endif /* STM32H5 */
+#if defined(STM32H5) || defined(STM32U5)
+#define GTZC_MCPBB_NB_VCTR_REG_MAX            GTZC_MPCBB_NB_VCTR_REG_MAX
+#define GTZC_MCPBB_NB_LCK_VCTR_REG_MAX        GTZC_MPCBB_NB_LCK_VCTR_REG_MAX
+#define GTZC_MCPBB_SUPERBLOCK_UNLOCKED        GTZC_MPCBB_SUPERBLOCK_UNLOCKED
+#define GTZC_MCPBB_SUPERBLOCK_LOCKED          GTZC_MPCBB_SUPERBLOCK_LOCKED
+#define GTZC_MCPBB_BLOCK_NSEC                 GTZC_MPCBB_BLOCK_NSEC
+#define GTZC_MCPBB_BLOCK_SEC                  GTZC_MPCBB_BLOCK_SEC
+#define GTZC_MCPBB_BLOCK_NPRIV                GTZC_MPCBB_BLOCK_NPRIV
+#define GTZC_MCPBB_BLOCK_PRIV                 GTZC_MPCBB_BLOCK_PRIV
+#define GTZC_MCPBB_LOCK_OFF                   GTZC_MPCBB_LOCK_OFF
+#define GTZC_MCPBB_LOCK_ON                    GTZC_MPCBB_LOCK_ON
+#endif /* STM32H5 || STM32U5 */
 /**
   * @}
   */
@@ -867,7 +1014,8 @@ extern "C" {
 #define I2C_NOSTRETCH_ENABLED                   I2C_NOSTRETCH_ENABLE
 #define I2C_ANALOGFILTER_ENABLED                I2C_ANALOGFILTER_ENABLE
 #define I2C_ANALOGFILTER_DISABLED               I2C_ANALOGFILTER_DISABLE
-#if defined(STM32F0) || defined(STM32F1) || defined(STM32F3) || defined(STM32G0) || defined(STM32L4) || defined(STM32L1) || defined(STM32F7)
+#if defined(STM32F0) || defined(STM32F1) || defined(STM32F3) || defined(STM32G0) || defined(STM32L4) || \
+    defined(STM32L1) || defined(STM32F7)
 #define HAL_I2C_STATE_MEM_BUSY_TX               HAL_I2C_STATE_BUSY_TX
 #define HAL_I2C_STATE_MEM_BUSY_RX               HAL_I2C_STATE_BUSY_RX
 #define HAL_I2C_STATE_MASTER_BUSY_TX            HAL_I2C_STATE_BUSY_TX
@@ -1005,7 +1153,7 @@ extern "C" {
 #define OPAMP_PGACONNECT_VM0                  OPAMP_PGA_CONNECT_INVERTINGINPUT_IO0
 #define OPAMP_PGACONNECT_VM1                  OPAMP_PGA_CONNECT_INVERTINGINPUT_IO1
 
-#if defined(STM32L1) || defined(STM32L4) || defined(STM32L5) || defined(STM32H7) || defined(STM32G4)
+#if defined(STM32L1) || defined(STM32L4) || defined(STM32L5) || defined(STM32H7) || defined(STM32G4) || defined(STM32U5)
 #define HAL_OPAMP_MSP_INIT_CB_ID       HAL_OPAMP_MSPINIT_CB_ID
 #define HAL_OPAMP_MSP_DEINIT_CB_ID     HAL_OPAMP_MSPDEINIT_CB_ID
 #endif
@@ -1101,6 +1249,26 @@ extern "C" {
 #define RTC_TAMPERPIN_PA0  RTC_TAMPERPIN_POS1
 #define RTC_TAMPERPIN_PI8  RTC_TAMPERPIN_POS1
 
+#if defined(STM32H5) || defined(STM32H7RS)
+#define TAMP_SECRETDEVICE_ERASE_NONE        TAMP_DEVICESECRETS_ERASE_NONE
+#define TAMP_SECRETDEVICE_ERASE_BKP_SRAM    TAMP_DEVICESECRETS_ERASE_BKPSRAM
+#endif /* STM32H5 || STM32H7RS */
+
+#if defined(STM32WBA)
+#define TAMP_SECRETDEVICE_ERASE_NONE            TAMP_DEVICESECRETS_ERASE_NONE
+#define TAMP_SECRETDEVICE_ERASE_SRAM2           TAMP_DEVICESECRETS_ERASE_SRAM2
+#define TAMP_SECRETDEVICE_ERASE_RHUK            TAMP_DEVICESECRETS_ERASE_RHUK
+#define TAMP_SECRETDEVICE_ERASE_ICACHE          TAMP_DEVICESECRETS_ERASE_ICACHE
+#define TAMP_SECRETDEVICE_ERASE_SAES_AES_HASH   TAMP_DEVICESECRETS_ERASE_SAES_AES_HASH
+#define TAMP_SECRETDEVICE_ERASE_PKA_SRAM        TAMP_DEVICESECRETS_ERASE_PKA_SRAM
+#define TAMP_SECRETDEVICE_ERASE_ALL             TAMP_DEVICESECRETS_ERASE_ALL
+#endif /* STM32WBA */
+
+#if defined(STM32H5) || defined(STM32WBA) || defined(STM32H7RS)
+#define TAMP_SECRETDEVICE_ERASE_DISABLE     TAMP_DEVICESECRETS_ERASE_NONE
+#define TAMP_SECRETDEVICE_ERASE_ENABLE      TAMP_SECRETDEVICE_ERASE_ALL
+#endif /* STM32H5 || STM32WBA || STM32H7RS */
+
 #if defined(STM32F7)
 #define RTC_TAMPCR_TAMPXE          RTC_TAMPER_ENABLE_BITS_MASK
 #define RTC_TAMPCR_TAMPXIE         RTC_TAMPER_IT_ENABLE_BITS_MASK
@@ -1111,12 +1279,12 @@ extern "C" {
 #define RTC_TAMPCR_TAMPXIE         RTC_TAMPER_X_INTERRUPT
 #endif /* STM32H7 */
 
-#if defined(STM32F7) || defined(STM32H7)
+#if defined(STM32F7) || defined(STM32H7) || defined(STM32L0)
 #define RTC_TAMPER1_INTERRUPT      RTC_IT_TAMP1
 #define RTC_TAMPER2_INTERRUPT      RTC_IT_TAMP2
 #define RTC_TAMPER3_INTERRUPT      RTC_IT_TAMP3
 #define RTC_ALL_TAMPER_INTERRUPT   RTC_IT_TAMP
-#endif /* STM32F7 || STM32H7 */
+#endif /* STM32F7 || STM32H7 || STM32L0 */
 
 /**
   * @}
@@ -1283,7 +1451,7 @@ extern "C" {
 #define TIM_TIM3_TI1_COMP1COMP2_OUT   TIM_TIM3_TI1_COMP1_COMP2
 #endif
 
-#if defined(STM32U5) || defined(STM32MP2)
+#if defined(STM32U5)
 #define OCREF_CLEAR_SELECT_Pos       OCREF_CLEAR_SELECT_POS
 #define OCREF_CLEAR_SELECT_Msk       OCREF_CLEAR_SELECT_MSK
 #endif
@@ -1396,36 +1564,48 @@ extern "C" {
 #define ETH_MMCRFAECR          0x00000198U
 #define ETH_MMCRGUFCR          0x000001C4U
 
-#define ETH_MAC_TXFIFO_FULL                             0x02000000U  /* Tx FIFO full */
-#define ETH_MAC_TXFIFONOT_EMPTY                         0x01000000U  /* Tx FIFO not empty */
-#define ETH_MAC_TXFIFO_WRITE_ACTIVE                     0x00400000U  /* Tx FIFO write active */
-#define ETH_MAC_TXFIFO_IDLE                             0x00000000U  /* Tx FIFO read status: Idle */
-#define ETH_MAC_TXFIFO_READ                             0x00100000U  /* Tx FIFO read status: Read (transferring data to the MAC transmitter) */
-#define ETH_MAC_TXFIFO_WAITING                          0x00200000U  /* Tx FIFO read status: Waiting for TxStatus from MAC transmitter */
-#define ETH_MAC_TXFIFO_WRITING                          0x00300000U  /* Tx FIFO read status: Writing the received TxStatus or flushing the TxFIFO */
-#define ETH_MAC_TRANSMISSION_PAUSE                      0x00080000U  /* MAC transmitter in pause */
-#define ETH_MAC_TRANSMITFRAMECONTROLLER_IDLE            0x00000000U  /* MAC transmit frame controller: Idle */
-#define ETH_MAC_TRANSMITFRAMECONTROLLER_WAITING         0x00020000U  /* MAC transmit frame controller: Waiting for Status of previous frame or IFG/backoff period to be over */
-#define ETH_MAC_TRANSMITFRAMECONTROLLER_GENRATING_PCF   0x00040000U  /* MAC transmit frame controller: Generating and transmitting a Pause control frame (in full duplex mode) */
-#define ETH_MAC_TRANSMITFRAMECONTROLLER_TRANSFERRING    0x00060000U  /* MAC transmit frame controller: Transferring input frame for transmission */
+#define ETH_MAC_TXFIFO_FULL                           0x02000000U  /* Tx FIFO full */
+#define ETH_MAC_TXFIFONOT_EMPTY                       0x01000000U  /* Tx FIFO not empty */
+#define ETH_MAC_TXFIFO_WRITE_ACTIVE                   0x00400000U  /* Tx FIFO write active */
+#define ETH_MAC_TXFIFO_IDLE                           0x00000000U  /* Tx FIFO read status: Idle */
+#define ETH_MAC_TXFIFO_READ                           0x00100000U  /* Tx FIFO read status: Read (transferring data to 
+                                                                      the MAC transmitter) */
+#define ETH_MAC_TXFIFO_WAITING                        0x00200000U  /* Tx FIFO read status: Waiting for TxStatus from 
+                                                                      MAC transmitter */
+#define ETH_MAC_TXFIFO_WRITING                        0x00300000U  /* Tx FIFO read status: Writing the received TxStatus
+                                                                      or flushing the TxFIFO */
+#define ETH_MAC_TRANSMISSION_PAUSE                    0x00080000U  /* MAC transmitter in pause */
+#define ETH_MAC_TRANSMITFRAMECONTROLLER_IDLE          0x00000000U  /* MAC transmit frame controller: Idle */
+#define ETH_MAC_TRANSMITFRAMECONTROLLER_WAITING       0x00020000U  /* MAC transmit frame controller: Waiting for Status 
+                                                                   of previous frame or IFG/backoff period to be over */
+#define ETH_MAC_TRANSMITFRAMECONTROLLER_GENRATING_PCF 0x00040000U  /* MAC transmit frame controller: Generating and 
+                                                             transmitting a Pause control frame (in full duplex mode) */
+#define ETH_MAC_TRANSMITFRAMECONTROLLER_TRANSFERRING  0x00060000U  /* MAC transmit frame controller: Transferring input 
+                                                                      frame for transmission */
 #define ETH_MAC_MII_TRANSMIT_ACTIVE           0x00010000U  /* MAC MII transmit engine active */
 #define ETH_MAC_RXFIFO_EMPTY                  0x00000000U  /* Rx FIFO fill level: empty */
-#define ETH_MAC_RXFIFO_BELOW_THRESHOLD        0x00000100U  /* Rx FIFO fill level: fill-level below flow-control de-activate threshold */
-#define ETH_MAC_RXFIFO_ABOVE_THRESHOLD        0x00000200U  /* Rx FIFO fill level: fill-level above flow-control activate threshold */
+#define ETH_MAC_RXFIFO_BELOW_THRESHOLD        0x00000100U  /* Rx FIFO fill level: fill-level below flow-control 
+                                                              de-activate threshold */
+#define ETH_MAC_RXFIFO_ABOVE_THRESHOLD        0x00000200U  /* Rx FIFO fill level: fill-level above flow-control 
+                                                              activate threshold */
 #define ETH_MAC_RXFIFO_FULL                   0x00000300U  /* Rx FIFO fill level: full */
 #if defined(STM32F1)
 #else
 #define ETH_MAC_READCONTROLLER_IDLE           0x00000000U  /* Rx FIFO read controller IDLE state */
 #define ETH_MAC_READCONTROLLER_READING_DATA   0x00000020U  /* Rx FIFO read controller Reading frame data */
-#define ETH_MAC_READCONTROLLER_READING_STATUS 0x00000040U  /* Rx FIFO read controller Reading frame status (or time-stamp) */
+#define ETH_MAC_READCONTROLLER_READING_STATUS 0x00000040U  /* Rx FIFO read controller Reading frame status 
+                                                             (or time-stamp) */
 #endif
-#define ETH_MAC_READCONTROLLER_FLUSHING       0x00000060U  /* Rx FIFO read controller Flushing the frame data and status */
+#define ETH_MAC_READCONTROLLER_FLUSHING       0x00000060U  /* Rx FIFO read controller Flushing the frame data and 
+                                                              status */
 #define ETH_MAC_RXFIFO_WRITE_ACTIVE           0x00000010U  /* Rx FIFO write controller active */
 #define ETH_MAC_SMALL_FIFO_NOTACTIVE          0x00000000U  /* MAC small FIFO read / write controllers not active */
 #define ETH_MAC_SMALL_FIFO_READ_ACTIVE        0x00000002U  /* MAC small FIFO read controller active */
 #define ETH_MAC_SMALL_FIFO_WRITE_ACTIVE       0x00000004U  /* MAC small FIFO write controller active */
 #define ETH_MAC_SMALL_FIFO_RW_ACTIVE          0x00000006U  /* MAC small FIFO read / write controllers active */
 #define ETH_MAC_MII_RECEIVE_PROTOCOL_ACTIVE   0x00000001U  /* MAC MII receive protocol engine active */
+
+#define ETH_TxPacketConfig        ETH_TxPacketConfigTypeDef   /* Transmit Packet Configuration structure definition */
 
 /**
   * @}
@@ -1590,7 +1770,8 @@ extern "C" {
 #define HAL_EnableDBGStandbyMode HAL_DBGMCU_EnableDBGStandbyMode
 #define HAL_DisableDBGStandbyMode HAL_DBGMCU_DisableDBGStandbyMode
 #define HAL_DBG_LowPowerConfig(Periph, cmd) (((cmd\
-                                              )==ENABLE)? HAL_DBGMCU_DBG_EnableLowPowerConfig(Periph) : HAL_DBGMCU_DBG_DisableLowPowerConfig(Periph))
+                                              )==ENABLE)? HAL_DBGMCU_DBG_EnableLowPowerConfig(Periph) : \
+                                             HAL_DBGMCU_DBG_DisableLowPowerConfig(Periph))
 #define HAL_VREFINT_OutputSelect  HAL_SYSCFG_VREFINT_OutputSelect
 #define HAL_Lock_Cmd(cmd) (((cmd)==ENABLE) ? HAL_SYSCFG_Enable_Lock_VREFINT() : HAL_SYSCFG_Disable_Lock_VREFINT())
 #if defined(STM32L0)
@@ -1599,8 +1780,10 @@ extern "C" {
 #endif
 #define HAL_ADC_EnableBuffer_Cmd(cmd)  (((cmd)==ENABLE) ? HAL_ADCEx_EnableVREFINT() : HAL_ADCEx_DisableVREFINT())
 #define HAL_ADC_EnableBufferSensor_Cmd(cmd) (((cmd\
-                                              )==ENABLE) ?  HAL_ADCEx_EnableVREFINTTempSensor() : HAL_ADCEx_DisableVREFINTTempSensor())
-#if defined(STM32H7A3xx) || defined(STM32H7B3xx) || defined(STM32H7B0xx) || defined(STM32H7A3xxQ) || defined(STM32H7B3xxQ) || defined(STM32H7B0xxQ)
+                                              )==ENABLE) ?  HAL_ADCEx_EnableVREFINTTempSensor() : \
+                                             HAL_ADCEx_DisableVREFINTTempSensor())
+#if defined(STM32H7A3xx) || defined(STM32H7B3xx) || defined(STM32H7B0xx) || defined(STM32H7A3xxQ) || \
+    defined(STM32H7B3xxQ) || defined(STM32H7B0xxQ)
 #define HAL_EnableSRDomainDBGStopMode      HAL_EnableDomain3DBGStopMode
 #define HAL_DisableSRDomainDBGStopMode     HAL_DisableDomain3DBGStopMode
 #define HAL_EnableSRDomainDBGStandbyMode   HAL_EnableDomain3DBGStandbyMode
@@ -1634,16 +1817,21 @@ extern "C" {
 #define HAL_FMPI2CEx_AnalogFilter_Config      HAL_FMPI2CEx_ConfigAnalogFilter
 #define HAL_FMPI2CEx_DigitalFilter_Config     HAL_FMPI2CEx_ConfigDigitalFilter
 
-#define HAL_I2CFastModePlusConfig(SYSCFG_I2CFastModePlus, cmd) (((cmd\
-                                                                 )==ENABLE)? HAL_I2CEx_EnableFastModePlus(SYSCFG_I2CFastModePlus): HAL_I2CEx_DisableFastModePlus(SYSCFG_I2CFastModePlus))
+#define HAL_I2CFastModePlusConfig(SYSCFG_I2CFastModePlus, cmd) ((cmd == ENABLE)? \
+                                                                HAL_I2CEx_EnableFastModePlus(SYSCFG_I2CFastModePlus): \
+                                                                HAL_I2CEx_DisableFastModePlus(SYSCFG_I2CFastModePlus))
 
-#if defined(STM32H7) || defined(STM32WB) || defined(STM32G0) || defined(STM32F0) || defined(STM32F1) || defined(STM32F2) || defined(STM32F3) || defined(STM32F4) || defined(STM32F7) || defined(STM32L0) || defined(STM32L4) || defined(STM32L5) || defined(STM32G4) || defined(STM32L1)
+#if defined(STM32H7) || defined(STM32WB) || defined(STM32G0) || defined(STM32F0) || defined(STM32F1) || \
+    defined(STM32F2) || defined(STM32F3) || defined(STM32F4) || defined(STM32F7) || defined(STM32L0) || \
+    defined(STM32L4) || defined(STM32L5) || defined(STM32G4) || defined(STM32L1)
 #define HAL_I2C_Master_Sequential_Transmit_IT  HAL_I2C_Master_Seq_Transmit_IT
 #define HAL_I2C_Master_Sequential_Receive_IT   HAL_I2C_Master_Seq_Receive_IT
 #define HAL_I2C_Slave_Sequential_Transmit_IT   HAL_I2C_Slave_Seq_Transmit_IT
 #define HAL_I2C_Slave_Sequential_Receive_IT    HAL_I2C_Slave_Seq_Receive_IT
-#endif /* STM32H7 || STM32WB  || STM32G0 || STM32F0 || STM32F1 || STM32F2 || STM32F3 || STM32F4 || STM32F7 || STM32L0 || STM32L4 || STM32L5 || STM32G4 || STM32L1 */
-#if defined(STM32H7) || defined(STM32WB) || defined(STM32G0) || defined(STM32F4) || defined(STM32F7) || defined(STM32L0) || defined(STM32L4) || defined(STM32L5) || defined(STM32G4)|| defined(STM32L1)
+#endif /* STM32H7 || STM32WB  || STM32G0 || STM32F0 || STM32F1 || STM32F2 || STM32F3 || STM32F4 || STM32F7 || STM32L0 ||
+          STM32L4 || STM32L5 || STM32G4 || STM32L1 */
+#if defined(STM32H7) || defined(STM32WB) || defined(STM32G0) || defined(STM32F4) || defined(STM32F7) || \
+    defined(STM32L0) || defined(STM32L4) || defined(STM32L5) || defined(STM32G4)|| defined(STM32L1)
 #define HAL_I2C_Master_Sequential_Transmit_DMA HAL_I2C_Master_Seq_Transmit_DMA
 #define HAL_I2C_Master_Sequential_Receive_DMA  HAL_I2C_Master_Seq_Receive_DMA
 #define HAL_I2C_Slave_Sequential_Transmit_DMA  HAL_I2C_Slave_Seq_Transmit_DMA
@@ -1768,6 +1956,17 @@ extern "C" {
 #define PWR_SRAM5_PAGE13_STOP_RETENTION               PWR_SRAM5_PAGE13_STOP
 #define PWR_SRAM5_FULL_STOP_RETENTION                 PWR_SRAM5_FULL_STOP
 
+#define PWR_SRAM6_PAGE1_STOP_RETENTION                PWR_SRAM6_PAGE1_STOP
+#define PWR_SRAM6_PAGE2_STOP_RETENTION                PWR_SRAM6_PAGE2_STOP
+#define PWR_SRAM6_PAGE3_STOP_RETENTION                PWR_SRAM6_PAGE3_STOP
+#define PWR_SRAM6_PAGE4_STOP_RETENTION                PWR_SRAM6_PAGE4_STOP
+#define PWR_SRAM6_PAGE5_STOP_RETENTION                PWR_SRAM6_PAGE5_STOP
+#define PWR_SRAM6_PAGE6_STOP_RETENTION                PWR_SRAM6_PAGE6_STOP
+#define PWR_SRAM6_PAGE7_STOP_RETENTION                PWR_SRAM6_PAGE7_STOP
+#define PWR_SRAM6_PAGE8_STOP_RETENTION                PWR_SRAM6_PAGE8_STOP
+#define PWR_SRAM6_FULL_STOP_RETENTION                 PWR_SRAM6_FULL_STOP
+
+
 #define PWR_ICACHE_FULL_STOP_RETENTION                PWR_ICACHE_FULL_STOP
 #define PWR_DCACHE1_FULL_STOP_RETENTION               PWR_DCACHE1_FULL_STOP
 #define PWR_DCACHE2_FULL_STOP_RETENTION               PWR_DCACHE2_FULL_STOP
@@ -1776,6 +1975,8 @@ extern "C" {
 #define PWR_PKA32RAM_FULL_STOP_RETENTION              PWR_PKA32RAM_FULL_STOP
 #define PWR_GRAPHICPRAM_FULL_STOP_RETENTION           PWR_GRAPHICPRAM_FULL_STOP
 #define PWR_DSIRAM_FULL_STOP_RETENTION                PWR_DSIRAM_FULL_STOP
+#define PWR_JPEGRAM_FULL_STOP_RETENTION               PWR_JPEGRAM_FULL_STOP
+
 
 #define PWR_SRAM2_PAGE1_STANDBY_RETENTION             PWR_SRAM2_PAGE1_STANDBY
 #define PWR_SRAM2_PAGE2_STANDBY_RETENTION             PWR_SRAM2_PAGE2_STANDBY
@@ -1786,6 +1987,7 @@ extern "C" {
 #define PWR_SRAM3_FULL_RUN_RETENTION                  PWR_SRAM3_FULL_RUN
 #define PWR_SRAM4_FULL_RUN_RETENTION                  PWR_SRAM4_FULL_RUN
 #define PWR_SRAM5_FULL_RUN_RETENTION                  PWR_SRAM5_FULL_RUN
+#define PWR_SRAM6_FULL_RUN_RETENTION                  PWR_SRAM6_FULL_RUN
 
 #define PWR_ALL_RAM_RUN_RETENTION_MASK                PWR_ALL_RAM_RUN_MASK
 #endif
@@ -1793,6 +1995,20 @@ extern "C" {
 /**
   * @}
  */
+
+/** @defgroup HAL_RTC_Aliased_Functions HAL RTC Aliased Functions maintained for legacy purpose
+  * @{
+  */
+#if defined(STM32H5) || defined(STM32WBA) || defined(STM32H7RS)
+#define HAL_RTCEx_SetBoothardwareKey            HAL_RTCEx_LockBootHardwareKey
+#define HAL_RTCEx_BKUPBlock_Enable              HAL_RTCEx_BKUPBlock
+#define HAL_RTCEx_BKUPBlock_Disable             HAL_RTCEx_BKUPUnblock
+#define HAL_RTCEx_Erase_SecretDev_Conf          HAL_RTCEx_ConfigEraseDeviceSecrets
+#endif /* STM32H5 || STM32WBA || STM32H7RS */
+
+/**
+  * @}
+  */
 
 /** @defgroup HAL_SMBUS_Aliased_Functions HAL SMBUS Aliased Functions maintained for legacy purpose
   * @{
@@ -1819,7 +2035,8 @@ extern "C" {
 #define HAL_TIM_DMAError                                TIM_DMAError
 #define HAL_TIM_DMACaptureCplt                          TIM_DMACaptureCplt
 #define HAL_TIMEx_DMACommutationCplt                    TIMEx_DMACommutationCplt
-#if defined(STM32H7) || defined(STM32G0) || defined(STM32F0) || defined(STM32F1) || defined(STM32F2) || defined(STM32F3) || defined(STM32F4) || defined(STM32F7) || defined(STM32L0) || defined(STM32L4)
+#if defined(STM32H7) || defined(STM32G0) || defined(STM32F0) || defined(STM32F1) || defined(STM32F2) || \
+    defined(STM32F3) || defined(STM32F4) || defined(STM32F7) || defined(STM32L0) || defined(STM32L4)
 #define HAL_TIM_SlaveConfigSynchronization              HAL_TIM_SlaveConfigSynchro
 #define HAL_TIM_SlaveConfigSynchronization_IT           HAL_TIM_SlaveConfigSynchro_IT
 #define HAL_TIMEx_CommutationCallback                   HAL_TIMEx_CommutCallback
@@ -2076,7 +2293,8 @@ extern "C" {
 #define COMP_STOP                                        __HAL_COMP_DISABLE
 #define COMP_LOCK                                        __HAL_COMP_LOCK
 
-#if defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx) || defined(STM32F303x8) || defined(STM32F334x8) || defined(STM32F328xx)
+#if defined(STM32F301x8) || defined(STM32F302x8) || defined(STM32F318xx) || defined(STM32F303x8) || \
+    defined(STM32F334x8) || defined(STM32F328xx)
 #define __HAL_COMP_EXTI_RISING_IT_ENABLE(__EXTILINE__)   (((__EXTILINE__)  == COMP_EXTI_LINE_COMP2) ? __HAL_COMP_COMP2_EXTI_ENABLE_RISING_EDGE() : \
                                                           ((__EXTILINE__)  == COMP_EXTI_LINE_COMP4) ? __HAL_COMP_COMP4_EXTI_ENABLE_RISING_EDGE() : \
                                                           __HAL_COMP_COMP6_EXTI_ENABLE_RISING_EDGE())
@@ -2101,8 +2319,8 @@ extern "C" {
 #define __HAL_COMP_EXTI_CLEAR_FLAG(__FLAG__)             (((__FLAG__)  == COMP_EXTI_LINE_COMP2) ? __HAL_COMP_COMP2_EXTI_CLEAR_FLAG() : \
                                                           ((__FLAG__)  == COMP_EXTI_LINE_COMP4) ? __HAL_COMP_COMP4_EXTI_CLEAR_FLAG() : \
                                                           __HAL_COMP_COMP6_EXTI_CLEAR_FLAG())
-# endif
-# if defined(STM32F302xE) || defined(STM32F302xC)
+#endif
+#if defined(STM32F302xE) || defined(STM32F302xC)
 #define __HAL_COMP_EXTI_RISING_IT_ENABLE(__EXTILINE__)   (((__EXTILINE__)  == COMP_EXTI_LINE_COMP1) ? __HAL_COMP_COMP1_EXTI_ENABLE_RISING_EDGE() : \
                                                           ((__EXTILINE__)  == COMP_EXTI_LINE_COMP2) ? __HAL_COMP_COMP2_EXTI_ENABLE_RISING_EDGE() : \
                                                           ((__EXTILINE__)  == COMP_EXTI_LINE_COMP4) ? __HAL_COMP_COMP4_EXTI_ENABLE_RISING_EDGE() : \
@@ -2135,8 +2353,8 @@ extern "C" {
                                                           ((__FLAG__)  == COMP_EXTI_LINE_COMP2) ? __HAL_COMP_COMP2_EXTI_CLEAR_FLAG() : \
                                                           ((__FLAG__)  == COMP_EXTI_LINE_COMP4) ? __HAL_COMP_COMP4_EXTI_CLEAR_FLAG() : \
                                                           __HAL_COMP_COMP6_EXTI_CLEAR_FLAG())
-# endif
-# if defined(STM32F303xE) || defined(STM32F398xx) || defined(STM32F303xC) || defined(STM32F358xx)
+#endif
+#if defined(STM32F303xE) || defined(STM32F398xx) || defined(STM32F303xC) || defined(STM32F358xx)
 #define __HAL_COMP_EXTI_RISING_IT_ENABLE(__EXTILINE__)   (((__EXTILINE__)  == COMP_EXTI_LINE_COMP1) ? __HAL_COMP_COMP1_EXTI_ENABLE_RISING_EDGE() : \
                                                           ((__EXTILINE__)  == COMP_EXTI_LINE_COMP2) ? __HAL_COMP_COMP2_EXTI_ENABLE_RISING_EDGE() : \
                                                           ((__EXTILINE__)  == COMP_EXTI_LINE_COMP3) ? __HAL_COMP_COMP3_EXTI_ENABLE_RISING_EDGE() : \
@@ -2193,8 +2411,8 @@ extern "C" {
                                                           ((__FLAG__)  == COMP_EXTI_LINE_COMP5) ? __HAL_COMP_COMP5_EXTI_CLEAR_FLAG() : \
                                                           ((__FLAG__)  == COMP_EXTI_LINE_COMP6) ? __HAL_COMP_COMP6_EXTI_CLEAR_FLAG() : \
                                                           __HAL_COMP_COMP7_EXTI_CLEAR_FLAG())
-# endif
-# if defined(STM32F373xC) ||defined(STM32F378xx)
+#endif
+#if defined(STM32F373xC) ||defined(STM32F378xx)
 #define __HAL_COMP_EXTI_RISING_IT_ENABLE(__EXTILINE__)   (((__EXTILINE__)  == COMP_EXTI_LINE_COMP1) ? __HAL_COMP_COMP1_EXTI_ENABLE_RISING_EDGE() : \
                                                           __HAL_COMP_COMP2_EXTI_ENABLE_RISING_EDGE())
 #define __HAL_COMP_EXTI_RISING_IT_DISABLE(__EXTILINE__)  (((__EXTILINE__)  == COMP_EXTI_LINE_COMP1) ? __HAL_COMP_COMP1_EXTI_DISABLE_RISING_EDGE() : \
@@ -2211,7 +2429,7 @@ extern "C" {
                                                           __HAL_COMP_COMP2_EXTI_GET_FLAG())
 #define __HAL_COMP_EXTI_CLEAR_FLAG(__FLAG__)             (((__FLAG__)  == COMP_EXTI_LINE_COMP1) ? __HAL_COMP_COMP1_EXTI_CLEAR_FLAG() : \
                                                           __HAL_COMP_COMP2_EXTI_CLEAR_FLAG())
-# endif
+#endif
 #else
 #define __HAL_COMP_EXTI_RISING_IT_ENABLE(__EXTILINE__)   (((__EXTILINE__)  == COMP_EXTI_LINE_COMP1) ? __HAL_COMP_COMP1_EXTI_ENABLE_RISING_EDGE() : \
                                                           __HAL_COMP_COMP2_EXTI_ENABLE_RISING_EDGE())
@@ -2248,8 +2466,10 @@ extern "C" {
 /** @defgroup HAL_COMP_Aliased_Functions HAL COMP Aliased Functions maintained for legacy purpose
   * @{
   */
-#define HAL_COMP_Start_IT       HAL_COMP_Start /* Function considered as legacy as EXTI event or IT configuration is done into HAL_COMP_Init() */
-#define HAL_COMP_Stop_IT        HAL_COMP_Stop  /* Function considered as legacy as EXTI event or IT configuration is done into HAL_COMP_Init() */
+#define HAL_COMP_Start_IT       HAL_COMP_Start /* Function considered as legacy as EXTI event or IT configuration is 
+                                                  done into HAL_COMP_Init() */
+#define HAL_COMP_Stop_IT        HAL_COMP_Stop  /* Function considered as legacy as EXTI event or IT configuration is 
+                                                  done into HAL_COMP_Init() */
 /**
   * @}
   */
@@ -2408,7 +2628,9 @@ extern "C" {
 #define __HAL_PWR_INTERNALWAKEUP_ENABLE                          HAL_PWREx_EnableInternalWakeUpLine
 #define __HAL_PWR_PULL_UP_DOWN_CONFIG_DISABLE                    HAL_PWREx_DisablePullUpPullDownConfig
 #define __HAL_PWR_PULL_UP_DOWN_CONFIG_ENABLE                     HAL_PWREx_EnablePullUpPullDownConfig
-#define __HAL_PWR_PVD_EXTI_CLEAR_EGDE_TRIGGER()                  do { __HAL_PWR_PVD_EXTI_DISABLE_RISING_EDGE();__HAL_PWR_PVD_EXTI_DISABLE_FALLING_EDGE(); } while(0)
+#define __HAL_PWR_PVD_EXTI_CLEAR_EGDE_TRIGGER()                  do { __HAL_PWR_PVD_EXTI_DISABLE_RISING_EDGE(); \
+                                                                      __HAL_PWR_PVD_EXTI_DISABLE_FALLING_EDGE(); \
+                                                                    } while(0)
 #define __HAL_PWR_PVD_EXTI_EVENT_DISABLE                         __HAL_PWR_PVD_EXTI_DISABLE_EVENT
 #define __HAL_PWR_PVD_EXTI_EVENT_ENABLE                          __HAL_PWR_PVD_EXTI_ENABLE_EVENT
 #define __HAL_PWR_PVD_EXTI_FALLINGTRIGGER_DISABLE                __HAL_PWR_PVD_EXTI_DISABLE_FALLING_EDGE
@@ -2417,8 +2639,12 @@ extern "C" {
 #define __HAL_PWR_PVD_EXTI_RISINGTRIGGER_ENABLE                  __HAL_PWR_PVD_EXTI_ENABLE_RISING_EDGE
 #define __HAL_PWR_PVD_EXTI_SET_FALLING_EGDE_TRIGGER              __HAL_PWR_PVD_EXTI_ENABLE_FALLING_EDGE
 #define __HAL_PWR_PVD_EXTI_SET_RISING_EDGE_TRIGGER               __HAL_PWR_PVD_EXTI_ENABLE_RISING_EDGE
-#define __HAL_PWR_PVM_DISABLE()                                  do { HAL_PWREx_DisablePVM1();HAL_PWREx_DisablePVM2();HAL_PWREx_DisablePVM3();HAL_PWREx_DisablePVM4(); } while(0)
-#define __HAL_PWR_PVM_ENABLE()                                   do { HAL_PWREx_EnablePVM1();HAL_PWREx_EnablePVM2();HAL_PWREx_EnablePVM3();HAL_PWREx_EnablePVM4(); } while(0)
+#define __HAL_PWR_PVM_DISABLE()                                  do { HAL_PWREx_DisablePVM1();HAL_PWREx_DisablePVM2(); \
+                                                                      HAL_PWREx_DisablePVM3();HAL_PWREx_DisablePVM4(); \
+                                                                    } while(0)
+#define __HAL_PWR_PVM_ENABLE()                                   do { HAL_PWREx_EnablePVM1();HAL_PWREx_EnablePVM2(); \
+                                                                      HAL_PWREx_EnablePVM3();HAL_PWREx_EnablePVM4(); \
+                                                                    } while(0)
 #define __HAL_PWR_SRAM2CONTENT_PRESERVE_DISABLE                  HAL_PWREx_DisableSRAM2ContentRetention
 #define __HAL_PWR_SRAM2CONTENT_PRESERVE_ENABLE                   HAL_PWREx_EnableSRAM2ContentRetention
 #define __HAL_PWR_VDDIO2_DISABLE                                 HAL_PWREx_DisableVddIO2
@@ -2454,8 +2680,8 @@ extern "C" {
 #define RCC_StopWakeUpClock_HSI     RCC_STOP_WAKEUPCLOCK_HSI
 
 #define HAL_RCC_CCSCallback HAL_RCC_CSSCallback
-#define HAL_RC48_EnableBuffer_Cmd(cmd) (((cmd\
-                                         )==ENABLE) ? HAL_RCCEx_EnableHSI48_VREFINT() : HAL_RCCEx_DisableHSI48_VREFINT())
+#define HAL_RC48_EnableBuffer_Cmd(cmd) (((cmd)==ENABLE) ? \
+                                        HAL_RCCEx_EnableHSI48_VREFINT() : HAL_RCCEx_DisableHSI48_VREFINT())
 
 #define __ADC_CLK_DISABLE          __HAL_RCC_ADC_CLK_DISABLE
 #define __ADC_CLK_ENABLE           __HAL_RCC_ADC_CLK_ENABLE
@@ -2959,6 +3185,11 @@ extern "C" {
 
 #define  __HAL_RCC_WWDG_IS_CLK_ENABLED    __HAL_RCC_WWDG1_IS_CLK_ENABLED
 #define  __HAL_RCC_WWDG_IS_CLK_DISABLED  __HAL_RCC_WWDG1_IS_CLK_DISABLED
+#define  RCC_SPI4CLKSOURCE_D2PCLK1       RCC_SPI4CLKSOURCE_D2PCLK2
+#define  RCC_SPI5CLKSOURCE_D2PCLK1       RCC_SPI5CLKSOURCE_D2PCLK2
+#define  RCC_SPI45CLKSOURCE_D2PCLK1      RCC_SPI45CLKSOURCE_D2PCLK2
+#define  RCC_SPI45CLKSOURCE_CDPCLK1      RCC_SPI45CLKSOURCE_CDPCLK2
+#define  RCC_SPI45CLKSOURCE_PCLK1        RCC_SPI45CLKSOURCE_PCLK2
 #endif
 
 #define __WWDG_CLK_DISABLE __HAL_RCC_WWDG_CLK_DISABLE
@@ -3423,7 +3654,12 @@ extern "C" {
 #define RCC_MCOSOURCE_PLLCLK_NODIV  RCC_MCO1SOURCE_PLLCLK
 #define RCC_MCOSOURCE_PLLCLK_DIV2   RCC_MCO1SOURCE_PLLCLK_DIV2
 
-#if defined(STM32L4) || defined(STM32WB) || defined(STM32G0) || defined(STM32G4) || defined(STM32L5) || defined(STM32WL) || defined(STM32C0)
+#if defined(STM32U0)
+#define RCC_SYSCLKSOURCE_STATUS_PLLR   RCC_SYSCLKSOURCE_STATUS_PLLCLK
+#endif
+
+#if defined(STM32L4) || defined(STM32WB) || defined(STM32G0) || defined(STM32G4) || defined(STM32L5) || \
+    defined(STM32WL) || defined(STM32C0) || defined(STM32H7RS) || defined(STM32U0)
 #define RCC_RTCCLKSOURCE_NO_CLK     RCC_RTCCLKSOURCE_NONE
 #else
 #define RCC_RTCCLKSOURCE_NONE       RCC_RTCCLKSOURCE_NO_CLK
@@ -3525,8 +3761,10 @@ extern "C" {
 #define __HAL_RCC_GET_DFSDM_SOURCE  __HAL_RCC_GET_DFSDM1_SOURCE
 #define RCC_DFSDM1CLKSOURCE_PCLK    RCC_DFSDM1CLKSOURCE_PCLK2
 #define RCC_SWPMI1CLKSOURCE_PCLK    RCC_SWPMI1CLKSOURCE_PCLK1
+#if !defined(STM32U0)
 #define RCC_LPTIM1CLKSOURCE_PCLK    RCC_LPTIM1CLKSOURCE_PCLK1
 #define RCC_LPTIM2CLKSOURCE_PCLK    RCC_LPTIM2CLKSOURCE_PCLK1
+#endif
 
 #define RCC_DFSDM1AUDIOCLKSOURCE_I2SAPB1    RCC_DFSDM1AUDIOCLKSOURCE_I2S1
 #define RCC_DFSDM1AUDIOCLKSOURCE_I2SAPB2    RCC_DFSDM1AUDIOCLKSOURCE_I2S2
@@ -3568,6 +3806,92 @@ extern "C" {
 #define IS_RCC_PLLFRACN_VALUE                 IS_RCC_PLL_FRACN_VALUE
 #endif /* STM32U5 */
 
+#if defined(STM32H5)
+#define __HAL_RCC_PLLFRACN_ENABLE       __HAL_RCC_PLL_FRACN_ENABLE
+#define __HAL_RCC_PLLFRACN_DISABLE      __HAL_RCC_PLL_FRACN_DISABLE
+#define __HAL_RCC_PLLFRACN_CONFIG       __HAL_RCC_PLL_FRACN_CONFIG
+#define IS_RCC_PLLFRACN_VALUE           IS_RCC_PLL_FRACN_VALUE
+
+#define RCC_PLLSOURCE_NONE              RCC_PLL1_SOURCE_NONE
+#define RCC_PLLSOURCE_HSI               RCC_PLL1_SOURCE_HSI
+#define RCC_PLLSOURCE_CSI               RCC_PLL1_SOURCE_CSI
+#define RCC_PLLSOURCE_HSE               RCC_PLL1_SOURCE_HSE
+#define RCC_PLLVCIRANGE_0               RCC_PLL1_VCIRANGE_0
+#define RCC_PLLVCIRANGE_1               RCC_PLL1_VCIRANGE_1
+#define RCC_PLLVCIRANGE_2               RCC_PLL1_VCIRANGE_2
+#define RCC_PLLVCIRANGE_3               RCC_PLL1_VCIRANGE_3
+#define RCC_PLL1VCOWIDE                 RCC_PLL1_VCORANGE_WIDE
+#define RCC_PLL1VCOMEDIUM               RCC_PLL1_VCORANGE_MEDIUM
+
+#define IS_RCC_PLLSOURCE                IS_RCC_PLL1_SOURCE
+#define IS_RCC_PLLRGE_VALUE             IS_RCC_PLL1_VCIRGE_VALUE
+#define IS_RCC_PLLVCORGE_VALUE          IS_RCC_PLL1_VCORGE_VALUE
+#define IS_RCC_PLLCLOCKOUT_VALUE        IS_RCC_PLL1_CLOCKOUT_VALUE
+#define IS_RCC_PLL_FRACN_VALUE          IS_RCC_PLL1_FRACN_VALUE
+#define IS_RCC_PLLM_VALUE               IS_RCC_PLL1_DIVM_VALUE
+#define IS_RCC_PLLN_VALUE               IS_RCC_PLL1_MULN_VALUE
+#define IS_RCC_PLLP_VALUE               IS_RCC_PLL1_DIVP_VALUE
+#define IS_RCC_PLLQ_VALUE               IS_RCC_PLL1_DIVQ_VALUE
+#define IS_RCC_PLLR_VALUE               IS_RCC_PLL1_DIVR_VALUE
+
+#define __HAL_RCC_PLL_ENABLE            __HAL_RCC_PLL1_ENABLE
+#define __HAL_RCC_PLL_DISABLE           __HAL_RCC_PLL1_DISABLE
+#define __HAL_RCC_PLL_FRACN_ENABLE      __HAL_RCC_PLL1_FRACN_ENABLE
+#define __HAL_RCC_PLL_FRACN_DISABLE     __HAL_RCC_PLL1_FRACN_DISABLE
+#define __HAL_RCC_PLL_CONFIG            __HAL_RCC_PLL1_CONFIG
+#define __HAL_RCC_PLL_PLLSOURCE_CONFIG  __HAL_RCC_PLL1_PLLSOURCE_CONFIG
+#define __HAL_RCC_PLL_DIVM_CONFIG       __HAL_RCC_PLL1_DIVM_CONFIG
+#define __HAL_RCC_PLL_FRACN_CONFIG      __HAL_RCC_PLL1_FRACN_CONFIG
+#define __HAL_RCC_PLL_VCIRANGE          __HAL_RCC_PLL1_VCIRANGE
+#define __HAL_RCC_PLL_VCORANGE          __HAL_RCC_PLL1_VCORANGE
+#define __HAL_RCC_GET_PLL_OSCSOURCE     __HAL_RCC_GET_PLL1_OSCSOURCE
+#define __HAL_RCC_PLLCLKOUT_ENABLE      __HAL_RCC_PLL1_CLKOUT_ENABLE
+#define __HAL_RCC_PLLCLKOUT_DISABLE     __HAL_RCC_PLL1_CLKOUT_DISABLE
+#define __HAL_RCC_GET_PLLCLKOUT_CONFIG  __HAL_RCC_GET_PLL1_CLKOUT_CONFIG
+
+#define __HAL_RCC_PLL2FRACN_ENABLE      __HAL_RCC_PLL2_FRACN_ENABLE
+#define __HAL_RCC_PLL2FRACN_DISABLE     __HAL_RCC_PLL2_FRACN_DISABLE
+#define __HAL_RCC_PLL2CLKOUT_ENABLE     __HAL_RCC_PLL2_CLKOUT_ENABLE
+#define __HAL_RCC_PLL2CLKOUT_DISABLE    __HAL_RCC_PLL2_CLKOUT_DISABLE
+#define __HAL_RCC_PLL2FRACN_CONFIG      __HAL_RCC_PLL2_FRACN_CONFIG
+#define __HAL_RCC_GET_PLL2CLKOUT_CONFIG __HAL_RCC_GET_PLL2_CLKOUT_CONFIG
+
+#define __HAL_RCC_PLL3FRACN_ENABLE      __HAL_RCC_PLL3_FRACN_ENABLE
+#define __HAL_RCC_PLL3FRACN_DISABLE     __HAL_RCC_PLL3_FRACN_DISABLE
+#define __HAL_RCC_PLL3CLKOUT_ENABLE     __HAL_RCC_PLL3_CLKOUT_ENABLE
+#define __HAL_RCC_PLL3CLKOUT_DISABLE    __HAL_RCC_PLL3_CLKOUT_DISABLE
+#define __HAL_RCC_PLL3FRACN_CONFIG      __HAL_RCC_PLL3_FRACN_CONFIG
+#define __HAL_RCC_GET_PLL3CLKOUT_CONFIG __HAL_RCC_GET_PLL3_CLKOUT_CONFIG
+
+#define RCC_PLL2VCIRANGE_0              RCC_PLL2_VCIRANGE_0
+#define RCC_PLL2VCIRANGE_1              RCC_PLL2_VCIRANGE_1
+#define RCC_PLL2VCIRANGE_2              RCC_PLL2_VCIRANGE_2
+#define RCC_PLL2VCIRANGE_3              RCC_PLL2_VCIRANGE_3
+
+#define RCC_PLL2VCOWIDE                 RCC_PLL2_VCORANGE_WIDE
+#define RCC_PLL2VCOMEDIUM               RCC_PLL2_VCORANGE_MEDIUM
+
+#define RCC_PLL2SOURCE_NONE             RCC_PLL2_SOURCE_NONE
+#define RCC_PLL2SOURCE_HSI              RCC_PLL2_SOURCE_HSI
+#define RCC_PLL2SOURCE_CSI              RCC_PLL2_SOURCE_CSI
+#define RCC_PLL2SOURCE_HSE              RCC_PLL2_SOURCE_HSE
+
+#define RCC_PLL3VCIRANGE_0              RCC_PLL3_VCIRANGE_0
+#define RCC_PLL3VCIRANGE_1              RCC_PLL3_VCIRANGE_1
+#define RCC_PLL3VCIRANGE_2              RCC_PLL3_VCIRANGE_2
+#define RCC_PLL3VCIRANGE_3              RCC_PLL3_VCIRANGE_3
+
+#define RCC_PLL3VCOWIDE                 RCC_PLL3_VCORANGE_WIDE
+#define RCC_PLL3VCOMEDIUM               RCC_PLL3_VCORANGE_MEDIUM
+
+#define RCC_PLL3SOURCE_NONE             RCC_PLL3_SOURCE_NONE
+#define RCC_PLL3SOURCE_HSI              RCC_PLL3_SOURCE_HSI
+#define RCC_PLL3SOURCE_CSI              RCC_PLL3_SOURCE_CSI
+#define RCC_PLL3SOURCE_HSE              RCC_PLL3_SOURCE_HSE
+
+
+#endif /* STM32H5 */
+
 /**
   * @}
   */
@@ -3584,9 +3908,9 @@ extern "C" {
 /** @defgroup HAL_RTC_Aliased_Macros HAL RTC Aliased Macros maintained for legacy purpose
   * @{
   */
-#if defined (STM32G0) || defined (STM32L5) || defined (STM32L412xx) || defined (STM32L422xx) || defined (STM32L4P5xx)|| \
-    defined (STM32L4Q5xx) || defined (STM32G4) || defined (STM32WL) || defined (STM32U5) || \
-    defined (STM32C0)
+#if defined (STM32G0) || defined (STM32L5) || defined (STM32L412xx) || defined (STM32L422xx) || \
+    defined (STM32L4P5xx)|| defined (STM32L4Q5xx) || defined (STM32G4) || defined (STM32WL) || defined (STM32U5) || \
+    defined (STM32WBA) || defined (STM32H5) || defined (STM32C0) || defined (STM32H7RS) ||  defined (STM32U0)
 #else
 #define __HAL_RTC_CLEAR_FLAG                      __HAL_RTC_EXTI_CLEAR_FLAG
 #endif
@@ -3621,6 +3945,13 @@ extern "C" {
                                                         __HAL_RTC_TAMPER_TIMESTAMP_EXTI_GENERATE_SWIT()))
 #endif   /* STM32F1 */
 
+#if defined (STM32F0) || defined (STM32F2) || defined (STM32F3) || defined (STM32F4) || defined (STM32F7) || \
+    defined (STM32H7) || \
+    defined (STM32L0) || defined (STM32L1) || \
+    defined (STM32WB)
+#define __HAL_RTC_TAMPER_GET_IT                   __HAL_RTC_TAMPER_GET_FLAG
+#endif
+
 #define IS_ALARM                                  IS_RTC_ALARM
 #define IS_ALARM_MASK                             IS_RTC_ALARM_MASK
 #define IS_TAMPER                                 IS_RTC_TAMPER
@@ -3638,6 +3969,11 @@ extern "C" {
 
 #define __RTC_WRITEPROTECTION_ENABLE  __HAL_RTC_WRITEPROTECTION_ENABLE
 #define __RTC_WRITEPROTECTION_DISABLE  __HAL_RTC_WRITEPROTECTION_DISABLE
+
+#if defined (STM32H5)
+#define __HAL_RCC_RTCAPB_CLK_ENABLE   __HAL_RCC_RTC_CLK_ENABLE
+#define __HAL_RCC_RTCAPB_CLK_DISABLE  __HAL_RCC_RTC_CLK_DISABLE
+#endif   /* STM32H5 */
 
 /**
   * @}
@@ -3897,6 +4233,9 @@ extern "C" {
 #define __HAL_TIM_GetCompare            __HAL_TIM_GET_COMPARE
 
 #define TIM_BREAKINPUTSOURCE_DFSDM  TIM_BREAKINPUTSOURCE_DFSDM1
+
+#define TIM_OCMODE_ASSYMETRIC_PWM1      TIM_OCMODE_ASYMMETRIC_PWM1
+#define TIM_OCMODE_ASSYMETRIC_PWM2      TIM_OCMODE_ASYMMETRIC_PWM2
 /**
   * @}
   */

--- a/lib/STM32F7xx_HAL_Driver/Inc/stm32f7xx_hal_can.h
+++ b/lib/STM32F7xx_HAL_Driver/Inc/stm32f7xx_hal_can.h
@@ -209,7 +209,11 @@ typedef struct
 /**
   * @brief  CAN handle Structure definition
   */
+#if USE_HAL_CAN_REGISTER_CALLBACKS == 1
 typedef struct __CAN_HandleTypeDef
+#else
+typedef struct
+#endif /* USE_HAL_CAN_REGISTER_CALLBACKS */
 {
   CAN_TypeDef                 *Instance;                 /*!< Register base address */
 

--- a/lib/STM32F7xx_HAL_Driver/Inc/stm32f7xx_hal_cortex.h
+++ b/lib/STM32F7xx_HAL_Driver/Inc/stm32f7xx_hal_cortex.h
@@ -274,6 +274,8 @@ uint32_t HAL_SYSTICK_Config(uint32_t TicksNumb);
 #if (__MPU_PRESENT == 1)
 void HAL_MPU_Enable(uint32_t MPU_Control);
 void HAL_MPU_Disable(void);
+void HAL_MPU_EnableRegion(uint32_t RegionNumber);
+void HAL_MPU_DisableRegion(uint32_t RegionNumber);
 void HAL_MPU_ConfigRegion(MPU_Region_InitTypeDef *MPU_Init);
 #endif /* __MPU_PRESENT */
 uint32_t HAL_NVIC_GetPriorityGrouping(void);

--- a/lib/STM32F7xx_HAL_Driver/Inc/stm32f7xx_hal_def.h
+++ b/lib/STM32F7xx_HAL_Driver/Inc/stm32f7xx_hal_def.h
@@ -54,7 +54,9 @@ typedef enum
 
 /* Exported macro ------------------------------------------------------------*/
 
+#if !defined(UNUSED)
 #define UNUSED(X) (void)X      /* To avoid gcc/g++ warnings */
+#endif /* UNUSED */
 
 #define HAL_MAX_DELAY      0xFFFFFFFFU
 

--- a/lib/STM32F7xx_HAL_Driver/Inc/stm32f7xx_hal_gpio.h
+++ b/lib/STM32F7xx_HAL_Driver/Inc/stm32f7xx_hal_gpio.h
@@ -14,14 +14,14 @@
   * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
-  */ 
+  */
 
 /* Define to prevent recursive inclusion -------------------------------------*/
 #ifndef __STM32F7xx_HAL_GPIO_H
 #define __STM32F7xx_HAL_GPIO_H
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 /* Includes ------------------------------------------------------------------*/
@@ -33,16 +33,16 @@
 
 /** @addtogroup GPIO
   * @{
-  */ 
+  */
 
 /* Exported types ------------------------------------------------------------*/
 /** @defgroup GPIO_Exported_Types GPIO Exported Types
   * @{
   */
 
-/** 
-  * @brief GPIO Init structure definition  
-  */ 
+/**
+  * @brief GPIO Init structure definition
+  */
 typedef struct
 {
   uint32_t Pin;       /*!< Specifies the GPIO pins to be configured.
@@ -57,18 +57,18 @@ typedef struct
   uint32_t Speed;     /*!< Specifies the speed for the selected pins.
                            This parameter can be a value of @ref GPIO_speed_define */
 
-  uint32_t Alternate;  /*!< Peripheral to be connected to the selected pins. 
+  uint32_t Alternate;  /*!< Peripheral to be connected to the selected pins.
                             This parameter can be a value of @ref GPIO_Alternate_function_selection */
-}GPIO_InitTypeDef;
+} GPIO_InitTypeDef;
 
-/** 
-  * @brief  GPIO Bit SET and Bit RESET enumeration 
+/**
+  * @brief  GPIO Bit SET and Bit RESET enumeration
   */
 typedef enum
 {
   GPIO_PIN_RESET = 0,
   GPIO_PIN_SET
-}GPIO_PinState;
+} GPIO_PinState;
 /**
   * @}
   */
@@ -77,7 +77,7 @@ typedef enum
 
 /** @defgroup GPIO_Exported_Constants GPIO Exported Constants
   * @{
-  */ 
+  */
 
 /** @defgroup GPIO_pins_define GPIO pins define
   * @{
@@ -106,14 +106,14 @@ typedef enum
   */
 
 /** @defgroup GPIO_mode_define GPIO mode define
-  * @brief GPIO Configuration Mode 
+  * @brief GPIO Configuration Mode
   *        Elements values convention: 0x00WX00YZ
   *           - W  : EXTI trigger detection on 3 bits
   *           - X  : EXTI mode (IT or Event) on 2 bits
   *           - Y  : Output type (Push Pull or Open Drain) on 1 bit
   *           - Z  : GPIO mode (Input, Output, Alternate or Analog) on 2 bits
   * @{
-  */ 
+  */
 #define  GPIO_MODE_INPUT                        MODE_INPUT                                                  /*!< Input Floating Mode                   */
 #define  GPIO_MODE_OUTPUT_PP                    (MODE_OUTPUT | OUTPUT_PP)                                   /*!< Output Push Pull Mode                 */
 #define  GPIO_MODE_OUTPUT_OD                    (MODE_OUTPUT | OUTPUT_OD)                                   /*!< Output Open Drain Mode                */
@@ -121,11 +121,11 @@ typedef enum
 #define  GPIO_MODE_AF_OD                        (MODE_AF | OUTPUT_OD)                                       /*!< Alternate Function Open Drain Mode    */
 
 #define  GPIO_MODE_ANALOG                       MODE_ANALOG                                                 /*!< Analog Mode  */
-    
+
 #define  GPIO_MODE_IT_RISING                    (MODE_INPUT | EXTI_IT | TRIGGER_RISING)                     /*!< External Interrupt Mode with Rising edge trigger detection          */
 #define  GPIO_MODE_IT_FALLING                   (MODE_INPUT | EXTI_IT | TRIGGER_FALLING)                    /*!< External Interrupt Mode with Falling edge trigger detection         */
 #define  GPIO_MODE_IT_RISING_FALLING            (MODE_INPUT | EXTI_IT | TRIGGER_RISING | TRIGGER_FALLING)   /*!< External Interrupt Mode with Rising/Falling edge trigger detection  */
- 
+
 #define  GPIO_MODE_EVT_RISING                   (MODE_INPUT | EXTI_EVT | TRIGGER_RISING)                     /*!< External Event Mode with Rising edge trigger detection             */
 #define  GPIO_MODE_EVT_FALLING                  (MODE_INPUT | EXTI_EVT | TRIGGER_FALLING)                    /*!< External Event Mode with Falling edge trigger detection            */
 #define  GPIO_MODE_EVT_RISING_FALLING           (MODE_INPUT | EXTI_EVT | TRIGGER_RISING | TRIGGER_FALLING)   /*!< External Event Mode with Rising/Falling edge trigger detection     */
@@ -136,7 +136,7 @@ typedef enum
 /** @defgroup GPIO_speed_define  GPIO speed define
   * @brief GPIO Output Maximum frequency
   * @{
-  */  
+  */
 #define  GPIO_SPEED_FREQ_LOW         ((uint32_t)0x00000000U)  /*!< Low speed     */
 #define  GPIO_SPEED_FREQ_MEDIUM      ((uint32_t)0x00000001U)  /*!< Medium speed  */
 #define  GPIO_SPEED_FREQ_HIGH        ((uint32_t)0x00000002U)  /*!< Fast speed    */
@@ -145,17 +145,17 @@ typedef enum
   * @}
   */
 
- /** @defgroup GPIO_pull_define GPIO pull define
-   * @brief GPIO Pull-Up or Pull-Down Activation
-   * @{
-   */  
+/** @defgroup GPIO_pull_define GPIO pull define
+  * @brief GPIO Pull-Up or Pull-Down Activation
+  * @{
+  */
 #define  GPIO_NOPULL        ((uint32_t)0x00000000U)   /*!< No Pull-up or Pull-down activation  */
 #define  GPIO_PULLUP        ((uint32_t)0x00000001U)   /*!< Pull-up activation                  */
 #define  GPIO_PULLDOWN      ((uint32_t)0x00000002U)   /*!< Pull-down activation                */
 /**
   * @}
   */
-  
+
 /**
   * @}
   */
@@ -230,20 +230,20 @@ void  HAL_GPIO_DeInit(GPIO_TypeDef  *GPIOx, uint32_t GPIO_Pin);
   * @{
   */
 /* IO operation functions *****************************************************/
-GPIO_PinState HAL_GPIO_ReadPin(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin);
-void HAL_GPIO_WritePin(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin, GPIO_PinState PinState);
-void HAL_GPIO_TogglePin(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin);
-HAL_StatusTypeDef HAL_GPIO_LockPin(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin);
+GPIO_PinState HAL_GPIO_ReadPin(GPIO_TypeDef *GPIOx, uint16_t GPIO_Pin);
+void HAL_GPIO_WritePin(GPIO_TypeDef *GPIOx, uint16_t GPIO_Pin, GPIO_PinState PinState);
+void HAL_GPIO_TogglePin(GPIO_TypeDef *GPIOx, uint16_t GPIO_Pin);
+HAL_StatusTypeDef HAL_GPIO_LockPin(GPIO_TypeDef *GPIOx, uint16_t GPIO_Pin);
 void HAL_GPIO_EXTI_IRQHandler(uint16_t GPIO_Pin);
 void HAL_GPIO_EXTI_Callback(uint16_t GPIO_Pin);
 
 /**
   * @}
-  */ 
+  */
 
 /**
   * @}
-  */ 
+  */
 /* Private types -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
 /* Private constants ---------------------------------------------------------*/
@@ -309,7 +309,7 @@ void HAL_GPIO_EXTI_Callback(uint16_t GPIO_Pin);
 
 /**
   * @}
-  */ 
+  */
 
 /**
   * @}

--- a/lib/STM32F7xx_HAL_Driver/Inc/stm32f7xx_hal_gpio_ex.h
+++ b/lib/STM32F7xx_HAL_Driver/Inc/stm32f7xx_hal_gpio_ex.h
@@ -14,14 +14,14 @@
   * If no LICENSE file comes with this software, it is provided AS-IS.
   *
   ******************************************************************************
-  */ 
+  */
 
 /* Define to prevent recursive inclusion -------------------------------------*/
 #ifndef __STM32F7xx_HAL_GPIO_EX_H
 #define __STM32F7xx_HAL_GPIO_EX_H
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 /* Includes ------------------------------------------------------------------*/
@@ -33,7 +33,7 @@
 
 /** @defgroup GPIOEx GPIOEx
   * @{
-  */ 
+  */
 
 /* Exported types ------------------------------------------------------------*/
 
@@ -41,41 +41,41 @@
 /** @defgroup GPIOEx_Exported_Constants GPIO Exported Constants
   * @{
   */
-  
+
 /** @defgroup GPIO_Alternate_function_selection GPIO Alternate Function Selection
   * @{
-  */  
+  */
 /*--------------- STM32F74xxx/STM32F75xxx/STM32F76xxx/STM32F77xxx -------------*/
 #if defined (STM32F745xx) || defined (STM32F746xx) || defined (STM32F756xx) || defined (STM32F765xx) || defined (STM32F767xx) ||\
-    defined (STM32F769xx) || defined (STM32F777xx) || defined (STM32F779xx) || defined (STM32F750xx)   
-/** 
-  * @brief   AF 0 selection  
-  */ 
+    defined (STM32F769xx) || defined (STM32F777xx) || defined (STM32F779xx) || defined (STM32F750xx)
+/**
+  * @brief   AF 0 selection
+  */
 #define GPIO_AF0_RTC_50Hz      ((uint8_t)0x00U)  /* RTC_50Hz Alternate Function mapping                       */
 #define GPIO_AF0_MCO           ((uint8_t)0x00U)  /* MCO (MCO1 and MCO2) Alternate Function mapping            */
 #define GPIO_AF0_SWJ           ((uint8_t)0x00U)  /* SWJ (SWD and JTAG) Alternate Function mapping             */
 #define GPIO_AF0_TRACE         ((uint8_t)0x00U)  /* TRACE Alternate Function mapping                          */
 
-/** 
-  * @brief   AF 1 selection  
-  */ 
+/**
+  * @brief   AF 1 selection
+  */
 #define GPIO_AF1_TIM1          ((uint8_t)0x01U)  /* TIM1 Alternate Function mapping */
 #define GPIO_AF1_TIM2          ((uint8_t)0x01U)  /* TIM2 Alternate Function mapping */
 #if defined (STM32F765xx) || defined(STM32F767xx) || defined(STM32F769xx) || defined(STM32F777xx) || defined(STM32F779xx)
 #define GPIO_AF1_UART5         ((uint8_t)0x01U)  /* UART5 Alternate Function mapping */
-#define GPIO_AF1_I2C4          ((uint8_t)0x01U)  /* I2C4 Alternate Function mapping  */   
+#define GPIO_AF1_I2C4          ((uint8_t)0x01U)  /* I2C4 Alternate Function mapping  */
 #endif /* STM32F767xx || STM32F769xx || STM32F777xx || STM32F779xx */
 
-/** 
-  * @brief   AF 2 selection  
-  */ 
+/**
+  * @brief   AF 2 selection
+  */
 #define GPIO_AF2_TIM3          ((uint8_t)0x02U)  /* TIM3 Alternate Function mapping */
 #define GPIO_AF2_TIM4          ((uint8_t)0x02U)  /* TIM4 Alternate Function mapping */
 #define GPIO_AF2_TIM5          ((uint8_t)0x02U)  /* TIM5 Alternate Function mapping */
 
-/** 
-  * @brief   AF 3 selection  
-  */ 
+/**
+  * @brief   AF 3 selection
+  */
 #define GPIO_AF3_TIM8          ((uint8_t)0x03U)  /* TIM8 Alternate Function mapping  */
 #define GPIO_AF3_TIM9          ((uint8_t)0x03U)  /* TIM9 Alternate Function mapping  */
 #define GPIO_AF3_TIM10         ((uint8_t)0x03U)  /* TIM10 Alternate Function mapping */
@@ -85,9 +85,9 @@
 #if defined (STM32F765xx) || defined(STM32F767xx) || defined(STM32F769xx) || defined(STM32F777xx) || defined(STM32F779xx)
 #define GPIO_AF3_DFSDM1         ((uint8_t)0x03U)  /* DFSDM1 Alternate Function mapping */
 #endif /* STM32F767xx || STM32F769xx || STM32F777xx || STM32F779xx */
-/** 
-  * @brief   AF 4 selection  
-  */ 
+/**
+  * @brief   AF 4 selection
+  */
 #define GPIO_AF4_I2C1          ((uint8_t)0x04U)  /* I2C1 Alternate Function mapping */
 #define GPIO_AF4_I2C2          ((uint8_t)0x04U)  /* I2C2 Alternate Function mapping */
 #define GPIO_AF4_I2C3          ((uint8_t)0x04U)  /* I2C3 Alternate Function mapping */
@@ -95,11 +95,11 @@
 #define GPIO_AF4_CEC           ((uint8_t)0x04U)  /* CEC Alternate Function mapping */
 #if defined (STM32F765xx) || defined(STM32F767xx) || defined(STM32F769xx) || defined(STM32F777xx) || defined(STM32F779xx)
 #define GPIO_AF4_USART1        ((uint8_t)0x04)  /* USART1 Alternate Function mapping */
-#endif /* STM32F767xx || STM32F769xx || STM32F777xx || STM32F779xx */   
+#endif /* STM32F767xx || STM32F769xx || STM32F777xx || STM32F779xx */
 
-/** 
-  * @brief   AF 5 selection  
-  */ 
+/**
+  * @brief   AF 5 selection
+  */
 #define GPIO_AF5_SPI1          ((uint8_t)0x05U)  /* SPI1 Alternate Function mapping        */
 #define GPIO_AF5_SPI2          ((uint8_t)0x05U)  /* SPI2/I2S2 Alternate Function mapping   */
 #define GPIO_AF5_SPI3          ((uint8_t)0x05U)  /* SPI3/I2S3 Alternate Function mapping   */
@@ -107,19 +107,19 @@
 #define GPIO_AF5_SPI5          ((uint8_t)0x05U)  /* SPI5 Alternate Function mapping        */
 #define GPIO_AF5_SPI6          ((uint8_t)0x05U)  /* SPI6 Alternate Function mapping        */
 
-/** 
-  * @brief   AF 6 selection  
-  */ 
+/**
+  * @brief   AF 6 selection
+  */
 #define GPIO_AF6_SPI3          ((uint8_t)0x06U)  /* SPI3/I2S3 Alternate Function mapping  */
 #define GPIO_AF6_SAI1          ((uint8_t)0x06U)  /* SAI1 Alternate Function mapping       */
 #if defined (STM32F765xx) || defined(STM32F767xx) || defined(STM32F769xx) || defined(STM32F777xx) || defined(STM32F779xx)
-#define GPIO_AF6_UART4         ((uint8_t)0x06U)   /* UART4 Alternate Function mapping     */   
+#define GPIO_AF6_UART4         ((uint8_t)0x06U)   /* UART4 Alternate Function mapping     */
 #define GPIO_AF6_DFSDM1        ((uint8_t)0x06U)  /* DFSDM1 Alternate Function mapping     */
-#endif /* STM32F767xx || STM32F769xx || STM32F777xx || STM32F779xx */   
+#endif /* STM32F767xx || STM32F769xx || STM32F777xx || STM32F779xx */
 
-/** 
-  * @brief   AF 7 selection  
-  */ 
+/**
+  * @brief   AF 7 selection
+  */
 #define GPIO_AF7_USART1        ((uint8_t)0x07U)  /* USART1 Alternate Function mapping     */
 #define GPIO_AF7_USART2        ((uint8_t)0x07U)  /* USART2 Alternate Function mapping     */
 #define GPIO_AF7_USART3        ((uint8_t)0x07U)  /* USART3 Alternate Function mapping     */
@@ -130,11 +130,11 @@
 #if defined (STM32F765xx) || defined(STM32F767xx) || defined(STM32F769xx) || defined(STM32F777xx) || defined(STM32F779xx)
 #define GPIO_AF7_SPI6          ((uint8_t)0x07U)  /* SPI6 Alternate Function mapping       */
 #define GPIO_AF7_DFSDM1         ((uint8_t)0x07U) /* DFSDM1 Alternate Function mapping      */
-#endif /* STM32F767xx || STM32F769xx || STM32F777xx || STM32F779xx */  
+#endif /* STM32F767xx || STM32F769xx || STM32F777xx || STM32F779xx */
 
-/** 
-  * @brief   AF 8 selection  
-  */ 
+/**
+  * @brief   AF 8 selection
+  */
 #define GPIO_AF8_UART4         ((uint8_t)0x08U)  /* UART4 Alternate Function mapping  */
 #define GPIO_AF8_UART5         ((uint8_t)0x08U)  /* UART5 Alternate Function mapping  */
 #define GPIO_AF8_USART6        ((uint8_t)0x08U)  /* USART6 Alternate Function mapping */
@@ -143,13 +143,13 @@
 #define GPIO_AF8_SPDIFRX       ((uint8_t)0x08U)  /* SPIDIF-RX Alternate Function mapping */
 #define GPIO_AF8_SAI2          ((uint8_t)0x08U)  /* SAI2 Alternate Function mapping   */
 #if defined (STM32F765xx) || defined(STM32F767xx) || defined(STM32F769xx) || defined(STM32F777xx) || defined(STM32F779xx)
-#define GPIO_AF8_SPI6          ((uint8_t)0x08U)  /* SPI6 Alternate Function mapping   */  
-#endif /* STM32F767xx || STM32F769xx || STM32F777xx || STM32F779xx */    
+#define GPIO_AF8_SPI6          ((uint8_t)0x08U)  /* SPI6 Alternate Function mapping   */
+#endif /* STM32F767xx || STM32F769xx || STM32F777xx || STM32F779xx */
 
 
-/** 
-  * @brief   AF 9 selection 
-  */ 
+/**
+  * @brief   AF 9 selection
+  */
 #define GPIO_AF9_CAN1          ((uint8_t)0x09U)  /* CAN1 Alternate Function mapping    */
 #define GPIO_AF9_CAN2          ((uint8_t)0x09U)  /* CAN2 Alternate Function mapping    */
 #define GPIO_AF9_TIM12         ((uint8_t)0x09U)  /* TIM12 Alternate Function mapping   */
@@ -162,129 +162,129 @@
 #if defined(STM32F746xx) || defined(STM32F756xx) || defined(STM32F765xx) || defined(STM32F765xx) || defined(STM32F767xx) || defined(STM32F769xx) || defined(STM32F777xx) || defined(STM32F779xx) || defined(STM32F750xx)
 #define GPIO_AF9_FMC           ((uint8_t)0x09U)   /* FMC Alternate Function mapping     */
 #endif /* STM32F746xx || STM32F756xx || STM32F767xx || STM32F769xx || STM32F777xx || STM32F779xx || STM32F750xx */
-/** 
-  * @brief   AF 10 selection  
-  */ 
+/**
+  * @brief   AF 10 selection
+  */
 #define GPIO_AF10_OTG_FS        ((uint8_t)0xAU)  /* OTG_FS Alternate Function mapping */
 #define GPIO_AF10_OTG_HS        ((uint8_t)0xAU)  /* OTG_HS Alternate Function mapping */
 #define GPIO_AF10_QUADSPI       ((uint8_t)0xAU)  /* QUADSPI Alternate Function mapping */
 #define GPIO_AF10_SAI2          ((uint8_t)0xAU)  /* SAI2 Alternate Function mapping */
 #if defined (STM32F765xx) || defined(STM32F767xx) || defined(STM32F769xx) || defined(STM32F777xx) || defined(STM32F779xx)
 #define GPIO_AF10_DFSDM1         ((uint8_t)0x0AU)  /* DFSDM1 Alternate Function mapping  */
-#define GPIO_AF10_SDMMC2         ((uint8_t)0x0AU)  /* SDMMC2 Alternate Function mapping */   
+#define GPIO_AF10_SDMMC2         ((uint8_t)0x0AU)  /* SDMMC2 Alternate Function mapping */
 #define GPIO_AF10_LTDC           ((uint8_t)0x0AU)  /* LCD-TFT Alternate Function mapping */
-#endif /* STM32F767xx || STM32F769xx || STM32F777xx || STM32F779xx */   
+#endif /* STM32F767xx || STM32F769xx || STM32F777xx || STM32F779xx */
 
-/** 
-  * @brief   AF 11 selection  
-  */ 
+/**
+  * @brief   AF 11 selection
+  */
 #define GPIO_AF11_ETH           ((uint8_t)0x0BU)  /* ETHERNET Alternate Function mapping */
 #if defined(STM32F765xx) || defined (STM32F767xx) || defined (STM32F769xx) || defined (STM32F777xx) || defined (STM32F779xx)
 #define GPIO_AF11_CAN3          ((uint8_t)0x0BU)  /* CAN3 Alternate Function mapping     */
 #define GPIO_AF11_SDMMC2        ((uint8_t)0x0BU)  /* SDMMC2 Alternate Function mapping   */
-#define GPIO_AF11_I2C4          ((uint8_t)0x0BU)  /* I2C4 Alternate Function mapping     */   
+#define GPIO_AF11_I2C4          ((uint8_t)0x0BU)  /* I2C4 Alternate Function mapping     */
 #endif /* STM32F767xx || STM32F769xx || STM32F777xx || STM32F779xx */
-   
-/** 
-  * @brief   AF 12 selection  
-  */ 
+
+/**
+  * @brief   AF 12 selection
+  */
 #define GPIO_AF12_FMC           ((uint8_t)0xCU)  /* FMC Alternate Function mapping                      */
 #define GPIO_AF12_OTG_HS_FS     ((uint8_t)0xCU)  /* OTG HS configured in FS, Alternate Function mapping */
 #define GPIO_AF12_SDMMC1        ((uint8_t)0xCU)  /* SDMMC1 Alternate Function mapping                   */
-#if defined(STM32F765xx) || defined (STM32F767xx) || defined (STM32F769xx) || defined (STM32F777xx) || defined (STM32F779xx)   
+#if defined(STM32F765xx) || defined (STM32F767xx) || defined (STM32F769xx) || defined (STM32F777xx) || defined (STM32F779xx)
 #define GPIO_AF12_MDIOS        ((uint8_t)0xCU)  /* SDMMC1 Alternate Function mapping                    */
-#define GPIO_AF12_UART7        ((uint8_t)0xCU)  /* UART7 Alternate Function mapping                     */   
+#define GPIO_AF12_UART7        ((uint8_t)0xCU)  /* UART7 Alternate Function mapping                     */
 #endif /* STM32F767xx || STM32F769xx || STM32F777xx || STM32F779xx */
-   
-/** 
-  * @brief   AF 13 selection  
-  */ 
+
+/**
+  * @brief   AF 13 selection
+  */
 #define GPIO_AF13_DCMI          ((uint8_t)0x0DU)  /* DCMI Alternate Function mapping */
-#if defined (STM32F769xx) || defined (STM32F779xx)   
+#if defined (STM32F769xx) || defined (STM32F779xx)
 #define GPIO_AF13_DSI           ((uint8_t)0x0DU)  /* DSI Alternate Function mapping  */
-#endif /* STM32F767xx || STM32F769xx || STM32F777xx || STM32F779xx */   
+#endif /* STM32F767xx || STM32F769xx || STM32F777xx || STM32F779xx */
 #if defined(STM32F746xx) || defined(STM32F756xx) || defined(STM32F767xx) || defined(STM32F769xx) || defined(STM32F777xx) || defined(STM32F779xx) || defined(STM32F750xx)
-#define GPIO_AF13_LTDC          ((uint8_t)0x0DU)  /* LTDC Alternate Function mapping */   
-   
-/** 
-  * @brief   AF 14 selection  
+#define GPIO_AF13_LTDC          ((uint8_t)0x0DU)  /* LTDC Alternate Function mapping */
+
+/**
+  * @brief   AF 14 selection
   */
 #define GPIO_AF14_LTDC          ((uint8_t)0x0EU)  /* LCD-TFT Alternate Function mapping */
 #endif /* STM32F746xx || STM32F756xx || STM32F767xx || STM32F769xx || STM32F777xx || STM32F779xx || STM32F750xx */
-/** 
-  * @brief   AF 15 selection  
-  */ 
+/**
+  * @brief   AF 15 selection
+  */
 #define GPIO_AF15_EVENTOUT      ((uint8_t)0x0FU)  /* EVENTOUT Alternate Function mapping */
 #endif /* STM32F745xx || STM32F746xx || STM32F756xx || STM32F765xx || STM32F767xx || STM32F769xx || STM32F777xx || STM32F779xx */
 /*----------------------------------------------------------------------------*/
 
-/*---------------------------- STM32F72xxx/STM32F73xxx -----------------------*/      
+/*---------------------------- STM32F72xxx/STM32F73xxx -----------------------*/
 #if defined(STM32F722xx) || defined(STM32F723xx) || defined(STM32F732xx) || defined(STM32F733xx) || defined(STM32F730xx)
- /** 
-  * @brief   AF 0 selection  
-  */ 
+/**
+ * @brief   AF 0 selection
+ */
 #define GPIO_AF0_RTC_50Hz      ((uint8_t)0x00U)  /* RTC_50Hz Alternate Function mapping                       */
 #define GPIO_AF0_MCO           ((uint8_t)0x00U)  /* MCO (MCO1 and MCO2) Alternate Function mapping            */
 #define GPIO_AF0_SWJ           ((uint8_t)0x00U)  /* SWJ (SWD and JTAG) Alternate Function mapping             */
 #define GPIO_AF0_TRACE         ((uint8_t)0x00U)  /* TRACE Alternate Function mapping                          */
 
-/** 
-  * @brief   AF 1 selection  
-  */ 
+/**
+  * @brief   AF 1 selection
+  */
 #define GPIO_AF1_TIM1          ((uint8_t)0x01U)  /* TIM1 Alternate Function mapping */
 #define GPIO_AF1_TIM2          ((uint8_t)0x01U)  /* TIM2 Alternate Function mapping */
 
-/** 
-  * @brief   AF 2 selection  
-  */ 
+/**
+  * @brief   AF 2 selection
+  */
 #define GPIO_AF2_TIM3          ((uint8_t)0x02U)  /* TIM3 Alternate Function mapping */
 #define GPIO_AF2_TIM4          ((uint8_t)0x02U)  /* TIM4 Alternate Function mapping */
 #define GPIO_AF2_TIM5          ((uint8_t)0x02U)  /* TIM5 Alternate Function mapping */
 
-/** 
-  * @brief   AF 3 selection  
-  */ 
+/**
+  * @brief   AF 3 selection
+  */
 #define GPIO_AF3_TIM8          ((uint8_t)0x03U)  /* TIM8 Alternate Function mapping  */
 #define GPIO_AF3_TIM9          ((uint8_t)0x03U)  /* TIM9 Alternate Function mapping  */
 #define GPIO_AF3_TIM10         ((uint8_t)0x03U)  /* TIM10 Alternate Function mapping */
 #define GPIO_AF3_TIM11         ((uint8_t)0x03U)  /* TIM11 Alternate Function mapping */
 #define GPIO_AF3_LPTIM1        ((uint8_t)0x03U)  /* LPTIM1 Alternate Function mapping */
 
-/** 
-  * @brief   AF 4 selection  
-  */ 
+/**
+  * @brief   AF 4 selection
+  */
 #define GPIO_AF4_I2C1          ((uint8_t)0x04U)  /* I2C1 Alternate Function mapping */
 #define GPIO_AF4_I2C2          ((uint8_t)0x04U)  /* I2C2 Alternate Function mapping */
-#define GPIO_AF4_I2C3          ((uint8_t)0x04U)  /* I2C3 Alternate Function mapping */ 
+#define GPIO_AF4_I2C3          ((uint8_t)0x04U)  /* I2C3 Alternate Function mapping */
 
-/** 
-  * @brief   AF 5 selection  
-  */ 
+/**
+  * @brief   AF 5 selection
+  */
 #define GPIO_AF5_SPI1          ((uint8_t)0x05U)  /* SPI1 Alternate Function mapping        */
 #define GPIO_AF5_SPI2          ((uint8_t)0x05U)  /* SPI2/I2S2 Alternate Function mapping   */
 #define GPIO_AF5_SPI3          ((uint8_t)0x05U)  /* SPI3/I2S3 Alternate Function mapping   */
 #define GPIO_AF5_SPI4          ((uint8_t)0x05U)  /* SPI4 Alternate Function mapping        */
 #define GPIO_AF5_SPI5          ((uint8_t)0x05U)  /* SPI5 Alternate Function mapping        */
 
-/** 
-  * @brief   AF 6 selection  
-  */ 
+/**
+  * @brief   AF 6 selection
+  */
 #define GPIO_AF6_SPI3          ((uint8_t)0x06U)  /* SPI3/I2S3 Alternate Function mapping  */
 #define GPIO_AF6_SAI1          ((uint8_t)0x06U)  /* SAI1 Alternate Function mapping       */
 
-/** 
-  * @brief   AF 7 selection  
-  */ 
+/**
+  * @brief   AF 7 selection
+  */
 #define GPIO_AF7_USART1        ((uint8_t)0x07U)  /* USART1 Alternate Function mapping     */
 #define GPIO_AF7_USART2        ((uint8_t)0x07U)  /* USART2 Alternate Function mapping     */
 #define GPIO_AF7_USART3        ((uint8_t)0x07U)  /* USART3 Alternate Function mapping     */
 #define GPIO_AF7_UART5         ((uint8_t)0x07U)  /* UART5 Alternate Function mapping      */
 #define GPIO_AF7_SPI2          ((uint8_t)0x07U)  /* SPI2 Alternate Function mapping       */
-#define GPIO_AF7_SPI3          ((uint8_t)0x07U)  /* SPI3 Alternate Function mapping       */ 
+#define GPIO_AF7_SPI3          ((uint8_t)0x07U)  /* SPI3 Alternate Function mapping       */
 
-/** 
-  * @brief   AF 8 selection  
-  */ 
+/**
+  * @brief   AF 8 selection
+  */
 #define GPIO_AF8_UART4         ((uint8_t)0x08U)  /* UART4 Alternate Function mapping  */
 #define GPIO_AF8_UART5         ((uint8_t)0x08U)  /* UART5 Alternate Function mapping  */
 #define GPIO_AF8_USART6        ((uint8_t)0x08U)  /* USART6 Alternate Function mapping */
@@ -292,51 +292,51 @@
 #define GPIO_AF8_UART8         ((uint8_t)0x08U)  /* UART8 Alternate Function mapping  */
 #define GPIO_AF8_SAI2          ((uint8_t)0x08U)  /* SAI2 Alternate Function mapping   */
 
-/** 
-  * @brief   AF 9 selection 
-  */ 
+/**
+  * @brief   AF 9 selection
+  */
 #define GPIO_AF9_CAN1          ((uint8_t)0x09U)  /* CAN1 Alternate Function mapping    */
 #define GPIO_AF9_TIM12         ((uint8_t)0x09U)  /* TIM12 Alternate Function mapping   */
 #define GPIO_AF9_TIM13         ((uint8_t)0x09U)  /* TIM13 Alternate Function mapping   */
 #define GPIO_AF9_TIM14         ((uint8_t)0x09U)  /* TIM14 Alternate Function mapping   */
 #define GPIO_AF9_QUADSPI       ((uint8_t)0x09U)  /* QUADSPI Alternate Function mapping */
 
-/** 
-  * @brief   AF 10 selection  
-  */ 
+/**
+  * @brief   AF 10 selection
+  */
 #define GPIO_AF10_OTG_FS        ((uint8_t)0xAU)  /* OTG_FS Alternate Function mapping */
 #define GPIO_AF10_OTG_HS        ((uint8_t)0xAU)  /* OTG_HS Alternate Function mapping */
 #define GPIO_AF10_QUADSPI       ((uint8_t)0xAU)  /* QUADSPI Alternate Function mapping */
 #define GPIO_AF10_SAI2          ((uint8_t)0xAU)  /* SAI2 Alternate Function mapping */
-#define GPIO_AF10_SDMMC2        ((uint8_t)0x0AU) /* SDMMC2 Alternate Function mapping */   
+#define GPIO_AF10_SDMMC2        ((uint8_t)0x0AU) /* SDMMC2 Alternate Function mapping */
 
-/** 
-  * @brief   AF 11 selection  
-  */ 
+/**
+  * @brief   AF 11 selection
+  */
 #define GPIO_AF11_SDMMC2        ((uint8_t)0x0BU) /* SDMMC2 Alternate Function mapping   */
-   
-/** 
-  * @brief   AF 12 selection  
-  */ 
+
+/**
+  * @brief   AF 12 selection
+  */
 #define GPIO_AF12_FMC           ((uint8_t)0xCU)  /* FMC Alternate Function mapping                      */
 #define GPIO_AF12_OTG_HS_FS     ((uint8_t)0xCU)  /* OTG HS configured in FS, Alternate Function mapping */
 #define GPIO_AF12_SDMMC1        ((uint8_t)0xCU)  /* SDMMC1 Alternate Function mapping                   */
-   
-/** 
-  * @brief   AF 13 selection  
-  */ 
-#define GPIO_AF13_RNG           ((uint8_t)0x0DU)  /* RNG Alternate Function mapping */   
-   
-/** 
-  * @brief   AF 15 selection  
-  */ 
-#define GPIO_AF15_EVENTOUT      ((uint8_t)0x0FU)  /* EVENTOUT Alternate Function mapping */     
+
+/**
+  * @brief   AF 13 selection
+  */
+#define GPIO_AF13_RNG           ((uint8_t)0x0DU)  /* RNG Alternate Function mapping */
+
+/**
+  * @brief   AF 15 selection
+  */
+#define GPIO_AF15_EVENTOUT      ((uint8_t)0x0FU)  /* EVENTOUT Alternate Function mapping */
 #endif /* STM32F722xx || STM32F723xx || STM32F732xx || STM32F733xx || STM32F730xx */
 /*----------------------------------------------------------------------------*/
 
 /**
   * @}
-  */ 
+  */
 
 /**
   * @}
@@ -350,7 +350,7 @@
   * @}
   */
 
-/* Exported functions --------------------------------------------------------*/ 
+/* Exported functions --------------------------------------------------------*/
 /** @defgroup GPIOEx_Exported_Functions GPIO Exported Functions
   * @{
   */
@@ -437,101 +437,7 @@
   * @{
   */
 #if defined(STM32F756xx) || defined(STM32F746xx)  || defined(STM32F750xx)
-#define IS_GPIO_AF(AF)   (((AF) == GPIO_AF0_RTC_50Hz)   || ((AF) == GPIO_AF1_TIM1)        || \
-                          ((AF) == GPIO_AF0_SWJ)        || ((AF) == GPIO_AF0_TRACE)      || \
-                          ((AF) == GPIO_AF0_MCO)       || ((AF) == GPIO_AF1_TIM2)       || \
-                          ((AF) == GPIO_AF2_TIM3)       || ((AF) == GPIO_AF2_TIM4)       || \
-                          ((AF) == GPIO_AF2_TIM5)       || ((AF) == GPIO_AF3_TIM8)       || \
-                          ((AF) == GPIO_AF3_TIM9)       || ((AF) == GPIO_AF3_TIM10)      || \
-                          ((AF) == GPIO_AF3_TIM11)      || ((AF) == GPIO_AF3_LPTIM1)     || \
-                          ((AF) == GPIO_AF3_CEC)        || ((AF) == GPIO_AF4_CEC)        || \
-                          ((AF) == GPIO_AF4_I2C1)       || ((AF) == GPIO_AF4_I2C2)       || \
-                          ((AF) == GPIO_AF4_I2C3)       || ((AF) == GPIO_AF4_I2C4)       || \
-                          ((AF) == GPIO_AF5_SPI1)       || ((AF) == GPIO_AF5_SPI2)       || \
-                          ((AF) == GPIO_AF5_SPI3)       || ((AF) == GPIO_AF5_SPI4)       || \
-                          ((AF) == GPIO_AF5_SPI5)       || ((AF) == GPIO_AF5_SPI6)       || \
-                          ((AF) == GPIO_AF6_SPI3)       || ((AF) == GPIO_AF6_SAI1)       || \
-                          ((AF) == GPIO_AF7_SPI3)       || ((AF) == GPIO_AF7_SPI2)        || \
-                          ((AF) == GPIO_AF7_USART1)     || ((AF) == GPIO_AF7_USART2)      || \
-                          ((AF) == GPIO_AF7_USART3)     || ((AF) == GPIO_AF7_UART5)       || \
-                          ((AF) == GPIO_AF7_SPDIFRX)    || ((AF) == GPIO_AF8_SPDIFRX)     || \
-                          ((AF) == GPIO_AF8_SAI2)       || ((AF) == GPIO_AF8_USART6)      || \
-                          ((AF) == GPIO_AF8_UART4)      || ((AF) == GPIO_AF8_UART5)       || \
-                          ((AF) == GPIO_AF8_UART7)      || ((AF) == GPIO_AF8_UART8)       || \
-                          ((AF) == GPIO_AF9_CAN1)       || ((AF) == GPIO_AF9_CAN2)        || \
-                          ((AF) == GPIO_AF9_TIM12)      || ((AF) == GPIO_AF9_TIM12)      || \
-                          ((AF) == GPIO_AF9_TIM14)      || ((AF) == GPIO_AF9_QUADSPI)    || \
-                          ((AF) == GPIO_AF9_LTDC)       || ((AF) == GPIO_AF10_OTG_FS)    || \
-                          ((AF) == GPIO_AF10_OTG_HS)    || ((AF) == GPIO_AF10_SAI2)      || \
-                          ((AF) == GPIO_AF10_QUADSPI)   || ((AF) == GPIO_AF11_ETH)       || \
-                          ((AF) == GPIO_AF12_OTG_HS_FS) || ((AF) == GPIO_AF12_SDMMC1)     || \
-                          ((AF) == GPIO_AF12_FMC)       || ((AF) == GPIO_AF15_EVENTOUT)  || \
-                          ((AF) == GPIO_AF13_DCMI)      || ((AF) == GPIO_AF14_LTDC))
-#elif defined(STM32F745xx)
 #define IS_GPIO_AF(AF)   (((AF) == GPIO_AF0_RTC_50Hz)   || ((AF) == GPIO_AF1_TIM1)       || \
-                          ((AF) == GPIO_AF0_SWJ)        || ((AF) == GPIO_AF0_TRACE)      || \
-                          ((AF) == GPIO_AF0_MCO)       || ((AF) == GPIO_AF1_TIM2)        || \
-                          ((AF) == GPIO_AF2_TIM3)       || ((AF) == GPIO_AF2_TIM4)       || \
-                          ((AF) == GPIO_AF2_TIM5)       || ((AF) == GPIO_AF3_TIM8)       || \
-                          ((AF) == GPIO_AF3_TIM9)       || ((AF) == GPIO_AF3_TIM10)      || \
-                          ((AF) == GPIO_AF3_TIM11)      || ((AF) == GPIO_AF3_LPTIM1)     || \
-                          ((AF) == GPIO_AF3_CEC)        || ((AF) == GPIO_AF4_CEC)        || \
-                          ((AF) == GPIO_AF4_I2C1)       || ((AF) == GPIO_AF4_I2C2)       || \
-                          ((AF) == GPIO_AF4_I2C3)       || ((AF) == GPIO_AF4_I2C4)       || \
-                          ((AF) == GPIO_AF5_SPI1)       || ((AF) == GPIO_AF5_SPI2)       || \
-                          ((AF) == GPIO_AF5_SPI3)       || ((AF) == GPIO_AF5_SPI4)       || \
-                          ((AF) == GPIO_AF5_SPI5)       || ((AF) == GPIO_AF5_SPI6)       || \
-                          ((AF) == GPIO_AF6_SPI3)       || ((AF) == GPIO_AF6_SAI1)       || \
-                          ((AF) == GPIO_AF7_SPI3)       || ((AF) == GPIO_AF7_SPI2)        || \
-                          ((AF) == GPIO_AF7_USART1)     || ((AF) == GPIO_AF7_USART2)      || \
-                          ((AF) == GPIO_AF7_USART3)     || ((AF) == GPIO_AF7_UART5)       || \
-                          ((AF) == GPIO_AF7_SPDIFRX)    || ((AF) == GPIO_AF8_SPDIFRX)     || \
-                          ((AF) == GPIO_AF8_SAI2)       || ((AF) == GPIO_AF8_USART6)      || \
-                          ((AF) == GPIO_AF8_UART4)      || ((AF) == GPIO_AF8_UART5)       || \
-                          ((AF) == GPIO_AF8_UART7)      || ((AF) == GPIO_AF8_UART8)       || \
-                          ((AF) == GPIO_AF9_CAN1)       || ((AF) == GPIO_AF9_CAN2)        || \
-                          ((AF) == GPIO_AF9_TIM12)      || ((AF) == GPIO_AF9_TIM12)      || \
-                          ((AF) == GPIO_AF9_TIM14)      || ((AF) == GPIO_AF9_QUADSPI)    || \
-                          ((AF) == GPIO_AF13_DCMI)      || ((AF) == GPIO_AF10_OTG_FS)    || \
-                          ((AF) == GPIO_AF10_OTG_HS)    || ((AF) == GPIO_AF10_SAI2)      || \
-                          ((AF) == GPIO_AF10_QUADSPI)   || ((AF) == GPIO_AF11_ETH)       || \
-                          ((AF) == GPIO_AF12_OTG_HS_FS) || ((AF) == GPIO_AF12_SDMMC1)    || \
-                          ((AF) == GPIO_AF12_FMC)       || ((AF) == GPIO_AF15_EVENTOUT))
-#elif defined(STM32F767xx) || defined(STM32F777xx)
-#define IS_GPIO_AF(AF)   (((AF) == GPIO_AF0_RTC_50Hz)   || ((AF) == GPIO_AF1_TIM1)        || \
-                          ((AF) == GPIO_AF0_SWJ)        || ((AF) == GPIO_AF0_TRACE)      || \
-                          ((AF) == GPIO_AF0_MCO)       || ((AF) == GPIO_AF1_TIM2)       || \
-                          ((AF) == GPIO_AF2_TIM3)       || ((AF) == GPIO_AF2_TIM4)       || \
-                          ((AF) == GPIO_AF2_TIM5)       || ((AF) == GPIO_AF3_TIM8)       || \
-                          ((AF) == GPIO_AF3_TIM9)       || ((AF) == GPIO_AF3_TIM10)      || \
-                          ((AF) == GPIO_AF3_TIM11)      || ((AF) == GPIO_AF3_LPTIM1)     || \
-                          ((AF) == GPIO_AF3_CEC)        || ((AF) == GPIO_AF4_CEC)        || \
-                          ((AF) == GPIO_AF4_I2C1)       || ((AF) == GPIO_AF4_I2C2)       || \
-                          ((AF) == GPIO_AF4_I2C3)       || ((AF) == GPIO_AF4_I2C4)       || \
-                          ((AF) == GPIO_AF5_SPI1)       || ((AF) == GPIO_AF5_SPI2)       || \
-                          ((AF) == GPIO_AF5_SPI3)       || ((AF) == GPIO_AF5_SPI4)       || \
-                          ((AF) == GPIO_AF5_SPI5)       || ((AF) == GPIO_AF5_SPI6)       || \
-                          ((AF) == GPIO_AF6_SPI3)       || ((AF) == GPIO_AF6_SAI1)       || \
-                          ((AF) == GPIO_AF7_SPI3)       || ((AF) == GPIO_AF7_SPI2)       || \
-                          ((AF) == GPIO_AF7_USART1)     || ((AF) == GPIO_AF7_USART2)     || \
-                          ((AF) == GPIO_AF7_USART3)     || ((AF) == GPIO_AF7_UART5)      || \
-                          ((AF) == GPIO_AF7_SPDIFRX)    || ((AF) == GPIO_AF8_SPDIFRX)    || \
-                          ((AF) == GPIO_AF8_SAI2)       || ((AF) == GPIO_AF8_USART6)     || \
-                          ((AF) == GPIO_AF8_UART4)      || ((AF) == GPIO_AF8_UART5)      || \
-                          ((AF) == GPIO_AF8_UART7)      || ((AF) == GPIO_AF8_UART8)      || \
-                          ((AF) == GPIO_AF9_CAN1)       || ((AF) == GPIO_AF9_CAN2)       || \
-                          ((AF) == GPIO_AF9_TIM12)      || ((AF) == GPIO_AF9_TIM12)      || \
-                          ((AF) == GPIO_AF9_TIM14)      || ((AF) == GPIO_AF9_QUADSPI)    || \
-                          ((AF) == GPIO_AF10_OTG_FS)    || ((AF) == GPIO_AF9_LTDC)       || \
-                          ((AF) == GPIO_AF10_OTG_HS)    || ((AF) == GPIO_AF10_SAI2)      || \
-                          ((AF) == GPIO_AF10_QUADSPI)   || ((AF) == GPIO_AF11_ETH)       || \
-                          ((AF) == GPIO_AF10_SDMMC2)    || ((AF) == GPIO_AF11_SDMMC2)    || \
-                          ((AF) == GPIO_AF11_CAN3)      || ((AF) == GPIO_AF12_OTG_HS_FS) || \
-                          ((AF) == GPIO_AF12_SDMMC1)    || ((AF) == GPIO_AF12_FMC)       || \
-                          ((AF) == GPIO_AF15_EVENTOUT)  || ((AF) == GPIO_AF13_DCMI)      || \
-		                  ((AF) == GPIO_AF14_LTDC))
-#elif defined(STM32F769xx) || defined(STM32F779xx)
-#define IS_GPIO_AF(AF)   (((AF) == GPIO_AF0_RTC_50Hz)   || ((AF) == GPIO_AF1_TIM1)        || \
                           ((AF) == GPIO_AF0_SWJ)        || ((AF) == GPIO_AF0_TRACE)      || \
                           ((AF) == GPIO_AF0_MCO)        || ((AF) == GPIO_AF1_TIM2)       || \
                           ((AF) == GPIO_AF2_TIM3)       || ((AF) == GPIO_AF2_TIM4)       || \
@@ -553,7 +459,101 @@
                           ((AF) == GPIO_AF8_UART4)      || ((AF) == GPIO_AF8_UART5)      || \
                           ((AF) == GPIO_AF8_UART7)      || ((AF) == GPIO_AF8_UART8)      || \
                           ((AF) == GPIO_AF9_CAN1)       || ((AF) == GPIO_AF9_CAN2)       || \
-                          ((AF) == GPIO_AF9_TIM12)      || ((AF) == GPIO_AF9_TIM12)      || \
+                          ((AF) == GPIO_AF9_TIM12)      || ((AF) == GPIO_AF9_TIM13)      || \
+                          ((AF) == GPIO_AF9_TIM14)      || ((AF) == GPIO_AF9_QUADSPI)    || \
+                          ((AF) == GPIO_AF9_LTDC)       || ((AF) == GPIO_AF10_OTG_FS)    || \
+                          ((AF) == GPIO_AF10_OTG_HS)    || ((AF) == GPIO_AF10_SAI2)      || \
+                          ((AF) == GPIO_AF10_QUADSPI)   || ((AF) == GPIO_AF11_ETH)       || \
+                          ((AF) == GPIO_AF12_OTG_HS_FS) || ((AF) == GPIO_AF12_SDMMC1)    || \
+                          ((AF) == GPIO_AF12_FMC)       || ((AF) == GPIO_AF15_EVENTOUT)  || \
+                          ((AF) == GPIO_AF13_DCMI)      || ((AF) == GPIO_AF14_LTDC))
+#elif defined(STM32F745xx)
+#define IS_GPIO_AF(AF)   (((AF) == GPIO_AF0_RTC_50Hz)   || ((AF) == GPIO_AF1_TIM1)       || \
+                          ((AF) == GPIO_AF0_SWJ)        || ((AF) == GPIO_AF0_TRACE)      || \
+                          ((AF) == GPIO_AF0_MCO)       || ((AF) == GPIO_AF1_TIM2)        || \
+                          ((AF) == GPIO_AF2_TIM3)       || ((AF) == GPIO_AF2_TIM4)       || \
+                          ((AF) == GPIO_AF2_TIM5)       || ((AF) == GPIO_AF3_TIM8)       || \
+                          ((AF) == GPIO_AF3_TIM9)       || ((AF) == GPIO_AF3_TIM10)      || \
+                          ((AF) == GPIO_AF3_TIM11)      || ((AF) == GPIO_AF3_LPTIM1)     || \
+                          ((AF) == GPIO_AF3_CEC)        || ((AF) == GPIO_AF4_CEC)        || \
+                          ((AF) == GPIO_AF4_I2C1)       || ((AF) == GPIO_AF4_I2C2)       || \
+                          ((AF) == GPIO_AF4_I2C3)       || ((AF) == GPIO_AF4_I2C4)       || \
+                          ((AF) == GPIO_AF5_SPI1)       || ((AF) == GPIO_AF5_SPI2)       || \
+                          ((AF) == GPIO_AF5_SPI3)       || ((AF) == GPIO_AF5_SPI4)       || \
+                          ((AF) == GPIO_AF5_SPI5)       || ((AF) == GPIO_AF5_SPI6)       || \
+                          ((AF) == GPIO_AF6_SPI3)       || ((AF) == GPIO_AF6_SAI1)       || \
+                          ((AF) == GPIO_AF7_SPI3)       || ((AF) == GPIO_AF7_SPI2)       || \
+                          ((AF) == GPIO_AF7_USART1)     || ((AF) == GPIO_AF7_USART2)     || \
+                          ((AF) == GPIO_AF7_USART3)     || ((AF) == GPIO_AF7_UART5)      || \
+                          ((AF) == GPIO_AF7_SPDIFRX)    || ((AF) == GPIO_AF8_SPDIFRX)    || \
+                          ((AF) == GPIO_AF8_SAI2)       || ((AF) == GPIO_AF8_USART6)     || \
+                          ((AF) == GPIO_AF8_UART4)      || ((AF) == GPIO_AF8_UART5)      || \
+                          ((AF) == GPIO_AF8_UART7)      || ((AF) == GPIO_AF8_UART8)      || \
+                          ((AF) == GPIO_AF9_CAN1)       || ((AF) == GPIO_AF9_CAN2)       || \
+                          ((AF) == GPIO_AF9_TIM12)      || ((AF) == GPIO_AF9_TIM13)      || \
+                          ((AF) == GPIO_AF9_TIM14)      || ((AF) == GPIO_AF9_QUADSPI)    || \
+                          ((AF) == GPIO_AF13_DCMI)      || ((AF) == GPIO_AF10_OTG_FS)    || \
+                          ((AF) == GPIO_AF10_OTG_HS)    || ((AF) == GPIO_AF10_SAI2)      || \
+                          ((AF) == GPIO_AF10_QUADSPI)   || ((AF) == GPIO_AF11_ETH)       || \
+                          ((AF) == GPIO_AF12_OTG_HS_FS) || ((AF) == GPIO_AF12_SDMMC1)    || \
+                          ((AF) == GPIO_AF12_FMC)       || ((AF) == GPIO_AF15_EVENTOUT))
+#elif defined(STM32F767xx) || defined(STM32F777xx)
+#define IS_GPIO_AF(AF)   (((AF) == GPIO_AF0_RTC_50Hz)   || ((AF) == GPIO_AF1_TIM1)       || \
+                          ((AF) == GPIO_AF0_SWJ)        || ((AF) == GPIO_AF0_TRACE)      || \
+                          ((AF) == GPIO_AF0_MCO)        || ((AF) == GPIO_AF1_TIM2)       || \
+                          ((AF) == GPIO_AF2_TIM3)       || ((AF) == GPIO_AF2_TIM4)       || \
+                          ((AF) == GPIO_AF2_TIM5)       || ((AF) == GPIO_AF3_TIM8)       || \
+                          ((AF) == GPIO_AF3_TIM9)       || ((AF) == GPIO_AF3_TIM10)      || \
+                          ((AF) == GPIO_AF3_TIM11)      || ((AF) == GPIO_AF3_LPTIM1)     || \
+                          ((AF) == GPIO_AF3_CEC)        || ((AF) == GPIO_AF4_CEC)        || \
+                          ((AF) == GPIO_AF4_I2C1)       || ((AF) == GPIO_AF4_I2C2)       || \
+                          ((AF) == GPIO_AF4_I2C3)       || ((AF) == GPIO_AF4_I2C4)       || \
+                          ((AF) == GPIO_AF5_SPI1)       || ((AF) == GPIO_AF5_SPI2)       || \
+                          ((AF) == GPIO_AF5_SPI3)       || ((AF) == GPIO_AF5_SPI4)       || \
+                          ((AF) == GPIO_AF5_SPI5)       || ((AF) == GPIO_AF5_SPI6)       || \
+                          ((AF) == GPIO_AF6_SPI3)       || ((AF) == GPIO_AF6_SAI1)       || \
+                          ((AF) == GPIO_AF7_SPI3)       || ((AF) == GPIO_AF7_SPI2)       || \
+                          ((AF) == GPIO_AF7_USART1)     || ((AF) == GPIO_AF7_USART2)     || \
+                          ((AF) == GPIO_AF7_USART3)     || ((AF) == GPIO_AF7_UART5)      || \
+                          ((AF) == GPIO_AF7_SPDIFRX)    || ((AF) == GPIO_AF8_SPDIFRX)    || \
+                          ((AF) == GPIO_AF8_SAI2)       || ((AF) == GPIO_AF8_USART6)     || \
+                          ((AF) == GPIO_AF8_UART4)      || ((AF) == GPIO_AF8_UART5)      || \
+                          ((AF) == GPIO_AF8_UART7)      || ((AF) == GPIO_AF8_UART8)      || \
+                          ((AF) == GPIO_AF9_CAN1)       || ((AF) == GPIO_AF9_CAN2)       || \
+                          ((AF) == GPIO_AF9_TIM12)      || ((AF) == GPIO_AF9_TIM13)      || \
+                          ((AF) == GPIO_AF9_TIM14)      || ((AF) == GPIO_AF9_QUADSPI)    || \
+                          ((AF) == GPIO_AF10_OTG_FS)    || ((AF) == GPIO_AF9_LTDC)       || \
+                          ((AF) == GPIO_AF10_OTG_HS)    || ((AF) == GPIO_AF10_SAI2)      || \
+                          ((AF) == GPIO_AF10_QUADSPI)   || ((AF) == GPIO_AF11_ETH)       || \
+                          ((AF) == GPIO_AF10_SDMMC2)    || ((AF) == GPIO_AF11_SDMMC2)    || \
+                          ((AF) == GPIO_AF11_CAN3)      || ((AF) == GPIO_AF12_OTG_HS_FS) || \
+                          ((AF) == GPIO_AF12_SDMMC1)    || ((AF) == GPIO_AF12_FMC)       || \
+                          ((AF) == GPIO_AF15_EVENTOUT)  || ((AF) == GPIO_AF13_DCMI)      || \
+                          ((AF) == GPIO_AF14_LTDC))
+#elif defined(STM32F769xx) || defined(STM32F779xx)
+#define IS_GPIO_AF(AF)   (((AF) == GPIO_AF0_RTC_50Hz)   || ((AF) == GPIO_AF1_TIM1)       || \
+                          ((AF) == GPIO_AF0_SWJ)        || ((AF) == GPIO_AF0_TRACE)      || \
+                          ((AF) == GPIO_AF0_MCO)        || ((AF) == GPIO_AF1_TIM2)       || \
+                          ((AF) == GPIO_AF2_TIM3)       || ((AF) == GPIO_AF2_TIM4)       || \
+                          ((AF) == GPIO_AF2_TIM5)       || ((AF) == GPIO_AF3_TIM8)       || \
+                          ((AF) == GPIO_AF3_TIM9)       || ((AF) == GPIO_AF3_TIM10)      || \
+                          ((AF) == GPIO_AF3_TIM11)      || ((AF) == GPIO_AF3_LPTIM1)     || \
+                          ((AF) == GPIO_AF3_CEC)        || ((AF) == GPIO_AF4_CEC)        || \
+                          ((AF) == GPIO_AF4_I2C1)       || ((AF) == GPIO_AF4_I2C2)       || \
+                          ((AF) == GPIO_AF4_I2C3)       || ((AF) == GPIO_AF4_I2C4)       || \
+                          ((AF) == GPIO_AF5_SPI1)       || ((AF) == GPIO_AF5_SPI2)       || \
+                          ((AF) == GPIO_AF5_SPI3)       || ((AF) == GPIO_AF5_SPI4)       || \
+                          ((AF) == GPIO_AF5_SPI5)       || ((AF) == GPIO_AF5_SPI6)       || \
+                          ((AF) == GPIO_AF6_SPI3)       || ((AF) == GPIO_AF6_SAI1)       || \
+                          ((AF) == GPIO_AF7_SPI3)       || ((AF) == GPIO_AF7_SPI2)       || \
+                          ((AF) == GPIO_AF7_USART1)     || ((AF) == GPIO_AF7_USART2)     || \
+                          ((AF) == GPIO_AF7_USART3)     || ((AF) == GPIO_AF7_UART5)      || \
+                          ((AF) == GPIO_AF7_SPDIFRX)    || ((AF) == GPIO_AF8_SPDIFRX)    || \
+                          ((AF) == GPIO_AF8_SAI2)       || ((AF) == GPIO_AF8_USART6)     || \
+                          ((AF) == GPIO_AF8_UART4)      || ((AF) == GPIO_AF8_UART5)      || \
+                          ((AF) == GPIO_AF8_UART7)      || ((AF) == GPIO_AF8_UART8)      || \
+                          ((AF) == GPIO_AF9_CAN1)       || ((AF) == GPIO_AF9_CAN2)       || \
+                          ((AF) == GPIO_AF9_TIM12)      || ((AF) == GPIO_AF9_TIM13)      || \
                           ((AF) == GPIO_AF9_TIM14)      || ((AF) == GPIO_AF9_QUADSPI)    || \
                           ((AF) == GPIO_AF9_LTDC)       || ((AF) == GPIO_AF10_OTG_FS)    || \
                           ((AF) == GPIO_AF10_OTG_HS)    || ((AF) == GPIO_AF10_SAI2)      || \
@@ -564,7 +564,7 @@
                           ((AF) == GPIO_AF15_EVENTOUT)  || ((AF) == GPIO_AF13_DCMI)      || \
                           ((AF) == GPIO_AF14_LTDC)      || ((AF) == GPIO_AF13_DSI))
 #elif defined(STM32F765xx)
-#define IS_GPIO_AF(AF)   (((AF) == GPIO_AF0_RTC_50Hz)   || ((AF) == GPIO_AF1_TIM1)        || \
+#define IS_GPIO_AF(AF)   (((AF) == GPIO_AF0_RTC_50Hz)   || ((AF) == GPIO_AF1_TIM1)       || \
                           ((AF) == GPIO_AF0_SWJ)        || ((AF) == GPIO_AF0_TRACE)      || \
                           ((AF) == GPIO_AF0_MCO)        || ((AF) == GPIO_AF1_TIM2)       || \
                           ((AF) == GPIO_AF2_TIM3)       || ((AF) == GPIO_AF2_TIM4)       || \
@@ -596,7 +596,7 @@
                           ((AF) == GPIO_AF15_EVENTOUT)  || ((AF) == GPIO_AF13_DCMI)      || \
                           ((AF) == GPIO_AF10_OTG_FS))
 #elif defined (STM32F722xx) || defined (STM32F723xx) || defined (STM32F732xx) || defined (STM32F733xx) || defined (STM32F730xx)
-#define IS_GPIO_AF(AF)   (((AF) == GPIO_AF0_RTC_50Hz)   || ((AF) == GPIO_AF1_TIM1)        || \
+#define IS_GPIO_AF(AF)   (((AF) == GPIO_AF0_RTC_50Hz)   || ((AF) == GPIO_AF1_TIM1)       || \
                           ((AF) == GPIO_AF0_SWJ)        || ((AF) == GPIO_AF0_TRACE)      || \
                           ((AF) == GPIO_AF0_MCO)        || ((AF) == GPIO_AF1_TIM2)       || \
                           ((AF) == GPIO_AF2_TIM3)       || ((AF) == GPIO_AF2_TIM4)       || \
@@ -615,7 +615,7 @@
                           ((AF) == GPIO_AF8_UART4)      || ((AF) == GPIO_AF8_UART5)      || \
                           ((AF) == GPIO_AF8_UART7)      || ((AF) == GPIO_AF8_UART8)      || \
                           ((AF) == GPIO_AF9_CAN1)       || ((AF) == GPIO_AF9_TIM12)      || \
-                          ((AF) == GPIO_AF9_TIM12)      || ((AF) == GPIO_AF9_TIM14)      || \
+                          ((AF) == GPIO_AF9_TIM13)      || ((AF) == GPIO_AF9_TIM14)      || \
                           ((AF) == GPIO_AF9_QUADSPI)    || ((AF) == GPIO_AF10_OTG_HS)    || \
                           ((AF) == GPIO_AF10_SAI2)      || ((AF) == GPIO_AF10_QUADSPI)   || \
                           ((AF) == GPIO_AF10_SDMMC2)    || ((AF) == GPIO_AF11_SDMMC2)    || \
@@ -625,7 +625,7 @@
 #endif /* STM32F756xx || STM32F746xx || STM32F750xx */
 /**
   * @}
-  */ 
+  */
 
 /**
   * @}
@@ -642,12 +642,12 @@
 
 /**
   * @}
-  */ 
+  */
 
 /**
   * @}
-  */ 
-  
+  */
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/STM32F7xx_HAL_Driver/Inc/stm32f7xx_hal_i2c.h
+++ b/lib/STM32F7xx_HAL_Driver/Inc/stm32f7xx_hal_i2c.h
@@ -118,8 +118,6 @@ typedef enum
   HAL_I2C_STATE_BUSY_RX_LISTEN    = 0x2AU,   /*!< Address Listen Mode and Data Reception
                                                  process is ongoing                         */
   HAL_I2C_STATE_ABORT             = 0x60U,   /*!< Abort user request ongoing                */
-  HAL_I2C_STATE_TIMEOUT           = 0xA0U,   /*!< Timeout state                             */
-  HAL_I2C_STATE_ERROR             = 0xE0U    /*!< Error                                     */
 
 } HAL_I2C_StateTypeDef;
 
@@ -206,6 +204,7 @@ typedef struct __I2C_HandleTypeDef
   DMA_HandleTypeDef          *hdmatx;        /*!< I2C Tx DMA handle parameters              */
 
   DMA_HandleTypeDef          *hdmarx;        /*!< I2C Rx DMA handle parameters              */
+
 
   HAL_LockTypeDef            Lock;           /*!< I2C locking object                        */
 
@@ -709,9 +708,9 @@ void HAL_I2C_AbortCpltCallback(I2C_HandleTypeDef *hi2c);
   * @{
   */
 /* Peripheral State, Mode and Error functions  *********************************/
-HAL_I2C_StateTypeDef HAL_I2C_GetState(I2C_HandleTypeDef *hi2c);
-HAL_I2C_ModeTypeDef  HAL_I2C_GetMode(I2C_HandleTypeDef *hi2c);
-uint32_t             HAL_I2C_GetError(I2C_HandleTypeDef *hi2c);
+HAL_I2C_StateTypeDef HAL_I2C_GetState(const I2C_HandleTypeDef *hi2c);
+HAL_I2C_ModeTypeDef  HAL_I2C_GetMode(const I2C_HandleTypeDef *hi2c);
+uint32_t             HAL_I2C_GetError(const I2C_HandleTypeDef *hi2c);
 
 /**
   * @}
@@ -804,8 +803,8 @@ uint32_t             HAL_I2C_GetError(I2C_HandleTypeDef *hi2c);
                                                                  (I2C_CR2_START) | (I2C_CR2_AUTOEND)) & \
                                                                 (~I2C_CR2_RD_WRN)) : \
                                                      (uint32_t)((((uint32_t)(__ADDRESS__) & (I2C_CR2_SADD)) | \
-                                                                 (I2C_CR2_ADD10) | (I2C_CR2_START)) & \
-                                                                (~I2C_CR2_RD_WRN)))
+                                                                 (I2C_CR2_ADD10) | (I2C_CR2_START) | \
+                                                                 (I2C_CR2_AUTOEND)) & (~I2C_CR2_RD_WRN)))
 
 #define I2C_CHECK_FLAG(__ISR__, __FLAG__)         ((((__ISR__) & ((__FLAG__) & I2C_FLAG_MASK)) == \
                                                     ((__FLAG__) & I2C_FLAG_MASK)) ? SET : RESET)

--- a/lib/STM32F7xx_HAL_Driver/Inc/stm32f7xx_hal_rcc_ex.h
+++ b/lib/STM32F7xx_HAL_Driver/Inc/stm32f7xx_hal_rcc_ex.h
@@ -1326,6 +1326,9 @@ typedef struct
                                         UNUSED(tmpreg); \
                                       } while(0)
 
+#if defined (STM32F745xx) || defined (STM32F746xx) || defined (STM32F756xx) || defined (STM32F765xx) ||\
+    defined (STM32F767xx) || defined (STM32F769xx) || defined (STM32F777xx) || defined (STM32F779xx) ||\
+    defined (STM32F750xx)
 #define __HAL_RCC_SPI6_CLK_ENABLE()   do { \
                                         __IO uint32_t tmpreg; \
                                         SET_BIT(RCC->APB2ENR, RCC_APB2ENR_SPI6EN);\
@@ -1333,6 +1336,7 @@ typedef struct
                                         tmpreg = READ_BIT(RCC->APB2ENR, RCC_APB2ENR_SPI6EN);\
                                         UNUSED(tmpreg); \
                                       } while(0)
+#endif /* STM32F745xx || STM32F746xx || STM32F756xx || STM32F765xx || STM32F767xx || STM32F769xx || STM32F777xx || STM32F779xx || STM32F750xx */
 
 #define __HAL_RCC_SAI1_CLK_ENABLE()   do { \
                                         __IO uint32_t tmpreg; \
@@ -1415,7 +1419,13 @@ typedef struct
 #define __HAL_RCC_TIM10_CLK_DISABLE()  (RCC->APB2ENR &= ~(RCC_APB2ENR_TIM10EN))
 #define __HAL_RCC_TIM11_CLK_DISABLE()  (RCC->APB2ENR &= ~(RCC_APB2ENR_TIM11EN))
 #define __HAL_RCC_SPI5_CLK_DISABLE()   (RCC->APB2ENR &= ~(RCC_APB2ENR_SPI5EN))
+
+#if defined (STM32F745xx) || defined (STM32F746xx) || defined (STM32F756xx) || defined (STM32F765xx) ||\
+    defined (STM32F767xx) || defined (STM32F769xx) || defined (STM32F777xx) || defined (STM32F779xx) ||\
+    defined (STM32F750xx)
 #define __HAL_RCC_SPI6_CLK_DISABLE()   (RCC->APB2ENR &= ~(RCC_APB2ENR_SPI6EN))
+#endif /* STM32F745xx || STM32F746xx || STM32F756xx || STM32F765xx || STM32F767xx || STM32F769xx || STM32F777xx || STM32F779xx || STM32F750xx */
+
 #define __HAL_RCC_SAI1_CLK_DISABLE()   (RCC->APB2ENR &= ~(RCC_APB2ENR_SAI1EN))
 #define __HAL_RCC_SAI2_CLK_DISABLE()   (RCC->APB2ENR &= ~(RCC_APB2ENR_SAI2EN))
 #if defined (STM32F746xx) || defined (STM32F756xx) || defined (STM32F767xx) || defined (STM32F769xx) || defined (STM32F777xx) || defined (STM32F779xx) || defined (STM32F750xx)
@@ -1664,7 +1674,13 @@ typedef struct
 #define __HAL_RCC_TIM10_IS_CLK_ENABLED()   ((RCC->APB2ENR & (RCC_APB2ENR_TIM10EN)) != RESET)
 #define __HAL_RCC_TIM11_IS_CLK_ENABLED()   ((RCC->APB2ENR & (RCC_APB2ENR_TIM11EN)) != RESET)
 #define __HAL_RCC_SPI5_IS_CLK_ENABLED()    ((RCC->APB2ENR & (RCC_APB2ENR_SPI5EN)) != RESET)
+
+#if defined (STM32F745xx) || defined (STM32F746xx) || defined (STM32F756xx) || defined (STM32F765xx) ||\
+    defined (STM32F767xx) || defined (STM32F769xx) || defined (STM32F777xx) || defined (STM32F779xx) ||\
+    defined (STM32F750xx)
 #define __HAL_RCC_SPI6_IS_CLK_ENABLED()    ((RCC->APB2ENR & (RCC_APB2ENR_SPI6EN)) != RESET)
+#endif /* STM32F745xx || STM32F746xx || STM32F756xx || STM32F765xx || STM32F767xx || STM32F769xx || STM32F777xx || STM32F779xx || STM32F750xx */
+
 #define __HAL_RCC_SAI1_IS_CLK_ENABLED()    ((RCC->APB2ENR & (RCC_APB2ENR_SAI1EN)) != RESET)
 #define __HAL_RCC_SAI2_IS_CLK_ENABLED()    ((RCC->APB2ENR & (RCC_APB2ENR_SAI2EN)) != RESET)
 #if defined (STM32F746xx) || defined (STM32F756xx) || defined (STM32F767xx) || defined (STM32F769xx) || defined (STM32F777xx) || defined (STM32F779xx) || defined (STM32F750xx)
@@ -1699,7 +1715,13 @@ typedef struct
 #define __HAL_RCC_TIM10_IS_CLK_DISABLED()  ((RCC->APB2ENR & (RCC_APB2ENR_TIM10EN)) == RESET)
 #define __HAL_RCC_TIM11_IS_CLK_DISABLED()  ((RCC->APB2ENR & (RCC_APB2ENR_TIM11EN)) == RESET)
 #define __HAL_RCC_SPI5_IS_CLK_DISABLED()   ((RCC->APB2ENR & (RCC_APB2ENR_SPI5EN)) == RESET)
+
+#if defined (STM32F745xx) || defined (STM32F746xx) || defined (STM32F756xx) || defined (STM32F765xx) ||\
+    defined (STM32F767xx) || defined (STM32F769xx) || defined (STM32F777xx) || defined (STM32F779xx) ||\
+    defined (STM32F750xx)
 #define __HAL_RCC_SPI6_IS_CLK_DISABLED()   ((RCC->APB2ENR & (RCC_APB2ENR_SPI6EN)) == RESET)
+#endif /* STM32F745xx || STM32F746xx || STM32F756xx || STM32F765xx || STM32F767xx || STM32F769xx || STM32F777xx || STM32F779xx || STM32F750xx */
+
 #define __HAL_RCC_SAI1_IS_CLK_DISABLED()   ((RCC->APB2ENR & (RCC_APB2ENR_SAI1EN)) == RESET)
 #define __HAL_RCC_SAI2_IS_CLK_DISABLED()   ((RCC->APB2ENR & (RCC_APB2ENR_SAI2EN)) == RESET)
 #if defined (STM32F746xx) || defined (STM32F756xx) || defined (STM32F767xx) || defined (STM32F769xx) || defined (STM32F777xx) || defined (STM32F779xx) || defined (STM32F750xx)
@@ -1897,7 +1919,13 @@ typedef struct
 #define __HAL_RCC_TIM10_FORCE_RESET()    (RCC->APB2RSTR |= (RCC_APB2RSTR_TIM10RST))
 #define __HAL_RCC_TIM11_FORCE_RESET()    (RCC->APB2RSTR |= (RCC_APB2RSTR_TIM11RST))
 #define __HAL_RCC_SPI5_FORCE_RESET()     (RCC->APB2RSTR |= (RCC_APB2RSTR_SPI5RST))
+
+#if defined (STM32F745xx) || defined (STM32F746xx) || defined (STM32F756xx) || defined (STM32F765xx) ||\
+    defined (STM32F767xx) || defined (STM32F769xx) || defined (STM32F777xx) || defined (STM32F779xx) ||\
+    defined (STM32F750xx)
 #define __HAL_RCC_SPI6_FORCE_RESET()     (RCC->APB2RSTR |= (RCC_APB2RSTR_SPI6RST))
+#endif /* STM32F745xx || STM32F746xx || STM32F756xx || STM32F765xx || STM32F767xx || STM32F769xx || STM32F777xx || STM32F779xx || STM32F750xx */
+
 #define __HAL_RCC_SAI1_FORCE_RESET()     (RCC->APB2RSTR |= (RCC_APB2RSTR_SAI1RST))
 #define __HAL_RCC_SAI2_FORCE_RESET()     (RCC->APB2RSTR |= (RCC_APB2RSTR_SAI2RST))
 #if defined (STM32F746xx) || defined (STM32F756xx) || defined (STM32F767xx) || defined (STM32F769xx) || defined (STM32F777xx) || defined (STM32F779xx) || defined (STM32F750xx)
@@ -1919,7 +1947,13 @@ typedef struct
 #define __HAL_RCC_TIM10_RELEASE_RESET()  (RCC->APB2RSTR &= ~(RCC_APB2RSTR_TIM10RST))
 #define __HAL_RCC_TIM11_RELEASE_RESET()  (RCC->APB2RSTR &= ~(RCC_APB2RSTR_TIM11RST))
 #define __HAL_RCC_SPI5_RELEASE_RESET()   (RCC->APB2RSTR &= ~(RCC_APB2RSTR_SPI5RST))
+
+#if defined (STM32F745xx) || defined (STM32F746xx) || defined (STM32F756xx) || defined (STM32F765xx) ||\
+    defined (STM32F767xx) || defined (STM32F769xx) || defined (STM32F777xx) || defined (STM32F779xx) ||\
+    defined (STM32F750xx)
 #define __HAL_RCC_SPI6_RELEASE_RESET()   (RCC->APB2RSTR &= ~(RCC_APB2RSTR_SPI6RST))
+#endif /* STM32F745xx || STM32F746xx || STM32F756xx || STM32F765xx || STM32F767xx || STM32F769xx || STM32F777xx || STM32F779xx || STM32F750xx */
+
 #define __HAL_RCC_SAI1_RELEASE_RESET()   (RCC->APB2RSTR &= ~(RCC_APB2RSTR_SAI1RST))
 #define __HAL_RCC_SAI2_RELEASE_RESET()   (RCC->APB2RSTR &= ~(RCC_APB2RSTR_SAI2RST))
 #if defined (STM32F746xx) || defined (STM32F756xx) || defined (STM32F767xx) || defined (STM32F769xx) || defined (STM32F777xx) || defined (STM32F779xx) || defined (STM32F750xx)

--- a/lib/STM32F7xx_HAL_Driver/Inc/stm32f7xx_hal_rtc.h
+++ b/lib/STM32F7xx_HAL_Driver/Inc/stm32f7xx_hal_rtc.h
@@ -1,0 +1,921 @@
+/**
+  ******************************************************************************
+  * @file    stm32f7xx_hal_rtc.h
+  * @author  MCD Application Team
+  * @brief   Header file of RTC HAL module.
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2017 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef STM32F7xx_HAL_RTC_H
+#define STM32F7xx_HAL_RTC_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+
+#include "stm32f7xx_hal_def.h"
+
+/** @addtogroup STM32F7xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup RTC
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/
+
+/** @defgroup RTC_Exported_Types RTC Exported Types
+  * @{
+  */
+
+/**
+  * @brief  HAL State structures definition
+  */
+typedef enum
+{
+  HAL_RTC_STATE_RESET             = 0x00U,  /*!< RTC not yet initialized or disabled */
+  HAL_RTC_STATE_READY             = 0x01U,  /*!< RTC initialized and ready for use   */
+  HAL_RTC_STATE_BUSY              = 0x02U,  /*!< RTC process is ongoing              */
+  HAL_RTC_STATE_TIMEOUT           = 0x03U,  /*!< RTC timeout state                   */
+  HAL_RTC_STATE_ERROR             = 0x04U   /*!< RTC error state                     */
+} HAL_RTCStateTypeDef;
+
+/**
+  * @brief  RTC Configuration Structure definition
+  */
+typedef struct
+{
+  uint32_t HourFormat;      /*!< Specifies the RTC Hour Format.
+                                 This parameter can be a value of @ref RTC_Hour_Formats */
+
+  uint32_t AsynchPrediv;    /*!< Specifies the RTC Asynchronous Predivider value.
+                                 This parameter must be a number between Min_Data = 0x00 and Max_Data = 0x7F */
+
+  uint32_t SynchPrediv;     /*!< Specifies the RTC Synchronous Predivider value.
+                                 This parameter must be a number between Min_Data = 0x0000 and Max_Data = 0x7FFF */
+
+  uint32_t OutPut;          /*!< Specifies which signal will be routed to the RTC output.
+                                 This parameter can be a value of @ref RTC_Output_selection_Definitions */
+
+  uint32_t OutPutPolarity;  /*!< Specifies the polarity of the output signal.
+                                 This parameter can be a value of @ref RTC_Output_Polarity_Definitions */
+
+  uint32_t OutPutType;      /*!< Specifies the RTC Output Pin mode.
+                                 This parameter can be a value of @ref RTC_Output_Type_ALARM_OUT */
+} RTC_InitTypeDef;
+
+/**
+  * @brief  RTC Time structure definition
+  */
+typedef struct
+{
+  uint8_t Hours;            /*!< Specifies the RTC Time Hour.
+                                 This parameter must be a number between Min_Data = 0 and Max_Data = 12 if the RTC_HourFormat_12 is selected
+                                 This parameter must be a number between Min_Data = 0 and Max_Data = 23 if the RTC_HourFormat_24 is selected */
+
+  uint8_t Minutes;          /*!< Specifies the RTC Time Minutes.
+                                 This parameter must be a number between Min_Data = 0 and Max_Data = 59 */
+
+  uint8_t Seconds;          /*!< Specifies the RTC Time Seconds.
+                                 This parameter must be a number between Min_Data = 0 and Max_Data = 59 */
+
+  uint8_t TimeFormat;       /*!< Specifies the RTC AM/PM Time.
+                                 This parameter can be a value of @ref RTC_AM_PM_Definitions */
+
+  uint32_t SubSeconds;      /*!< Specifies the RTC_SSR RTC Sub Second register content.
+                                 This parameter corresponds to a time unit range between [0-1] Second
+                                 with [1 Sec / SecondFraction +1] granularity */
+
+  uint32_t SecondFraction;  /*!< Specifies the range or granularity of Sub Second register content
+                                 corresponding to Synchronous prescaler factor value (PREDIV_S)
+                                 This parameter corresponds to a time unit range between [0-1] Second
+                                 with [1 Sec / SecondFraction +1] granularity.
+                                 This field will be used only by HAL_RTC_GetTime function */
+
+  uint32_t DayLightSaving;  /*!< This interface is deprecated. To manage Daylight
+                                 Saving Time, please use HAL_RTC_DST_xxx functions */
+
+  uint32_t StoreOperation;  /*!< This interface is deprecated. To manage Daylight
+                                 Saving Time, please use HAL_RTC_DST_xxx functions */
+} RTC_TimeTypeDef;
+
+/**
+  * @brief  RTC Date structure definition
+  */
+typedef struct
+{
+  uint8_t WeekDay;  /*!< Specifies the RTC Date WeekDay.
+                         This parameter can be a value of @ref RTC_WeekDay_Definitions */
+
+  uint8_t Month;    /*!< Specifies the RTC Date Month (in BCD format).
+                         This parameter can be a value of @ref RTC_Month_Date_Definitions */
+
+  uint8_t Date;     /*!< Specifies the RTC Date.
+                         This parameter must be a number between Min_Data = 1 and Max_Data = 31 */
+
+  uint8_t Year;     /*!< Specifies the RTC Date Year.
+                         This parameter must be a number between Min_Data = 0 and Max_Data = 99 */
+
+} RTC_DateTypeDef;
+
+/**
+  * @brief  RTC Alarm structure definition
+  */
+typedef struct
+{
+  RTC_TimeTypeDef AlarmTime;     /*!< Specifies the RTC Alarm Time members */
+
+  uint32_t AlarmMask;            /*!< Specifies the RTC Alarm Masks.
+                                      This parameter can be a value of @ref RTC_AlarmMask_Definitions */
+
+  uint32_t AlarmSubSecondMask;   /*!< Specifies the RTC Alarm SubSeconds Masks.
+                                      This parameter can be a value of @ref RTC_Alarm_Sub_Seconds_Masks_Definitions */
+
+  uint32_t AlarmDateWeekDaySel;  /*!< Specifies the RTC Alarm is on Date or WeekDay.
+                                      This parameter can be a value of @ref RTC_AlarmDateWeekDay_Definitions */
+
+  uint8_t AlarmDateWeekDay;      /*!< Specifies the RTC Alarm Date/WeekDay.
+                                      If the Alarm Date is selected, this parameter must be set to a value in the 1-31 range.
+                                      If the Alarm WeekDay is selected, this parameter can be a value of @ref RTC_WeekDay_Definitions */
+
+  uint32_t Alarm;                /*!< Specifies the alarm .
+                                      This parameter can be a value of @ref RTC_Alarms_Definitions */
+} RTC_AlarmTypeDef;
+
+/**
+  * @brief  RTC Handle Structure definition
+  */
+#if (USE_HAL_RTC_REGISTER_CALLBACKS == 1)
+typedef struct __RTC_HandleTypeDef
+#else
+typedef struct
+#endif /* USE_HAL_RTC_REGISTER_CALLBACKS */
+{
+  RTC_TypeDef                 *Instance;  /*!< Register base address    */
+
+  RTC_InitTypeDef             Init;       /*!< RTC required parameters  */
+
+  HAL_LockTypeDef             Lock;       /*!< RTC locking object       */
+
+  __IO HAL_RTCStateTypeDef    State;      /*!< Time communication state */
+
+#if (USE_HAL_RTC_REGISTER_CALLBACKS == 1)
+  void (* AlarmAEventCallback)      (struct __RTC_HandleTypeDef *hrtc);  /*!< RTC Alarm A Event callback         */
+
+  void (* AlarmBEventCallback)      (struct __RTC_HandleTypeDef *hrtc);  /*!< RTC Alarm B Event callback         */
+
+  void (* TimeStampEventCallback)   (struct __RTC_HandleTypeDef *hrtc);  /*!< RTC Timestamp Event callback       */
+
+  void (* WakeUpTimerEventCallback) (struct __RTC_HandleTypeDef *hrtc);  /*!< RTC WakeUpTimer Event callback     */
+
+  void (* Tamper1EventCallback)     (struct __RTC_HandleTypeDef *hrtc);  /*!< RTC Tamper 1 Event callback        */
+
+  void (* Tamper2EventCallback)     (struct __RTC_HandleTypeDef *hrtc);  /*!< RTC Tamper 2 Event callback        */
+
+  void (* Tamper3EventCallback)     (struct __RTC_HandleTypeDef *hrtc);  /*!< RTC Tamper 3 Event callback        */
+
+  void (* MspInitCallback)          (struct __RTC_HandleTypeDef *hrtc);  /*!< RTC Msp Init callback              */
+
+  void (* MspDeInitCallback)        (struct __RTC_HandleTypeDef *hrtc);  /*!< RTC Msp DeInit callback            */
+
+#endif /* USE_HAL_RTC_REGISTER_CALLBACKS */
+
+} RTC_HandleTypeDef;
+
+#if (USE_HAL_RTC_REGISTER_CALLBACKS == 1)
+/**
+  * @brief  HAL RTC Callback ID enumeration definition
+  */
+typedef enum
+{
+  HAL_RTC_ALARM_A_EVENT_CB_ID           = 0x00U,    /*!< RTC Alarm A Event Callback ID       */
+  HAL_RTC_ALARM_B_EVENT_CB_ID           = 0x01U,    /*!< RTC Alarm B Event Callback ID       */
+  HAL_RTC_TIMESTAMP_EVENT_CB_ID         = 0x02U,    /*!< RTC Timestamp Event Callback ID     */
+  HAL_RTC_WAKEUPTIMER_EVENT_CB_ID       = 0x03U,    /*!< RTC Wakeup Timer Event Callback ID  */
+  HAL_RTC_TAMPER1_EVENT_CB_ID           = 0x04U,    /*!< RTC Tamper 1 Callback ID            */
+  HAL_RTC_TAMPER2_EVENT_CB_ID           = 0x05U,    /*!< RTC Tamper 2 Callback ID            */
+  HAL_RTC_TAMPER3_EVENT_CB_ID           = 0x06U,    /*!< RTC Tamper 3 Callback ID            */
+  HAL_RTC_MSPINIT_CB_ID                 = 0x0EU,    /*!< RTC Msp Init callback ID            */
+  HAL_RTC_MSPDEINIT_CB_ID               = 0x0FU     /*!< RTC Msp DeInit callback ID          */
+} HAL_RTC_CallbackIDTypeDef;
+
+/**
+  * @brief  HAL RTC Callback pointer definition
+  */
+typedef  void (*pRTC_CallbackTypeDef)(RTC_HandleTypeDef *hrtc);  /*!< pointer to an RTC callback function */
+#endif /* USE_HAL_RTC_REGISTER_CALLBACKS */
+
+/**
+  * @}
+  */
+
+/* Exported constants --------------------------------------------------------*/
+
+/** @defgroup RTC_Exported_Constants RTC Exported Constants
+  * @{
+  */
+
+/** @defgroup RTC_Hour_Formats RTC Hour Formats
+  * @{
+  */
+#define RTC_HOURFORMAT_24              0x00000000U
+#define RTC_HOURFORMAT_12              RTC_CR_FMT
+/**
+  * @}
+  */
+
+/** @defgroup RTC_Output_selection_Definitions RTC Output Selection Definitions
+  * @{
+  */
+#define RTC_OUTPUT_DISABLE             0x00000000U
+#define RTC_OUTPUT_ALARMA              RTC_CR_OSEL_0
+#define RTC_OUTPUT_ALARMB              RTC_CR_OSEL_1
+#define RTC_OUTPUT_WAKEUP              RTC_CR_OSEL
+/**
+  * @}
+  */
+
+/** @defgroup RTC_Output_Polarity_Definitions RTC Output Polarity Definitions
+  * @{
+  */
+#define RTC_OUTPUT_POLARITY_HIGH       0x00000000U
+#define RTC_OUTPUT_POLARITY_LOW        RTC_CR_POL
+/**
+  * @}
+  */
+
+/** @defgroup RTC_Output_Type_ALARM_OUT RTC Output Type ALARM OUT
+  * @{
+  */
+#define RTC_OUTPUT_TYPE_OPENDRAIN      0x00000000U
+#define RTC_OUTPUT_TYPE_PUSHPULL       RTC_OR_ALARMTYPE
+/**
+  * @}
+  */
+
+/** @defgroup RTC_AM_PM_Definitions RTC AM PM Definitions
+  * @{
+  */
+#define RTC_HOURFORMAT12_AM            ((uint8_t)0x00)
+#define RTC_HOURFORMAT12_PM            ((uint8_t)0x01)
+/**
+  * @}
+  */
+
+/** @defgroup RTC_DayLightSaving_Definitions RTC DayLight Saving Definitions
+  * @{
+  */
+#define RTC_DAYLIGHTSAVING_SUB1H       RTC_CR_SUB1H
+#define RTC_DAYLIGHTSAVING_ADD1H       RTC_CR_ADD1H
+#define RTC_DAYLIGHTSAVING_NONE        0x00000000U
+/**
+  * @}
+  */
+
+/** @defgroup RTC_StoreOperation_Definitions RTC Store Operation Definitions
+  * @{
+  */
+#define RTC_STOREOPERATION_RESET        0x00000000U
+#define RTC_STOREOPERATION_SET          RTC_CR_BKP
+/**
+  * @}
+  */
+
+/** @defgroup RTC_Input_parameter_format_definitions RTC Input Parameter Format Definitions
+  * @{
+  */
+#define RTC_FORMAT_BIN                  0x00000000U
+#define RTC_FORMAT_BCD                  0x00000001U
+/**
+  * @}
+  */
+
+/** @defgroup RTC_Month_Date_Definitions RTC Month Date Definitions (in BCD format)
+  * @{
+  */
+#define RTC_MONTH_JANUARY              ((uint8_t)0x01)
+#define RTC_MONTH_FEBRUARY             ((uint8_t)0x02)
+#define RTC_MONTH_MARCH                ((uint8_t)0x03)
+#define RTC_MONTH_APRIL                ((uint8_t)0x04)
+#define RTC_MONTH_MAY                  ((uint8_t)0x05)
+#define RTC_MONTH_JUNE                 ((uint8_t)0x06)
+#define RTC_MONTH_JULY                 ((uint8_t)0x07)
+#define RTC_MONTH_AUGUST               ((uint8_t)0x08)
+#define RTC_MONTH_SEPTEMBER            ((uint8_t)0x09)
+#define RTC_MONTH_OCTOBER              ((uint8_t)0x10)
+#define RTC_MONTH_NOVEMBER             ((uint8_t)0x11)
+#define RTC_MONTH_DECEMBER             ((uint8_t)0x12)
+/**
+  * @}
+  */
+
+/** @defgroup RTC_WeekDay_Definitions RTC WeekDay Definitions
+  * @{
+  */
+#define RTC_WEEKDAY_MONDAY             ((uint8_t)0x01)
+#define RTC_WEEKDAY_TUESDAY            ((uint8_t)0x02)
+#define RTC_WEEKDAY_WEDNESDAY          ((uint8_t)0x03)
+#define RTC_WEEKDAY_THURSDAY           ((uint8_t)0x04)
+#define RTC_WEEKDAY_FRIDAY             ((uint8_t)0x05)
+#define RTC_WEEKDAY_SATURDAY           ((uint8_t)0x06)
+#define RTC_WEEKDAY_SUNDAY             ((uint8_t)0x07)
+/**
+  * @}
+  */
+
+/** @defgroup RTC_AlarmDateWeekDay_Definitions RTC Alarm Date WeekDay Definitions
+  * @{
+  */
+#define RTC_ALARMDATEWEEKDAYSEL_DATE      0x00000000U
+#define RTC_ALARMDATEWEEKDAYSEL_WEEKDAY   RTC_ALRMAR_WDSEL
+/**
+  * @}
+  */
+
+/** @defgroup RTC_AlarmMask_Definitions RTC Alarm Mask Definitions
+  * @{
+  */
+#define RTC_ALARMMASK_NONE                0x00000000U
+#define RTC_ALARMMASK_DATEWEEKDAY         RTC_ALRMAR_MSK4
+#define RTC_ALARMMASK_HOURS               RTC_ALRMAR_MSK3
+#define RTC_ALARMMASK_MINUTES             RTC_ALRMAR_MSK2
+#define RTC_ALARMMASK_SECONDS             RTC_ALRMAR_MSK1
+#define RTC_ALARMMASK_ALL                 (RTC_ALARMMASK_DATEWEEKDAY | \
+                                           RTC_ALARMMASK_HOURS       | \
+                                           RTC_ALARMMASK_MINUTES     | \
+                                           RTC_ALARMMASK_SECONDS)
+/**
+  * @}
+  */
+
+/** @defgroup RTC_Alarms_Definitions RTC Alarms Definitions
+  * @{
+  */
+#define RTC_ALARM_A                       RTC_CR_ALRAE
+#define RTC_ALARM_B                       RTC_CR_ALRBE
+/**
+  * @}
+  */
+
+/** @defgroup RTC_Alarm_Sub_Seconds_Masks_Definitions RTC Alarm Sub Seconds Masks Definitions
+  * @{
+  */
+/*!< All Alarm SS fields are masked. There is no comparison on sub seconds for Alarm */
+#define RTC_ALARMSUBSECONDMASK_ALL         0x00000000U
+/*!< SS[14:1] are don't care in Alarm comparison. Only SS[0] is compared.     */
+#define RTC_ALARMSUBSECONDMASK_SS14_1      RTC_ALRMASSR_MASKSS_0
+/*!< SS[14:2] are don't care in Alarm comparison. Only SS[1:0] are compared.  */
+#define RTC_ALARMSUBSECONDMASK_SS14_2      RTC_ALRMASSR_MASKSS_1
+/*!< SS[14:3] are don't care in Alarm comparison. Only SS[2:0] are compared.  */
+#define RTC_ALARMSUBSECONDMASK_SS14_3      (RTC_ALRMASSR_MASKSS_0 | RTC_ALRMASSR_MASKSS_1)
+/*!< SS[14:4] are don't care in Alarm comparison. Only SS[3:0] are compared.  */
+#define RTC_ALARMSUBSECONDMASK_SS14_4      RTC_ALRMASSR_MASKSS_2
+/*!< SS[14:5] are don't care in Alarm comparison. Only SS[4:0] are compared.  */
+#define RTC_ALARMSUBSECONDMASK_SS14_5      (RTC_ALRMASSR_MASKSS_0 | RTC_ALRMASSR_MASKSS_2)
+/*!< SS[14:6] are don't care in Alarm comparison. Only SS[5:0] are compared.  */
+#define RTC_ALARMSUBSECONDMASK_SS14_6      (RTC_ALRMASSR_MASKSS_1 | RTC_ALRMASSR_MASKSS_2)
+/*!< SS[14:7] are don't care in Alarm comparison. Only SS[6:0] are compared.  */
+#define RTC_ALARMSUBSECONDMASK_SS14_7      (RTC_ALRMASSR_MASKSS_0 | RTC_ALRMASSR_MASKSS_1 | RTC_ALRMASSR_MASKSS_2)
+/*!< SS[14:8] are don't care in Alarm comparison. Only SS[7:0] are compared.  */
+#define RTC_ALARMSUBSECONDMASK_SS14_8      RTC_ALRMASSR_MASKSS_3
+/*!< SS[14:9] are don't care in Alarm comparison. Only SS[8:0] are compared.  */
+#define RTC_ALARMSUBSECONDMASK_SS14_9      (RTC_ALRMASSR_MASKSS_0 | RTC_ALRMASSR_MASKSS_3)
+/*!< SS[14:10] are don't care in Alarm comparison. Only SS[9:0] are compared. */
+#define RTC_ALARMSUBSECONDMASK_SS14_10     (RTC_ALRMASSR_MASKSS_1 | RTC_ALRMASSR_MASKSS_3)
+/*!< SS[14:11] are don't care in Alarm comparison. Only SS[10:0] are compared. */
+#define RTC_ALARMSUBSECONDMASK_SS14_11     (RTC_ALRMASSR_MASKSS_0 | RTC_ALRMASSR_MASKSS_1 | RTC_ALRMASSR_MASKSS_3)
+/*!< SS[14:12] are don't care in Alarm comparison. Only SS[11:0] are compared. */
+#define RTC_ALARMSUBSECONDMASK_SS14_12     (RTC_ALRMASSR_MASKSS_2 | RTC_ALRMASSR_MASKSS_3)
+/*!< SS[14:13] are don't care in Alarm comparison. Only SS[12:0] are compared. */
+#define RTC_ALARMSUBSECONDMASK_SS14_13     (RTC_ALRMASSR_MASKSS_0 | RTC_ALRMASSR_MASKSS_2 | RTC_ALRMASSR_MASKSS_3)
+/*!< SS[14] is don't care in Alarm comparison. Only SS[13:0] are compared. */
+#define RTC_ALARMSUBSECONDMASK_SS14        (RTC_ALRMASSR_MASKSS_1 | RTC_ALRMASSR_MASKSS_2 | RTC_ALRMASSR_MASKSS_3)
+/*!< SS[14:0] are compared and must match to activate alarm. */
+#define RTC_ALARMSUBSECONDMASK_NONE        RTC_ALRMASSR_MASKSS
+/**
+  * @}
+  */
+
+/** @defgroup RTC_Interrupts_Definitions RTC Interrupts Definitions
+  * @{
+  */
+#define RTC_IT_TS                         RTC_CR_TSIE         /*!< Enable Timestamp Interrupt               */
+#define RTC_IT_WUT                        RTC_CR_WUTIE        /*!< Enable Wakeup timer Interrupt            */
+#define RTC_IT_ALRB                       RTC_CR_ALRBIE       /*!< Enable Alarm B Interrupt                 */
+#define RTC_IT_ALRA                       RTC_CR_ALRAIE       /*!< Enable Alarm A Interrupt                 */
+/**
+  * @}
+  */
+
+/** @defgroup RTC_Flags_Definitions RTC Flags Definitions
+  * @{
+  */
+#define RTC_FLAG_RECALPF                  RTC_ISR_RECALPF     /*!< Recalibration pending flag               */
+#define RTC_FLAG_TAMP3F                   RTC_ISR_TAMP3F      /*!< Tamper 3 event flag                      */
+#define RTC_FLAG_TAMP2F                   RTC_ISR_TAMP2F      /*!< Tamper 2 event flag                      */
+#define RTC_FLAG_TAMP1F                   RTC_ISR_TAMP1F      /*!< Tamper 1 event flag                      */
+#define RTC_FLAG_TSOVF                    RTC_ISR_TSOVF       /*!< Timestamp overflow flag                  */
+#define RTC_FLAG_TSF                      RTC_ISR_TSF         /*!< Timestamp event flag                     */
+#define RTC_FLAG_ITSF                     RTC_ISR_ITSF        /*!< Internal Timestamp event flag            */
+#define RTC_FLAG_WUTF                     RTC_ISR_WUTF        /*!< Wakeup timer event flag                  */
+#define RTC_FLAG_ALRBF                    RTC_ISR_ALRBF       /*!< Alarm B event flag                       */
+#define RTC_FLAG_ALRAF                    RTC_ISR_ALRAF       /*!< Alarm A event flag                       */
+#define RTC_FLAG_INITF                    RTC_ISR_INITF       /*!< RTC in initialization mode flag          */
+#define RTC_FLAG_RSF                      RTC_ISR_RSF         /*!< Register synchronization flag            */
+#define RTC_FLAG_INITS                    RTC_ISR_INITS       /*!< RTC initialization status flag           */
+#define RTC_FLAG_SHPF                     RTC_ISR_SHPF        /*!< Shift operation pending flag             */
+#define RTC_FLAG_WUTWF                    RTC_ISR_WUTWF       /*!< WUTR register write allowance flag       */
+#define RTC_FLAG_ALRBWF                   RTC_ISR_ALRBWF      /*!< ALRMBR register write allowance flag     */
+#define RTC_FLAG_ALRAWF                   RTC_ISR_ALRAWF      /*!< ALRMAR register write allowance flag     */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Exported macros -----------------------------------------------------------*/
+
+/** @defgroup RTC_Exported_Macros RTC Exported Macros
+  * @{
+  */
+
+/** @brief Reset RTC handle state
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @retval None
+  */
+#if (USE_HAL_RTC_REGISTER_CALLBACKS == 1)
+#define __HAL_RTC_RESET_HANDLE_STATE(__HANDLE__) do {                                            \
+                                                      (__HANDLE__)->State = HAL_RTC_STATE_RESET; \
+                                                      (__HANDLE__)->MspInitCallback = NULL;      \
+                                                      (__HANDLE__)->MspDeInitCallback = NULL;    \
+                                                    } while(0U)
+#else
+#define __HAL_RTC_RESET_HANDLE_STATE(__HANDLE__) ((__HANDLE__)->State = HAL_RTC_STATE_RESET)
+#endif /* USE_HAL_RTC_REGISTER_CALLBACKS */
+
+/**
+  * @brief  Disable the write protection for RTC registers.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_WRITEPROTECTION_DISABLE(__HANDLE__) do {                                       \
+                                                           (__HANDLE__)->Instance->WPR = 0xCAU;  \
+                                                           (__HANDLE__)->Instance->WPR = 0x53U;  \
+                                                         } while(0U)
+
+/**
+  * @brief  Enable the write protection for RTC registers.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_WRITEPROTECTION_ENABLE(__HANDLE__) do {                                       \
+                                                          (__HANDLE__)->Instance->WPR = 0xFFU;  \
+                                                        } while(0U)
+
+/**
+  * @brief  Check whether the RTC Calendar is initialized.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_IS_CALENDAR_INITIALIZED(__HANDLE__)                 (((((__HANDLE__)->Instance->ISR) & (RTC_FLAG_INITS)) == RTC_FLAG_INITS) ? 1U : 0U)
+
+/**
+  * @brief  Enable the RTC ALARMA peripheral.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_ALARMA_ENABLE(__HANDLE__)                           ((__HANDLE__)->Instance->CR |= (RTC_CR_ALRAE))
+
+/**
+  * @brief  Disable the RTC ALARMA peripheral.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_ALARMA_DISABLE(__HANDLE__)                          ((__HANDLE__)->Instance->CR &= ~(RTC_CR_ALRAE))
+
+/**
+  * @brief  Enable the RTC ALARMB peripheral.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_ALARMB_ENABLE(__HANDLE__)                           ((__HANDLE__)->Instance->CR |= (RTC_CR_ALRBE))
+
+/**
+  * @brief  Disable the RTC ALARMB peripheral.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_ALARMB_DISABLE(__HANDLE__)                          ((__HANDLE__)->Instance->CR &= ~(RTC_CR_ALRBE))
+
+/**
+  * @brief  Enable the RTC Alarm interrupt.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @param  __INTERRUPT__ specifies the RTC Alarm interrupt sources to be enabled or disabled.
+  *          This parameter can be any combination of the following values:
+  *             @arg RTC_IT_ALRA: Alarm A interrupt
+  *             @arg RTC_IT_ALRB: Alarm B interrupt
+  * @retval None
+  */
+#define __HAL_RTC_ALARM_ENABLE_IT(__HANDLE__, __INTERRUPT__)          ((__HANDLE__)->Instance->CR |= (__INTERRUPT__))
+
+/**
+  * @brief  Disable the RTC Alarm interrupt.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @param  __INTERRUPT__ specifies the RTC Alarm interrupt sources to be enabled or disabled.
+  *          This parameter can be any combination of the following values:
+  *             @arg RTC_IT_ALRA: Alarm A interrupt
+  *             @arg RTC_IT_ALRB: Alarm B interrupt
+  * @retval None
+  */
+#define __HAL_RTC_ALARM_DISABLE_IT(__HANDLE__, __INTERRUPT__)         ((__HANDLE__)->Instance->CR &= ~(__INTERRUPT__))
+
+/**
+  * @brief  Check whether the specified RTC Alarm interrupt has occurred or not.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @param  __INTERRUPT__ specifies the RTC Alarm interrupt to check.
+  *         This parameter can be:
+  *            @arg RTC_IT_ALRA: Alarm A interrupt
+  *            @arg RTC_IT_ALRB: Alarm B interrupt
+  * @retval None
+  */
+#define __HAL_RTC_ALARM_GET_IT(__HANDLE__, __INTERRUPT__)           (((((__HANDLE__)->Instance->ISR) & ((__INTERRUPT__) >> 4U)) != 0U) ? 1U : 0U)
+
+/**
+  * @brief  Get the selected RTC Alarm's flag status.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @param  __FLAG__ specifies the RTC Alarm Flag to check.
+  *         This parameter can be:
+  *            @arg RTC_FLAG_ALRAF: Alarm A interrupt flag
+  *            @arg RTC_FLAG_ALRAWF: Alarm A 'write allowed' flag
+  *            @arg RTC_FLAG_ALRBF: Alarm B interrupt flag
+  *            @arg RTC_FLAG_ALRBWF: Alarm B 'write allowed' flag
+  * @retval None
+  */
+#define __HAL_RTC_ALARM_GET_FLAG(__HANDLE__, __FLAG__)                (((((__HANDLE__)->Instance->ISR) & (__FLAG__)) != 0U) ? 1U : 0U)
+
+/**
+  * @brief  Clear the RTC Alarm's pending flags.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @param  __FLAG__ specifies the RTC Alarm flag to be cleared.
+  *          This parameter can be:
+  *             @arg RTC_FLAG_ALRAF
+  *             @arg RTC_FLAG_ALRBF
+  * @retval None
+  */
+#define __HAL_RTC_ALARM_CLEAR_FLAG(__HANDLE__, __FLAG__)                  ((__HANDLE__)->Instance->ISR) = (~((__FLAG__) | RTC_ISR_INIT)|((__HANDLE__)->Instance->ISR & RTC_ISR_INIT))
+
+/**
+  * @brief  Check whether the specified RTC Alarm interrupt has been enabled or not.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @param  __INTERRUPT__ specifies the RTC Alarm interrupt sources to check.
+  *         This parameter can be:
+  *            @arg RTC_IT_ALRA: Alarm A interrupt
+  *            @arg RTC_IT_ALRB: Alarm B interrupt
+  * @retval None
+  */
+#define __HAL_RTC_ALARM_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__)     (((((__HANDLE__)->Instance->CR) & (__INTERRUPT__)) != 0U) ? 1U : 0U)
+
+/**
+  * @brief  Enable interrupt on the RTC Alarm associated EXTI line.
+  * @retval None
+  */
+#define __HAL_RTC_ALARM_EXTI_ENABLE_IT()            (EXTI->IMR |= RTC_EXTI_LINE_ALARM_EVENT)
+
+/**
+  * @brief  Disable interrupt on the RTC Alarm associated EXTI line.
+  * @retval None
+  */
+#define __HAL_RTC_ALARM_EXTI_DISABLE_IT()           (EXTI->IMR &= ~RTC_EXTI_LINE_ALARM_EVENT)
+
+/**
+  * @brief  Enable event on the RTC Alarm associated EXTI line.
+  * @retval None.
+  */
+#define __HAL_RTC_ALARM_EXTI_ENABLE_EVENT()          (EXTI->EMR |= RTC_EXTI_LINE_ALARM_EVENT)
+
+/**
+  * @brief  Disable event on the RTC Alarm associated EXTI line.
+  * @retval None.
+  */
+#define __HAL_RTC_ALARM_EXTI_DISABLE_EVENT()         (EXTI->EMR &= ~RTC_EXTI_LINE_ALARM_EVENT)
+
+/**
+  * @brief  Enable falling edge trigger on the RTC Alarm associated EXTI line.
+  * @retval None.
+  */
+#define __HAL_RTC_ALARM_EXTI_ENABLE_FALLING_EDGE()   (EXTI->FTSR |= RTC_EXTI_LINE_ALARM_EVENT)
+
+/**
+  * @brief  Disable falling edge trigger on the RTC Alarm associated EXTI line.
+  * @retval None.
+  */
+#define __HAL_RTC_ALARM_EXTI_DISABLE_FALLING_EDGE()  (EXTI->FTSR &= ~RTC_EXTI_LINE_ALARM_EVENT)
+
+/**
+  * @brief  Enable rising edge trigger on the RTC Alarm associated EXTI line.
+  * @retval None.
+  */
+#define __HAL_RTC_ALARM_EXTI_ENABLE_RISING_EDGE()    (EXTI->RTSR |= RTC_EXTI_LINE_ALARM_EVENT)
+
+/**
+  * @brief  Disable rising edge trigger on the RTC Alarm associated EXTI line.
+  * @retval None.
+  */
+#define __HAL_RTC_ALARM_EXTI_DISABLE_RISING_EDGE()   (EXTI->RTSR &= ~RTC_EXTI_LINE_ALARM_EVENT)
+
+/**
+  * @brief  Enable rising & falling edge trigger on the RTC Alarm associated EXTI line.
+  * @retval None.
+  */
+#define __HAL_RTC_ALARM_EXTI_ENABLE_RISING_FALLING_EDGE() do {                                             \
+                                                               __HAL_RTC_ALARM_EXTI_ENABLE_RISING_EDGE();  \
+                                                               __HAL_RTC_ALARM_EXTI_ENABLE_FALLING_EDGE(); \
+                                                             } while(0U)
+
+/**
+  * @brief  Disable rising & falling edge trigger on the RTC Alarm associated EXTI line.
+  * @retval None.
+  */
+#define __HAL_RTC_ALARM_EXTI_DISABLE_RISING_FALLING_EDGE() do {                                              \
+                                                                __HAL_RTC_ALARM_EXTI_DISABLE_RISING_EDGE();  \
+                                                                __HAL_RTC_ALARM_EXTI_DISABLE_FALLING_EDGE(); \
+                                                              } while(0U)
+
+/**
+  * @brief Check whether the RTC Alarm associated EXTI line interrupt flag is set or not.
+  * @retval Line Status.
+  */
+#define __HAL_RTC_ALARM_EXTI_GET_FLAG()              (EXTI->PR & RTC_EXTI_LINE_ALARM_EVENT)
+
+/**
+  * @brief Clear the RTC Alarm associated EXTI line flag.
+  * @retval None.
+  */
+#define __HAL_RTC_ALARM_EXTI_CLEAR_FLAG()            (EXTI->PR = RTC_EXTI_LINE_ALARM_EVENT)
+
+/**
+  * @brief Generate a Software interrupt on RTC Alarm associated EXTI line.
+  * @retval None.
+  */
+#define __HAL_RTC_ALARM_EXTI_GENERATE_SWIT()         (EXTI->SWIER |= RTC_EXTI_LINE_ALARM_EVENT)
+/**
+  * @}
+  */
+
+/* Include RTC HAL Extended module */
+#include "stm32f7xx_hal_rtc_ex.h"
+
+/* Exported functions --------------------------------------------------------*/
+
+/** @addtogroup RTC_Exported_Functions
+  * @{
+  */
+
+/** @addtogroup RTC_Exported_Functions_Group1
+  * @{
+  */
+/* Initialization and de-initialization functions  ****************************/
+HAL_StatusTypeDef HAL_RTC_Init(RTC_HandleTypeDef *hrtc);
+HAL_StatusTypeDef HAL_RTC_DeInit(RTC_HandleTypeDef *hrtc);
+void              HAL_RTC_MspInit(RTC_HandleTypeDef *hrtc);
+void              HAL_RTC_MspDeInit(RTC_HandleTypeDef *hrtc);
+
+/* Callbacks Register/UnRegister functions  ***********************************/
+#if (USE_HAL_RTC_REGISTER_CALLBACKS == 1)
+HAL_StatusTypeDef HAL_RTC_RegisterCallback(RTC_HandleTypeDef *hrtc, HAL_RTC_CallbackIDTypeDef CallbackID, pRTC_CallbackTypeDef pCallback);
+HAL_StatusTypeDef HAL_RTC_UnRegisterCallback(RTC_HandleTypeDef *hrtc, HAL_RTC_CallbackIDTypeDef CallbackID);
+#endif /* USE_HAL_RTC_REGISTER_CALLBACKS */
+/**
+  * @}
+  */
+
+/** @addtogroup RTC_Exported_Functions_Group2
+  * @{
+  */
+/* RTC Time and Date functions ************************************************/
+HAL_StatusTypeDef HAL_RTC_SetTime(RTC_HandleTypeDef *hrtc, RTC_TimeTypeDef *sTime, uint32_t Format);
+HAL_StatusTypeDef HAL_RTC_GetTime(RTC_HandleTypeDef *hrtc, RTC_TimeTypeDef *sTime, uint32_t Format);
+HAL_StatusTypeDef HAL_RTC_SetDate(RTC_HandleTypeDef *hrtc, RTC_DateTypeDef *sDate, uint32_t Format);
+HAL_StatusTypeDef HAL_RTC_GetDate(RTC_HandleTypeDef *hrtc, RTC_DateTypeDef *sDate, uint32_t Format);
+/**
+  * @}
+  */
+
+/** @addtogroup RTC_Exported_Functions_Group3
+  * @{
+  */
+/* RTC Alarm functions ********************************************************/
+HAL_StatusTypeDef HAL_RTC_SetAlarm(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef *sAlarm, uint32_t Format);
+HAL_StatusTypeDef HAL_RTC_SetAlarm_IT(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef *sAlarm, uint32_t Format);
+HAL_StatusTypeDef HAL_RTC_DeactivateAlarm(RTC_HandleTypeDef *hrtc, uint32_t Alarm);
+HAL_StatusTypeDef HAL_RTC_GetAlarm(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef *sAlarm, uint32_t Alarm, uint32_t Format);
+void              HAL_RTC_AlarmIRQHandler(RTC_HandleTypeDef *hrtc);
+HAL_StatusTypeDef HAL_RTC_PollForAlarmAEvent(RTC_HandleTypeDef *hrtc, uint32_t Timeout);
+void              HAL_RTC_AlarmAEventCallback(RTC_HandleTypeDef *hrtc);
+/**
+  * @}
+  */
+
+/** @addtogroup RTC_Exported_Functions_Group4
+  * @{
+  */
+/* Peripheral Control functions ***********************************************/
+HAL_StatusTypeDef   HAL_RTC_WaitForSynchro(RTC_HandleTypeDef *hrtc);
+
+/* RTC Daylight Saving Time functions *****************************************/
+void              HAL_RTC_DST_Add1Hour(RTC_HandleTypeDef *hrtc);
+void              HAL_RTC_DST_Sub1Hour(RTC_HandleTypeDef *hrtc);
+void              HAL_RTC_DST_SetStoreOperation(RTC_HandleTypeDef *hrtc);
+void              HAL_RTC_DST_ClearStoreOperation(RTC_HandleTypeDef *hrtc);
+uint32_t          HAL_RTC_DST_ReadStoreOperation(RTC_HandleTypeDef *hrtc);
+/**
+  * @}
+  */
+
+/** @addtogroup RTC_Exported_Functions_Group5
+  * @{
+  */
+/* Peripheral State functions *************************************************/
+HAL_RTCStateTypeDef HAL_RTC_GetState(RTC_HandleTypeDef *hrtc);
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Private types -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private constants ---------------------------------------------------------*/
+
+/** @defgroup RTC_Private_Constants RTC Private Constants
+  * @{
+  */
+/* Masks Definition */
+#define RTC_TR_RESERVED_MASK    ((uint32_t)(RTC_TR_HT  | RTC_TR_HU  | \
+                                            RTC_TR_MNT | RTC_TR_MNU | \
+                                            RTC_TR_ST  | RTC_TR_SU  | \
+                                            RTC_TR_PM))
+#define RTC_DR_RESERVED_MASK    ((uint32_t)(RTC_DR_YT | RTC_DR_YU | \
+                                            RTC_DR_MT | RTC_DR_MU | \
+                                            RTC_DR_DT | RTC_DR_DU | \
+                                            RTC_DR_WDU))
+#define RTC_ISR_RESERVED_MASK   ((uint32_t)(RTC_FLAGS_MASK | RTC_ISR_INIT))
+#define RTC_INIT_MASK           0xFFFFFFFFU
+#define RTC_RSF_MASK            ((uint32_t)~(RTC_ISR_INIT | RTC_ISR_RSF))
+#define RTC_FLAGS_MASK          ((uint32_t)(RTC_FLAG_INITF   | RTC_FLAG_INITS  | \
+                                            RTC_FLAG_ALRAF   | RTC_FLAG_ALRAWF | \
+                                            RTC_FLAG_ALRBF   | RTC_FLAG_ALRBWF | \
+                                            RTC_FLAG_WUTF    | RTC_FLAG_WUTWF  | \
+                                            RTC_FLAG_RECALPF | RTC_FLAG_SHPF   | \
+                                            RTC_FLAG_TSF     | RTC_FLAG_TSOVF  | \
+                                            RTC_FLAG_RSF     | RTC_TAMPER_FLAGS_MASK))
+
+#define RTC_TIMEOUT_VALUE       1000U
+
+#define RTC_EXTI_LINE_ALARM_EVENT  EXTI_IMR_IM17  /*!< External interrupt line 17 Connected to the RTC Alarm event */
+/**
+  * @}
+  */
+
+/* Private macros ------------------------------------------------------------*/
+
+/** @defgroup RTC_Private_Macros RTC Private Macros
+  * @{
+  */
+
+/** @defgroup RTC_IS_RTC_Definitions RTC Private macros to check input parameters
+  * @{
+  */
+#define IS_RTC_HOUR_FORMAT(FORMAT)     (((FORMAT) == RTC_HOURFORMAT_12) || \
+                                        ((FORMAT) == RTC_HOURFORMAT_24))
+
+#define IS_RTC_OUTPUT(OUTPUT) (((OUTPUT) == RTC_OUTPUT_DISABLE) || \
+                               ((OUTPUT) == RTC_OUTPUT_ALARMA)  || \
+                               ((OUTPUT) == RTC_OUTPUT_ALARMB)  || \
+                               ((OUTPUT) == RTC_OUTPUT_WAKEUP))
+
+#define IS_RTC_OUTPUT_POL(POL) (((POL) == RTC_OUTPUT_POLARITY_HIGH) || \
+                                ((POL) == RTC_OUTPUT_POLARITY_LOW))
+
+#define IS_RTC_OUTPUT_TYPE(TYPE) (((TYPE) == RTC_OUTPUT_TYPE_OPENDRAIN) || \
+                                  ((TYPE) == RTC_OUTPUT_TYPE_PUSHPULL))
+
+#define IS_RTC_ASYNCH_PREDIV(PREDIV)   ((PREDIV) <= 0x7FU)
+#define IS_RTC_SYNCH_PREDIV(PREDIV)    ((PREDIV) <= 0x7FFFU)
+
+#define IS_RTC_HOUR12(HOUR)            (((HOUR) > 0U) && ((HOUR) <= 12U))
+#define IS_RTC_HOUR24(HOUR)            ((HOUR) <= 23U)
+#define IS_RTC_MINUTES(MINUTES)        ((MINUTES) <= 59U)
+#define IS_RTC_SECONDS(SECONDS)        ((SECONDS) <= 59U)
+
+#define IS_RTC_HOURFORMAT12(PM)  (((PM) == RTC_HOURFORMAT12_AM) || \
+                                  ((PM) == RTC_HOURFORMAT12_PM))
+
+#define IS_RTC_DAYLIGHT_SAVING(SAVE) (((SAVE) == RTC_DAYLIGHTSAVING_SUB1H) || \
+                                      ((SAVE) == RTC_DAYLIGHTSAVING_ADD1H) || \
+                                      ((SAVE) == RTC_DAYLIGHTSAVING_NONE))
+
+#define IS_RTC_STORE_OPERATION(OPERATION) (((OPERATION) == RTC_STOREOPERATION_RESET) || \
+                                           ((OPERATION) == RTC_STOREOPERATION_SET))
+
+#define IS_RTC_FORMAT(FORMAT) (((FORMAT) == RTC_FORMAT_BIN) || ((FORMAT) == RTC_FORMAT_BCD))
+
+#define IS_RTC_YEAR(YEAR)              ((YEAR) <= 99U)
+#define IS_RTC_MONTH(MONTH)            (((MONTH) >= 1U) && ((MONTH) <= 12U))
+#define IS_RTC_DATE(DATE)              (((DATE) >= 1U) && ((DATE) <= 31U))
+
+#define IS_RTC_WEEKDAY(WEEKDAY) (((WEEKDAY) == RTC_WEEKDAY_MONDAY)    || \
+                                 ((WEEKDAY) == RTC_WEEKDAY_TUESDAY)   || \
+                                 ((WEEKDAY) == RTC_WEEKDAY_WEDNESDAY) || \
+                                 ((WEEKDAY) == RTC_WEEKDAY_THURSDAY)  || \
+                                 ((WEEKDAY) == RTC_WEEKDAY_FRIDAY)    || \
+                                 ((WEEKDAY) == RTC_WEEKDAY_SATURDAY)  || \
+                                 ((WEEKDAY) == RTC_WEEKDAY_SUNDAY))
+
+#define IS_RTC_ALARM_DATE_WEEKDAY_DATE(DATE) (((DATE) > 0U) && ((DATE) <= 31U))
+
+#define IS_RTC_ALARM_DATE_WEEKDAY_WEEKDAY(WEEKDAY) (((WEEKDAY) == RTC_WEEKDAY_MONDAY)    || \
+                                                    ((WEEKDAY) == RTC_WEEKDAY_TUESDAY)   || \
+                                                    ((WEEKDAY) == RTC_WEEKDAY_WEDNESDAY) || \
+                                                    ((WEEKDAY) == RTC_WEEKDAY_THURSDAY)  || \
+                                                    ((WEEKDAY) == RTC_WEEKDAY_FRIDAY)    || \
+                                                    ((WEEKDAY) == RTC_WEEKDAY_SATURDAY)  || \
+                                                    ((WEEKDAY) == RTC_WEEKDAY_SUNDAY))
+
+#define IS_RTC_ALARM_DATE_WEEKDAY_SEL(SEL) (((SEL) == RTC_ALARMDATEWEEKDAYSEL_DATE) || \
+                                            ((SEL) == RTC_ALARMDATEWEEKDAYSEL_WEEKDAY))
+
+#define IS_RTC_ALARM_MASK(MASK)  (((MASK) & ((uint32_t)~RTC_ALARMMASK_ALL)) == 0U)
+
+#define IS_RTC_ALARM(ALARM)      (((ALARM) == RTC_ALARM_A) || ((ALARM) == RTC_ALARM_B))
+
+#define IS_RTC_ALARM_SUB_SECOND_VALUE(VALUE) ((VALUE) <= RTC_ALRMASSR_SS)
+
+#define IS_RTC_ALARM_SUB_SECOND_MASK(MASK)   (((MASK) == RTC_ALARMSUBSECONDMASK_ALL)     || \
+                                              ((MASK) == RTC_ALARMSUBSECONDMASK_SS14_1)  || \
+                                              ((MASK) == RTC_ALARMSUBSECONDMASK_SS14_2)  || \
+                                              ((MASK) == RTC_ALARMSUBSECONDMASK_SS14_3)  || \
+                                              ((MASK) == RTC_ALARMSUBSECONDMASK_SS14_4)  || \
+                                              ((MASK) == RTC_ALARMSUBSECONDMASK_SS14_5)  || \
+                                              ((MASK) == RTC_ALARMSUBSECONDMASK_SS14_6)  || \
+                                              ((MASK) == RTC_ALARMSUBSECONDMASK_SS14_7)  || \
+                                              ((MASK) == RTC_ALARMSUBSECONDMASK_SS14_8)  || \
+                                              ((MASK) == RTC_ALARMSUBSECONDMASK_SS14_9)  || \
+                                              ((MASK) == RTC_ALARMSUBSECONDMASK_SS14_10) || \
+                                              ((MASK) == RTC_ALARMSUBSECONDMASK_SS14_11) || \
+                                              ((MASK) == RTC_ALARMSUBSECONDMASK_SS14_12) || \
+                                              ((MASK) == RTC_ALARMSUBSECONDMASK_SS14_13) || \
+                                              ((MASK) == RTC_ALARMSUBSECONDMASK_SS14)    || \
+                                              ((MASK) == RTC_ALARMSUBSECONDMASK_NONE))
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Private functions ---------------------------------------------------------*/
+
+/** @defgroup RTC_Private_Functions RTC Private Functions
+  * @{
+  */
+HAL_StatusTypeDef  RTC_EnterInitMode(RTC_HandleTypeDef *hrtc);
+HAL_StatusTypeDef  RTC_ExitInitMode(RTC_HandleTypeDef *hrtc);
+uint8_t            RTC_ByteToBcd2(uint8_t number);
+uint8_t            RTC_Bcd2ToByte(uint8_t number);
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* STM32F7xx_HAL_RTC_H */

--- a/lib/STM32F7xx_HAL_Driver/Inc/stm32f7xx_hal_rtc_ex.h
+++ b/lib/STM32F7xx_HAL_Driver/Inc/stm32f7xx_hal_rtc_ex.h
@@ -1,0 +1,1127 @@
+/**
+  ******************************************************************************
+  * @file    stm32f7xx_hal_rtc_ex.h
+  * @author  MCD Application Team
+  * @brief   Header file of RTC HAL Extended module.
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2017 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef STM32F7xx_HAL_RTC_EX_H
+#define STM32F7xx_HAL_RTC_EX_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+
+#include "stm32f7xx_hal_def.h"
+
+/** @addtogroup STM32F7xx_HAL_Driver
+  * @{
+  */
+
+/** @addtogroup RTCEx
+  * @{
+  */
+
+/* Exported types ------------------------------------------------------------*/
+
+/** @defgroup RTCEx_Exported_Types RTCEx Exported Types
+  * @{
+  */
+
+/**
+  * @brief  RTC Tamper structure definition
+  */
+typedef struct
+{
+  uint32_t Tamper;                      /*!< Specifies the Tamper Pin.
+                                             This parameter can be a value of @ref RTCEx_Tamper_Pin_Definitions */
+
+  uint32_t Interrupt;                   /*!< Specifies the Tamper Interrupt.
+                                             This parameter can be a value of @ref RTCEx_Tamper_Interrupt_Definitions */
+
+  uint32_t Trigger;                     /*!< Specifies the Tamper Trigger.
+                                             This parameter can be a value of @ref RTCEx_Tamper_Trigger_Definitions */
+
+  uint32_t NoErase;                     /*!< Specifies the Tamper no erase mode.
+                                             This parameter can be a value of @ref RTCEx_Tamper_EraseBackUp_Definitions */
+
+  uint32_t MaskFlag;                     /*!< Specifies the Tamper Flag masking.
+                                             This parameter can be a value of @ref RTCEx_Tamper_MaskFlag_Definitions   */
+
+  uint32_t Filter;                      /*!< Specifies the RTC Filter Tamper.
+                                             This parameter can be a value of @ref RTCEx_Tamper_Filter_Definitions */
+
+  uint32_t SamplingFrequency;           /*!< Specifies the sampling frequency.
+                                             This parameter can be a value of @ref RTCEx_Tamper_Sampling_Frequencies_Definitions */
+
+  uint32_t PrechargeDuration;           /*!< Specifies the Precharge Duration .
+                                             This parameter can be a value of @ref RTCEx_Tamper_Pin_Precharge_Duration_Definitions */
+
+  uint32_t TamperPullUp;                /*!< Specifies the Tamper PullUp .
+                                             This parameter can be a value of @ref RTCEx_Tamper_Pull_Up_Definitions */
+
+  uint32_t TimeStampOnTamperDetection;  /*!< Specifies the TimeStampOnTamperDetection.
+                                             This parameter can be a value of @ref RTCEx_Tamper_TimeStampOnTamperDetection_Definitions */
+} RTC_TamperTypeDef;
+/**
+  * @}
+  */
+
+/* Exported constants --------------------------------------------------------*/
+
+/** @defgroup RTCEx_Exported_Constants RTCEx Exported Constants
+  * @{
+  */
+
+/** @defgroup RTCEx_Backup_Registers_Definitions RTCEx Backup Registers Definitions
+  * @{
+  */
+#define RTC_BKP_DR0                       0x00000000U
+#define RTC_BKP_DR1                       0x00000001U
+#define RTC_BKP_DR2                       0x00000002U
+#define RTC_BKP_DR3                       0x00000003U
+#define RTC_BKP_DR4                       0x00000004U
+#define RTC_BKP_DR5                       0x00000005U
+#define RTC_BKP_DR6                       0x00000006U
+#define RTC_BKP_DR7                       0x00000007U
+#define RTC_BKP_DR8                       0x00000008U
+#define RTC_BKP_DR9                       0x00000009U
+#define RTC_BKP_DR10                      0x0000000AU
+#define RTC_BKP_DR11                      0x0000000BU
+#define RTC_BKP_DR12                      0x0000000CU
+#define RTC_BKP_DR13                      0x0000000DU
+#define RTC_BKP_DR14                      0x0000000EU
+#define RTC_BKP_DR15                      0x0000000FU
+#define RTC_BKP_DR16                      0x00000010U
+#define RTC_BKP_DR17                      0x00000011U
+#define RTC_BKP_DR18                      0x00000012U
+#define RTC_BKP_DR19                      0x00000013U
+#define RTC_BKP_DR20                      0x00000014U
+#define RTC_BKP_DR21                      0x00000015U
+#define RTC_BKP_DR22                      0x00000016U
+#define RTC_BKP_DR23                      0x00000017U
+#define RTC_BKP_DR24                      0x00000018U
+#define RTC_BKP_DR25                      0x00000019U
+#define RTC_BKP_DR26                      0x0000001AU
+#define RTC_BKP_DR27                      0x0000001BU
+#define RTC_BKP_DR28                      0x0000001CU
+#define RTC_BKP_DR29                      0x0000001DU
+#define RTC_BKP_DR30                      0x0000001EU
+#define RTC_BKP_DR31                      0x0000001FU
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_Timestamp_Edges_Definitions RTCEx Timestamp Edges Definitions
+  * @{
+  */
+#define RTC_TIMESTAMPEDGE_RISING          0x00000000U
+#define RTC_TIMESTAMPEDGE_FALLING         RTC_CR_TSEDGE
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_Timestamp_Pin_Selection RTC Timestamp Pin Selection
+  * @{
+  */
+#define RTC_TIMESTAMPPIN_DEFAULT            0x00000000U
+#define RTC_TIMESTAMPPIN_POS1               RTC_OR_TSINSEL_0
+#define RTC_TIMESTAMPPIN_POS2               RTC_OR_TSINSEL_1
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_Tamper_Pin_Definitions RTCEx Tamper Pins Definitions
+  * @{
+  */
+#define RTC_TAMPER_1                    RTC_TAMPCR_TAMP1E
+#define RTC_TAMPER_2                    RTC_TAMPCR_TAMP2E
+#define RTC_TAMPER_3                    RTC_TAMPCR_TAMP3E
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_Tamper_Pin_Selection RTC tamper Pins Selection
+  * @{
+  */
+#define RTC_TAMPERPIN_DEFAULT               0x00000000U
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_Tamper_Interrupt_Definitions RTCEx Tamper Interrupt Definitions
+  * @{
+  */
+#define RTC_IT_TAMP                       RTC_TAMPCR_TAMPIE   /*!< Enable global Tamper Interrupt           */
+#define RTC_IT_TAMP1                      RTC_TAMPCR_TAMP1IE  /*!< Enable Tamper 1 Interrupt                */
+#define RTC_IT_TAMP2                      RTC_TAMPCR_TAMP2IE  /*!< Enable Tamper 2 Interrupt                */
+#define RTC_IT_TAMP3                      RTC_TAMPCR_TAMP3IE  /*!< Enable Tamper 3 Interrupt                */
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_Tamper_Trigger_Definitions RTCEx Tamper Triggers Definitions
+  * @{
+  */
+#define RTC_TAMPERTRIGGER_RISINGEDGE       0x00000000U
+#define RTC_TAMPERTRIGGER_FALLINGEDGE      0x00000002U
+#define RTC_TAMPERTRIGGER_LOWLEVEL         RTC_TAMPERTRIGGER_RISINGEDGE
+#define RTC_TAMPERTRIGGER_HIGHLEVEL        RTC_TAMPERTRIGGER_FALLINGEDGE
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_Tamper_EraseBackUp_Definitions RTCEx Tamper EraseBackUp Definitions
+  * @{
+  */
+#define RTC_TAMPER_ERASE_BACKUP_ENABLE             0x00000000U
+#define RTC_TAMPER_ERASE_BACKUP_DISABLE            0x00020000U
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_Tamper_MaskFlag_Definitions RTCEx Tamper MaskFlag Definitions
+  * @{
+  */
+#define RTC_TAMPERMASK_FLAG_DISABLE                0x00000000U
+#define RTC_TAMPERMASK_FLAG_ENABLE                 0x00040000U
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_Tamper_Filter_Definitions RTCEx Tamper Filter Definitions
+  * @{
+  */
+#define RTC_TAMPERFILTER_DISABLE   0x00000000U             /*!< Tamper filter is disabled */
+
+#define RTC_TAMPERFILTER_2SAMPLE   RTC_TAMPCR_TAMPFLT_0    /*!< Tamper is activated after 2
+                                                                 consecutive samples at the active level */
+#define RTC_TAMPERFILTER_4SAMPLE   RTC_TAMPCR_TAMPFLT_1    /*!< Tamper is activated after 4
+                                                                 consecutive samples at the active level */
+#define RTC_TAMPERFILTER_8SAMPLE   RTC_TAMPCR_TAMPFLT      /*!< Tamper is activated after 8
+                                                                 consecutive samples at the active level */
+#define RTC_TAMPERFILTER_MASK      RTC_TAMPCR_TAMPFLT      /*!< Masking all bits except those of
+                                                                 field TAMPFLT                           */
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_Tamper_Sampling_Frequencies_Definitions RTCEx Tamper Sampling Frequencies Definitions
+  * @{
+  */
+#define RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV32768  0x00000000U                                     /*!< Each of the tamper inputs are sampled
+                                                                                                      with a frequency =  RTCCLK / 32768 */
+#define RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV16384  RTC_TAMPCR_TAMPFREQ_0                           /*!< Each of the tamper inputs are sampled
+                                                                                                      with a frequency =  RTCCLK / 16384 */
+#define RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV8192   RTC_TAMPCR_TAMPFREQ_1                           /*!< Each of the tamper inputs are sampled
+                                                                                                      with a frequency =  RTCCLK / 8192  */
+#define RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV4096   (RTC_TAMPCR_TAMPFREQ_0 | RTC_TAMPCR_TAMPFREQ_1) /*!< Each of the tamper inputs are sampled
+                                                                                                      with a frequency =  RTCCLK / 4096  */
+#define RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV2048   RTC_TAMPCR_TAMPFREQ_2                           /*!< Each of the tamper inputs are sampled
+                                                                                                      with a frequency =  RTCCLK / 2048  */
+#define RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV1024   (RTC_TAMPCR_TAMPFREQ_0 | RTC_TAMPCR_TAMPFREQ_2) /*!< Each of the tamper inputs are sampled
+                                                                                                      with a frequency =  RTCCLK / 1024  */
+#define RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV512    (RTC_TAMPCR_TAMPFREQ_1 | RTC_TAMPCR_TAMPFREQ_2) /*!< Each of the tamper inputs are sampled
+                                                                                                      with a frequency =  RTCCLK / 512   */
+#define RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV256    RTC_TAMPCR_TAMPFREQ                             /*!< Each of the tamper inputs are sampled
+                                                                                                      with a frequency =  RTCCLK / 256   */
+#define RTC_TAMPERSAMPLINGFREQ_RTCCLK_MASK      RTC_TAMPCR_TAMPFREQ                             /*!< Masking all bits except those of
+                                                                                                      field TAMPFREQ                     */
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_Tamper_Pin_Precharge_Duration_Definitions RTCEx Tamper Pin Precharge Duration Definitions
+  * @{
+  */
+#define RTC_TAMPERPRECHARGEDURATION_1RTCCLK     0x00000000U             /*!< Tamper pins are pre-charged before
+                                                                              sampling during 1 RTCCLK cycle  */
+#define RTC_TAMPERPRECHARGEDURATION_2RTCCLK     RTC_TAMPCR_TAMPPRCH_0   /*!< Tamper pins are pre-charged before
+                                                                              sampling during 2 RTCCLK cycles */
+#define RTC_TAMPERPRECHARGEDURATION_4RTCCLK     RTC_TAMPCR_TAMPPRCH_1   /*!< Tamper pins are pre-charged before
+                                                                              sampling during 4 RTCCLK cycles */
+#define RTC_TAMPERPRECHARGEDURATION_8RTCCLK     RTC_TAMPCR_TAMPPRCH     /*!< Tamper pins are pre-charged before
+                                                                              sampling during 8 RTCCLK cycles */
+#define RTC_TAMPERPRECHARGEDURATION_MASK        RTC_TAMPCR_TAMPPRCH     /*!< Masking all bits except those of
+                                                                              field TAMPPRCH                  */
+/**
+  * @}
+  */
+
+/** @defgroup  RTCEx_Tamper_Pull_Up_Definitions RTCEx Tamper Pull Up Definitions
+  * @{
+  */
+#define RTC_TAMPER_PULLUP_ENABLE  0x00000000U           /*!< Tamper pins are pre-charged before sampling     */
+#define RTC_TAMPER_PULLUP_DISABLE RTC_TAMPCR_TAMPPUDIS   /*!< Tamper pins are not pre-charged before sampling */
+#define RTC_TAMPER_PULLUP_MASK    RTC_TAMPCR_TAMPPUDIS   /*!< Masking all bits except bit TAMPPUDIS           */
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_Tamper_TimeStampOnTamperDetection_Definitions RTCEx Tamper TimeStamp On Tamper Detection Definitions
+  * @{
+  */
+#define RTC_TIMESTAMPONTAMPERDETECTION_ENABLE  RTC_TAMPCR_TAMPTS  /*!< TimeStamp on Tamper Detection event saved        */
+#define RTC_TIMESTAMPONTAMPERDETECTION_DISABLE 0x00000000U       /*!< TimeStamp on Tamper Detection event is not saved */
+#define RTC_TIMESTAMPONTAMPERDETECTION_MASK    RTC_TAMPCR_TAMPTS  /*!< Masking all bits except bit TAMPTS               */
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_Wakeup_Timer_Definitions RTCEx Wakeup Timer Definitions
+  * @{
+  */
+#define RTC_WAKEUPCLOCK_RTCCLK_DIV16        0x00000000U
+#define RTC_WAKEUPCLOCK_RTCCLK_DIV8         RTC_CR_WUCKSEL_0
+#define RTC_WAKEUPCLOCK_RTCCLK_DIV4         RTC_CR_WUCKSEL_1
+#define RTC_WAKEUPCLOCK_RTCCLK_DIV2         (RTC_CR_WUCKSEL_0 | RTC_CR_WUCKSEL_1)
+#define RTC_WAKEUPCLOCK_CK_SPRE_16BITS      RTC_CR_WUCKSEL_2
+#define RTC_WAKEUPCLOCK_CK_SPRE_17BITS      (RTC_CR_WUCKSEL_1 | RTC_CR_WUCKSEL_2)
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_Smooth_calib_period_Definitions RTCEx Smooth Calib Period Definitions
+  * @{
+  */
+#define RTC_SMOOTHCALIB_PERIOD_32SEC   0x00000000U      /*!< If RTCCLK = 32768 Hz, smooth calibration
+                                                              period is 32s, otherwise 2^20 RTCCLK pulses */
+#define RTC_SMOOTHCALIB_PERIOD_16SEC   RTC_CALR_CALW16  /*!< If RTCCLK = 32768 Hz, smooth calibration
+                                                              period is 16s, otherwise 2^19 RTCCLK pulses */
+#define RTC_SMOOTHCALIB_PERIOD_8SEC    RTC_CALR_CALW8   /*!< If RTCCLK = 32768 Hz, smooth calibration
+                                                              period is 8s, otherwise 2^18 RTCCLK pulses  */
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_Smooth_calib_Plus_pulses_Definitions RTCEx Smooth Calib Plus Pulses Definitions
+  * @{
+  */
+#define RTC_SMOOTHCALIB_PLUSPULSES_SET    RTC_CALR_CALP           /*!< The number of RTCCLK pulses added
+                                                                        during a X -second window = Y - CALM[8:0]
+                                                                        with Y = 512, 256, 128 when X = 32, 16, 8 */
+#define RTC_SMOOTHCALIB_PLUSPULSES_RESET  0x00000000U             /*!< The number of RTCCLK pulses subbstited
+                                                                        during a 32-second window = CALM[8:0] */
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_Add_1_Second_Parameter_Definitions RTCEx Add 1 Second Parameter Definitions
+  * @{
+  */
+#define RTC_SHIFTADD1S_RESET      0x00000000U
+#define RTC_SHIFTADD1S_SET        RTC_SHIFTR_ADD1S
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_Calib_Output_selection_Definitions RTCEx Calib Output Selection Definitions
+  * @{
+  */
+#define RTC_CALIBOUTPUT_512HZ            0x00000000U
+#define RTC_CALIBOUTPUT_1HZ              RTC_CR_COSEL
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Exported macros -----------------------------------------------------------*/
+
+/** @defgroup RTCEx_Exported_Macros RTCEx Exported Macros
+  * @{
+  */
+
+/* ---------------------------------WAKEUPTIMER-------------------------------*/
+
+/** @defgroup RTCEx_WakeUp_Timer RTCEx WakeUp Timer
+  * @{
+  */
+
+/**
+  * @brief  Enable the RTC WakeUp Timer peripheral.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_WAKEUPTIMER_ENABLE(__HANDLE__)                      ((__HANDLE__)->Instance->CR |= (RTC_CR_WUTE))
+
+/**
+  * @brief  Disable the RTC Wakeup Timer peripheral.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_WAKEUPTIMER_DISABLE(__HANDLE__)                     ((__HANDLE__)->Instance->CR &= ~(RTC_CR_WUTE))
+
+/**
+  * @brief  Enable the RTC Wakeup Timer interrupt.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @param  __INTERRUPT__ specifies the RTC Wakeup Timer interrupt sources to be enabled or disabled.
+  *         This parameter can be:
+  *            @arg RTC_IT_WUT: Wakeup Timer interrupt
+  * @retval None
+  */
+#define __HAL_RTC_WAKEUPTIMER_ENABLE_IT(__HANDLE__, __INTERRUPT__)    ((__HANDLE__)->Instance->CR |= (__INTERRUPT__))
+
+/**
+  * @brief  Disable the RTC Wakeup Timer interrupt.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @param  __INTERRUPT__ specifies the RTC Wakeup Timer interrupt sources to be enabled or disabled.
+  *         This parameter can be:
+  *            @arg RTC_IT_WUT: Wakeup Timer interrupt
+  * @retval None
+  */
+#define __HAL_RTC_WAKEUPTIMER_DISABLE_IT(__HANDLE__, __INTERRUPT__)   ((__HANDLE__)->Instance->CR &= ~(__INTERRUPT__))
+
+/**
+  * @brief  Check whether the specified RTC Wakeup Timer interrupt has occurred or not.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @param  __INTERRUPT__ specifies the RTC Wakeup Timer interrupt to check.
+  *         This parameter can be:
+  *            @arg RTC_IT_WUT: Wakeup Timer interrupt
+  * @retval None
+  */
+#define __HAL_RTC_WAKEUPTIMER_GET_IT(__HANDLE__, __INTERRUPT__)          (((((__HANDLE__)->Instance->ISR) & ((__INTERRUPT__) >> 4U)) != 0U) ? 1U : 0U)
+
+/**
+  * @brief  Check whether the specified RTC Wakeup timer interrupt has been enabled or not.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @param  __INTERRUPT__ specifies the RTC Wakeup timer interrupt sources to check.
+  *         This parameter can be:
+  *            @arg RTC_IT_WUT: WakeUpTimer interrupt
+  * @retval None
+  */
+#define __HAL_RTC_WAKEUPTIMER_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__)   (((((__HANDLE__)->Instance->CR) & (__INTERRUPT__)) != 0U) ? 1U : 0U)
+
+/**
+  * @brief  Get the selected RTC Wakeup Timer's flag status.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @param  __FLAG__ specifies the RTC Wakeup Timer flag to check.
+  *          This parameter can be:
+  *             @arg RTC_FLAG_WUTF: Wakeup Timer interrupt flag
+  *             @arg RTC_FLAG_WUTWF: Wakeup Timer 'write allowed' flag
+  * @retval None
+  */
+#define __HAL_RTC_WAKEUPTIMER_GET_FLAG(__HANDLE__, __FLAG__)          (((((__HANDLE__)->Instance->ISR) & (__FLAG__)) != 0U)? 1U : 0U)
+
+/**
+  * @brief  Clear the RTC Wakeup timer's pending flags.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @param  __FLAG__ specifies the RTC Wakeup Timer Flag to clear.
+  *         This parameter can be:
+  *             @arg RTC_FLAG_WUTF: Wakeup Timer interrupt Flag
+  * @retval None
+  */
+#define __HAL_RTC_WAKEUPTIMER_CLEAR_FLAG(__HANDLE__, __FLAG__)            ((__HANDLE__)->Instance->ISR) = (~((__FLAG__) | RTC_ISR_INIT)|((__HANDLE__)->Instance->ISR & RTC_ISR_INIT))
+
+/**
+  * @brief  Enable interrupt on the RTC Wakeup Timer associated EXTI line.
+  * @retval None
+  */
+#define __HAL_RTC_WAKEUPTIMER_EXTI_ENABLE_IT()       (EXTI->IMR |= RTC_EXTI_LINE_WAKEUPTIMER_EVENT)
+
+/**
+  * @brief  Disable interrupt on the RTC Wakeup Timer associated EXTI line.
+  * @retval None
+  */
+#define __HAL_RTC_WAKEUPTIMER_EXTI_DISABLE_IT()      (EXTI->IMR &= ~RTC_EXTI_LINE_WAKEUPTIMER_EVENT)
+
+/**
+  * @brief  Enable event on the RTC Wakeup Timer associated EXTI line.
+  * @retval None.
+  */
+#define __HAL_RTC_WAKEUPTIMER_EXTI_ENABLE_EVENT()    (EXTI->EMR |= RTC_EXTI_LINE_WAKEUPTIMER_EVENT)
+
+/**
+  * @brief  Disable event on the RTC Wakeup Timer associated EXTI line.
+  * @retval None.
+  */
+#define __HAL_RTC_WAKEUPTIMER_EXTI_DISABLE_EVENT()   (EXTI->EMR &= ~RTC_EXTI_LINE_WAKEUPTIMER_EVENT)
+
+/**
+  * @brief  Enable falling edge trigger on the RTC Wakeup Timer associated EXTI line.
+  * @retval None.
+  */
+#define __HAL_RTC_WAKEUPTIMER_EXTI_ENABLE_FALLING_EDGE()   (EXTI->FTSR |= RTC_EXTI_LINE_WAKEUPTIMER_EVENT)
+
+/**
+  * @brief  Disable falling edge trigger on the RTC Wakeup Timer associated EXTI line.
+  * @retval None.
+  */
+#define __HAL_RTC_WAKEUPTIMER_EXTI_DISABLE_FALLING_EDGE()  (EXTI->FTSR &= ~RTC_EXTI_LINE_WAKEUPTIMER_EVENT)
+
+/**
+  * @brief  Enable rising edge trigger on the RTC Wakeup Timer associated EXTI line.
+  * @retval None.
+  */
+#define __HAL_RTC_WAKEUPTIMER_EXTI_ENABLE_RISING_EDGE()    (EXTI->RTSR |= RTC_EXTI_LINE_WAKEUPTIMER_EVENT)
+
+/**
+  * @brief  Disable rising edge trigger on the RTC Wakeup Timer associated EXTI line.
+  * @retval None.
+  */
+#define __HAL_RTC_WAKEUPTIMER_EXTI_DISABLE_RISING_EDGE()   (EXTI->RTSR &= ~RTC_EXTI_LINE_WAKEUPTIMER_EVENT)
+
+/**
+  * @brief  Enable rising & falling edge trigger on the RTC Wakeup Timer associated EXTI line.
+  * @retval None.
+  */
+#define __HAL_RTC_WAKEUPTIMER_EXTI_ENABLE_RISING_FALLING_EDGE() do {                                                   \
+                                                                     __HAL_RTC_WAKEUPTIMER_EXTI_ENABLE_RISING_EDGE();  \
+                                                                     __HAL_RTC_WAKEUPTIMER_EXTI_ENABLE_FALLING_EDGE(); \
+                                                                   } while(0U)
+
+/**
+  * @brief  Disable rising & falling edge trigger on the RTC Wakeup Timer associated EXTI line.
+  * This parameter can be:
+  * @retval None.
+  */
+#define __HAL_RTC_WAKEUPTIMER_EXTI_DISABLE_RISING_FALLING_EDGE() do {                                                    \
+                                                                      __HAL_RTC_WAKEUPTIMER_EXTI_DISABLE_RISING_EDGE();  \
+                                                                      __HAL_RTC_WAKEUPTIMER_EXTI_DISABLE_FALLING_EDGE(); \
+                                                                    } while(0U)
+
+/**
+  * @brief Check whether the RTC Wakeup Timer associated EXTI line interrupt flag is set or not.
+  * @retval Line Status.
+  */
+#define __HAL_RTC_WAKEUPTIMER_EXTI_GET_FLAG()              (EXTI->PR & RTC_EXTI_LINE_WAKEUPTIMER_EVENT)
+
+/**
+  * @brief Clear the RTC Wakeup Timer associated EXTI line flag.
+  * @retval None.
+  */
+#define __HAL_RTC_WAKEUPTIMER_EXTI_CLEAR_FLAG()            (EXTI->PR = RTC_EXTI_LINE_WAKEUPTIMER_EVENT)
+
+/**
+  * @brief Generate a Software interrupt on the RTC Wakeup Timer associated EXTI line.
+  * @retval None.
+  */
+#define __HAL_RTC_WAKEUPTIMER_EXTI_GENERATE_SWIT()         (EXTI->SWIER |= RTC_EXTI_LINE_WAKEUPTIMER_EVENT)
+
+/**
+  * @}
+  */
+
+/* ---------------------------------TIMESTAMP---------------------------------*/
+
+/** @defgroup RTCEx_Timestamp RTCEx Timestamp
+  * @{
+  */
+
+/**
+  * @brief  Enable the RTC Timestamp peripheral.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_TIMESTAMP_ENABLE(__HANDLE__)                        ((__HANDLE__)->Instance->CR |= (RTC_CR_TSE))
+
+/**
+  * @brief  Disable the RTC Timestamp peripheral.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_TIMESTAMP_DISABLE(__HANDLE__)                       ((__HANDLE__)->Instance->CR &= ~(RTC_CR_TSE))
+
+/**
+  * @brief  Enable the RTC Timestamp interrupt.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @param  __INTERRUPT__ specifies the RTC Timestamp interrupt sources to be enabled or disabled.
+  *         This parameter can be:
+  *            @arg RTC_IT_TS: TimeStamp interrupt
+  * @retval None
+  */
+#define __HAL_RTC_TIMESTAMP_ENABLE_IT(__HANDLE__, __INTERRUPT__)      ((__HANDLE__)->Instance->CR |= (__INTERRUPT__))
+
+/**
+  * @brief  Disable the RTC Timestamp interrupt.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @param  __INTERRUPT__ specifies the RTC Timestamp interrupt sources to be enabled or disabled.
+  *         This parameter can be:
+  *            @arg RTC_IT_TS: TimeStamp interrupt
+  * @retval None
+  */
+#define __HAL_RTC_TIMESTAMP_DISABLE_IT(__HANDLE__, __INTERRUPT__)     ((__HANDLE__)->Instance->CR &= ~(__INTERRUPT__))
+
+/**
+  * @brief  Check whether the specified RTC Timestamp interrupt has occurred or not.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @param  __INTERRUPT__ specifies the RTC Timestamp interrupt to check.
+  *         This parameter can be:
+  *            @arg RTC_IT_TS: TimeStamp interrupt
+  * @retval None
+  */
+#define __HAL_RTC_TIMESTAMP_GET_IT(__HANDLE__, __INTERRUPT__)         (((((__HANDLE__)->Instance->ISR) & ((__INTERRUPT__) >> 4U)) != 0U) ? 1U : 0U)
+
+/**
+  * @brief  Check whether the specified RTC Timestamp interrupt has been enabled or not.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @param  __INTERRUPT__ specifies the RTC Timestamp interrupt source to check.
+  *         This parameter can be:
+  *            @arg RTC_IT_TS: TimeStamp interrupt
+  * @retval None
+  */
+#define __HAL_RTC_TIMESTAMP_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__)     (((((__HANDLE__)->Instance->CR) & (__INTERRUPT__)) != 0U) ? 1U : 0U)
+
+/**
+  * @brief  Get the selected RTC Timestamp's flag status.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @param  __FLAG__ specifies the RTC Timestamp flag to check.
+  *         This parameter can be:
+  *            @arg RTC_FLAG_TSF: Timestamp interrupt flag
+  *            @arg RTC_FLAG_TSOVF: Timestamp overflow flag
+  * @retval None
+  */
+#define __HAL_RTC_TIMESTAMP_GET_FLAG(__HANDLE__, __FLAG__)            (((((__HANDLE__)->Instance->ISR) & (__FLAG__)) != 0U)? 1U : 0U)
+
+/**
+  * @brief  Clear the RTC Timestamp's pending flags.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @param  __FLAG__ specifies the RTC Timestamp flag to clear.
+  *         This parameter can be:
+  *            @arg RTC_FLAG_TSF: Timestamp interrupt flag
+  *            @arg RTC_FLAG_TSOVF: Timestamp overflow flag
+  * @retval None
+  */
+#define __HAL_RTC_TIMESTAMP_CLEAR_FLAG(__HANDLE__, __FLAG__)          ((__HANDLE__)->Instance->ISR) = (~((__FLAG__) | RTC_ISR_INIT)|((__HANDLE__)->Instance->ISR & RTC_ISR_INIT))
+
+/**
+  * @brief  Enable the RTC internal TimeStamp peripheral.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_INTERNAL_TIMESTAMP_ENABLE(__HANDLE__)                ((__HANDLE__)->Instance->CR |= (RTC_CR_ITSE))
+
+/**
+  * @brief  Disable the RTC internal TimeStamp peripheral.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_INTERNAL_TIMESTAMP_DISABLE(__HANDLE__)               ((__HANDLE__)->Instance->CR &= ~(RTC_CR_ITSE))
+
+/**
+  * @brief  Get the selected RTC Internal Timestamp's flag status.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @param  __FLAG__ specifies the RTC Internal Timestamp flag is pending or not.
+  *         This parameter can be:
+  *            @arg RTC_FLAG_ITSF: Internal Timestamp interrupt flag
+  * @retval None
+  */
+#define __HAL_RTC_INTERNAL_TIMESTAMP_GET_FLAG(__HANDLE__, __FLAG__)    (((((__HANDLE__)->Instance->ISR) & (__FLAG__)) != 0U) ? 1U : 0U)
+
+/**
+  * @brief  Clear the RTC Internal Timestamp's pending flags.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @param  __FLAG__ specifies the RTC Internal Timestamp flag to clear.
+  *          This parameter can be:
+  *            @arg RTC_FLAG_ITSF: Internal Timestamp interrupt flag
+  * @retval None
+  */
+#define __HAL_RTC_INTERNAL_TIMESTAMP_CLEAR_FLAG(__HANDLE__, __FLAG__)  ((__HANDLE__)->Instance->ISR) = (~(((__FLAG__) | RTC_ISR_INIT)& 0x0003FFFFU)|((__HANDLE__)->Instance->ISR & RTC_ISR_INIT))
+
+/**
+  * @}
+  */
+
+/* ---------------------------------TAMPER------------------------------------*/
+
+/** @defgroup RTCEx_Tamper RTCEx Tamper
+  * @{
+  */
+
+/**
+  * @brief  Enable the RTC Tamper1 input detection.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_TAMPER1_ENABLE(__HANDLE__)                         ((__HANDLE__)->Instance->TAMPCR |= (RTC_TAMPCR_TAMP1E))
+
+/**
+  * @brief  Disable the RTC Tamper1 input detection.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_TAMPER1_DISABLE(__HANDLE__)                        ((__HANDLE__)->Instance->TAMPCR &= ~(RTC_TAMPCR_TAMP1E))
+
+/**
+  * @brief  Enable the RTC Tamper2 input detection.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_TAMPER2_ENABLE(__HANDLE__)                         ((__HANDLE__)->Instance->TAMPCR |= (RTC_TAMPCR_TAMP2E))
+
+/**
+  * @brief  Disable the RTC Tamper2 input detection.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_TAMPER2_DISABLE(__HANDLE__)                        ((__HANDLE__)->Instance->TAMPCR &= ~(RTC_TAMPCR_TAMP2E))
+
+/**
+  * @brief  Enable the RTC Tamper3 input detection.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_TAMPER3_ENABLE(__HANDLE__)                         ((__HANDLE__)->Instance->TAMPCR |= (RTC_TAMPCR_TAMP3E))
+
+/**
+  * @brief  Disable the RTC Tamper3 input detection.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_TAMPER3_DISABLE(__HANDLE__)                        ((__HANDLE__)->Instance->TAMPCR &= ~(RTC_TAMPCR_TAMP3E))
+
+/**
+  * @brief  Enable the RTC Tamper interrupt.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @param  __INTERRUPT__ specifies the RTC Tamper interrupt sources to be enabled.
+  *          This parameter can be any combination of the following values:
+  *            @arg RTC_IT_TAMP: Tamper global interrupt
+  *            @arg RTC_IT_TAMP1: Tamper 1 interrupt
+  *            @arg RTC_IT_TAMP2: Tamper 2 interrupt
+  *            @arg RTC_IT_TAMP3: Tamper 3 interrupt
+  * @retval None
+  */
+#define __HAL_RTC_TAMPER_ENABLE_IT(__HANDLE__, __INTERRUPT__)        ((__HANDLE__)->Instance->TAMPCR |= (__INTERRUPT__))
+
+/**
+  * @brief  Disable the RTC Tamper interrupt.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @param  __INTERRUPT__ specifies the RTC Tamper interrupt sources to be disabled.
+  *         This parameter can be any combination of the following values:
+  *            @arg RTC_IT_TAMP: Tamper global interrupt
+  *            @arg RTC_IT_TAMP1: Tamper 1 interrupt
+  *            @arg RTC_IT_TAMP2: Tamper 2 interrupt
+  *            @arg RTC_IT_TAMP3: Tamper 3 interrupt
+  * @retval None
+  */
+#define __HAL_RTC_TAMPER_DISABLE_IT(__HANDLE__, __INTERRUPT__)       ((__HANDLE__)->Instance->TAMPCR &= ~(__INTERRUPT__))
+
+/**
+  * @brief  Check whether the specified RTC Tamper interrupt has been enabled or not.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @param  __INTERRUPT__ specifies the RTC Tamper interrupt source to check.
+  *         This parameter can be:
+  *            @arg RTC_IT_TAMP: Tamper global interrupt
+  *            @arg RTC_IT_TAMP1: Tamper 1 interrupt
+  *            @arg RTC_IT_TAMP2: Tamper 2 interrupt
+  *            @arg RTC_IT_TAMP3: Tamper 3 interrupt
+  * @retval None
+  */
+#define __HAL_RTC_TAMPER_GET_IT_SOURCE(__HANDLE__, __INTERRUPT__)     (((((__HANDLE__)->Instance->TAMPCR) & (__INTERRUPT__)) != 0U) ? 1U : 0U)
+
+/**
+  * @brief  Get the selected RTC Tamper's flag status.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @param  __FLAG__ specifies the RTC Tamper flag to be checked.
+  *          This parameter can be:
+  *             @arg RTC_FLAG_TAMP1F: Tamper 1 interrupt flag
+  *             @arg RTC_FLAG_TAMP2F: Tamper 2 interrupt flag
+  *             @arg RTC_FLAG_TAMP3F: Tamper 3 interrupt flag
+  * @retval None
+  */
+#define __HAL_RTC_TAMPER_GET_FLAG(__HANDLE__, __FLAG__)               (((((__HANDLE__)->Instance->ISR) & (__FLAG__)) != 0U)? 1U : 0U)
+
+/**
+  * @brief  Clear the RTC Tamper's pending flags.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @param  __FLAG__ specifies the RTC Tamper Flag to clear.
+  *          This parameter can be:
+  *             @arg RTC_FLAG_TAMP1F: Tamper 1 interrupt flag
+  *             @arg RTC_FLAG_TAMP2F: Tamper 2 interrupt flag
+  *             @arg RTC_FLAG_TAMP3F: Tamper 3 interrupt flag
+  * @retval None
+  */
+#define __HAL_RTC_TAMPER_CLEAR_FLAG(__HANDLE__, __FLAG__)         ((__HANDLE__)->Instance->ISR) = (~((__FLAG__) | RTC_ISR_INIT)|((__HANDLE__)->Instance->ISR & RTC_ISR_INIT))
+/**
+  * @}
+  */
+
+/* --------------------------TAMPER/TIMESTAMP---------------------------------*/
+/** @defgroup RTCEx_Tamper_Timestamp EXTI RTC Tamper Timestamp EXTI
+  * @{
+  */
+
+/**
+  * @brief  Enable interrupt on the RTC Tamper and Timestamp associated EXTI line.
+  * @retval None
+  */
+#define __HAL_RTC_TAMPER_TIMESTAMP_EXTI_ENABLE_IT()        (EXTI->IMR |= RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT)
+
+/**
+  * @brief  Disable interrupt on the RTC Tamper and Timestamp associated EXTI line.
+  * @retval None
+  */
+#define __HAL_RTC_TAMPER_TIMESTAMP_EXTI_DISABLE_IT()       (EXTI->IMR &= ~RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT)
+
+/**
+  * @brief  Enable event on the RTC Tamper and Timestamp associated EXTI line.
+  * @retval None.
+  */
+#define __HAL_RTC_TAMPER_TIMESTAMP_EXTI_ENABLE_EVENT()    (EXTI->EMR |= RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT)
+
+/**
+  * @brief  Disable event on the RTC Tamper and Timestamp associated EXTI line.
+  * @retval None.
+  */
+#define __HAL_RTC_TAMPER_TIMESTAMP_EXTI_DISABLE_EVENT()   (EXTI->EMR &= ~RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT)
+
+/**
+  * @brief  Enable falling edge trigger on the RTC Tamper and Timestamp associated EXTI line.
+  * @retval None.
+  */
+#define __HAL_RTC_TAMPER_TIMESTAMP_EXTI_ENABLE_FALLING_EDGE()   (EXTI->FTSR |= RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT)
+
+/**
+  * @brief  Disable falling edge trigger on the RTC Tamper and Timestamp associated EXTI line.
+  * @retval None.
+  */
+#define __HAL_RTC_TAMPER_TIMESTAMP_EXTI_DISABLE_FALLING_EDGE()  (EXTI->FTSR &= ~RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT)
+
+/**
+  * @brief  Enable rising edge trigger on the RTC Tamper and Timestamp associated EXTI line.
+  * @retval None.
+  */
+#define __HAL_RTC_TAMPER_TIMESTAMP_EXTI_ENABLE_RISING_EDGE()    (EXTI->RTSR |= RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT)
+
+/**
+  * @brief  Disable rising edge trigger on the RTC Tamper and Timestamp associated EXTI line.
+  * @retval None.
+  */
+#define __HAL_RTC_TAMPER_TIMESTAMP_EXTI_DISABLE_RISING_EDGE()   (EXTI->RTSR &= ~RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT)
+
+/**
+  * @brief  Enable rising & falling edge trigger on the RTC Tamper and Timestamp associated EXTI line.
+  * @retval None.
+  */
+#define __HAL_RTC_TAMPER_TIMESTAMP_EXTI_ENABLE_RISING_FALLING_EDGE() do {                                                        \
+                                                                          __HAL_RTC_TAMPER_TIMESTAMP_EXTI_ENABLE_RISING_EDGE();  \
+                                                                          __HAL_RTC_TAMPER_TIMESTAMP_EXTI_ENABLE_FALLING_EDGE(); \
+                                                                        } while(0U)
+
+/**
+  * @brief  Disable rising & falling edge trigger on the RTC Tamper and Timestamp associated EXTI line.
+  * This parameter can be:
+  * @retval None.
+  */
+#define __HAL_RTC_TAMPER_TIMESTAMP_EXTI_DISABLE_RISING_FALLING_EDGE() do {                                                         \
+                                                                           __HAL_RTC_TAMPER_TIMESTAMP_EXTI_DISABLE_RISING_EDGE();  \
+                                                                           __HAL_RTC_TAMPER_TIMESTAMP_EXTI_DISABLE_FALLING_EDGE(); \
+                                                                         } while(0U)
+
+/**
+  * @brief Check whether the RTC Tamper and Timestamp associated EXTI line interrupt flag is set or not.
+  * @retval Line Status.
+  */
+#define __HAL_RTC_TAMPER_TIMESTAMP_EXTI_GET_FLAG()         (EXTI->PR & RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT)
+
+/**
+  * @brief Clear the RTC Tamper and Timestamp associated EXTI line flag.
+  * @retval None.
+  */
+#define __HAL_RTC_TAMPER_TIMESTAMP_EXTI_CLEAR_FLAG()       (EXTI->PR = RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT)
+
+/**
+  * @brief Generate a Software interrupt on the RTC Tamper and Timestamp associated EXTI line
+  * @retval None.
+  */
+#define __HAL_RTC_TAMPER_TIMESTAMP_EXTI_GENERATE_SWIT()    (EXTI->SWIER |= RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT)
+/**
+  * @}
+  */
+
+/* ------------------------------CALIBRATION----------------------------------*/
+
+/** @defgroup RTCEx_Calibration RTCEx Calibration
+  * @{
+  */
+
+/**
+  * @brief  Enable the RTC calibration output.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_CALIBRATION_OUTPUT_ENABLE(__HANDLE__)                 ((__HANDLE__)->Instance->CR |= (RTC_CR_COE))
+
+/**
+  * @brief  Disable the calibration output.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_CALIBRATION_OUTPUT_DISABLE(__HANDLE__)                ((__HANDLE__)->Instance->CR &= ~(RTC_CR_COE))
+
+/**
+  * @brief  Enable the clock reference detection.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_CLOCKREF_DETECTION_ENABLE(__HANDLE__)                 ((__HANDLE__)->Instance->CR |= (RTC_CR_REFCKON))
+
+/**
+  * @brief  Disable the clock reference detection.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @retval None
+  */
+#define __HAL_RTC_CLOCKREF_DETECTION_DISABLE(__HANDLE__)                ((__HANDLE__)->Instance->CR &= ~(RTC_CR_REFCKON))
+
+/**
+  * @brief  Get the selected RTC shift operation's flag status.
+  * @param  __HANDLE__ specifies the RTC handle.
+  * @param  __FLAG__ specifies the RTC shift operation Flag is pending or not.
+  *          This parameter can be:
+  *             @arg RTC_FLAG_SHPF: Shift pending flag
+  * @retval None
+  */
+#define __HAL_RTC_SHIFT_GET_FLAG(__HANDLE__, __FLAG__)                (((((__HANDLE__)->Instance->ISR) & (__FLAG__)) != 0U)? 1U : 0U)
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Exported functions --------------------------------------------------------*/
+
+/** @defgroup RTCEx_Exported_Functions RTCEx Exported Functions
+  * @{
+  */
+
+/** @addtogroup RTCEx_Exported_Functions_Group1
+  * @{
+  */
+/* RTC Timestamp and Tamper functions *****************************************/
+HAL_StatusTypeDef HAL_RTCEx_SetTimeStamp(RTC_HandleTypeDef *hrtc, uint32_t RTC_TimeStampEdge, uint32_t RTC_TimeStampPin);
+HAL_StatusTypeDef HAL_RTCEx_SetTimeStamp_IT(RTC_HandleTypeDef *hrtc, uint32_t RTC_TimeStampEdge, uint32_t RTC_TimeStampPin);
+HAL_StatusTypeDef HAL_RTCEx_DeactivateTimeStamp(RTC_HandleTypeDef *hrtc);
+HAL_StatusTypeDef HAL_RTCEx_SetInternalTimeStamp(RTC_HandleTypeDef *hrtc);
+HAL_StatusTypeDef HAL_RTCEx_DeactivateInternalTimeStamp(RTC_HandleTypeDef *hrtc);
+HAL_StatusTypeDef HAL_RTCEx_GetTimeStamp(RTC_HandleTypeDef *hrtc, RTC_TimeTypeDef *sTimeStamp, RTC_DateTypeDef *sTimeStampDate, uint32_t Format);
+
+HAL_StatusTypeDef HAL_RTCEx_SetTamper(RTC_HandleTypeDef *hrtc, RTC_TamperTypeDef *sTamper);
+HAL_StatusTypeDef HAL_RTCEx_SetTamper_IT(RTC_HandleTypeDef *hrtc, RTC_TamperTypeDef *sTamper);
+HAL_StatusTypeDef HAL_RTCEx_DeactivateTamper(RTC_HandleTypeDef *hrtc, uint32_t Tamper);
+void              HAL_RTCEx_TamperTimeStampIRQHandler(RTC_HandleTypeDef *hrtc);
+
+void              HAL_RTCEx_Tamper1EventCallback(RTC_HandleTypeDef *hrtc);
+void              HAL_RTCEx_Tamper2EventCallback(RTC_HandleTypeDef *hrtc);
+void              HAL_RTCEx_Tamper3EventCallback(RTC_HandleTypeDef *hrtc);
+void              HAL_RTCEx_TimeStampEventCallback(RTC_HandleTypeDef *hrtc);
+HAL_StatusTypeDef HAL_RTCEx_PollForTimeStampEvent(RTC_HandleTypeDef *hrtc, uint32_t Timeout);
+HAL_StatusTypeDef HAL_RTCEx_PollForTamper1Event(RTC_HandleTypeDef *hrtc, uint32_t Timeout);
+HAL_StatusTypeDef HAL_RTCEx_PollForTamper2Event(RTC_HandleTypeDef *hrtc, uint32_t Timeout);
+HAL_StatusTypeDef HAL_RTCEx_PollForTamper3Event(RTC_HandleTypeDef *hrtc, uint32_t Timeout);
+/**
+  * @}
+  */
+
+/** @addtogroup RTCEx_Exported_Functions_Group2
+  * @{
+  */
+/* RTC Wakeup functions ******************************************************/
+HAL_StatusTypeDef HAL_RTCEx_SetWakeUpTimer(RTC_HandleTypeDef *hrtc, uint32_t WakeUpCounter, uint32_t WakeUpClock);
+HAL_StatusTypeDef HAL_RTCEx_SetWakeUpTimer_IT(RTC_HandleTypeDef *hrtc, uint32_t WakeUpCounter, uint32_t WakeUpClock);
+HAL_StatusTypeDef HAL_RTCEx_DeactivateWakeUpTimer(RTC_HandleTypeDef *hrtc);
+uint32_t          HAL_RTCEx_GetWakeUpTimer(RTC_HandleTypeDef *hrtc);
+void              HAL_RTCEx_WakeUpTimerIRQHandler(RTC_HandleTypeDef *hrtc);
+void              HAL_RTCEx_WakeUpTimerEventCallback(RTC_HandleTypeDef *hrtc);
+HAL_StatusTypeDef HAL_RTCEx_PollForWakeUpTimerEvent(RTC_HandleTypeDef *hrtc, uint32_t Timeout);
+/**
+  * @}
+  */
+
+/** @addtogroup RTCEx_Exported_Functions_Group3
+  * @{
+  */
+/* Extended Control functions ************************************************/
+void              HAL_RTCEx_BKUPWrite(RTC_HandleTypeDef *hrtc, uint32_t BackupRegister, uint32_t Data);
+uint32_t          HAL_RTCEx_BKUPRead(RTC_HandleTypeDef *hrtc, uint32_t BackupRegister);
+
+HAL_StatusTypeDef HAL_RTCEx_SetSmoothCalib(RTC_HandleTypeDef *hrtc, uint32_t SmoothCalibPeriod, uint32_t SmoothCalibPlusPulses, uint32_t SmoothCalibMinusPulsesValue);
+HAL_StatusTypeDef HAL_RTCEx_SetSynchroShift(RTC_HandleTypeDef *hrtc, uint32_t ShiftAdd1S, uint32_t ShiftSubFS);
+HAL_StatusTypeDef HAL_RTCEx_SetCalibrationOutPut(RTC_HandleTypeDef *hrtc, uint32_t CalibOutput);
+HAL_StatusTypeDef HAL_RTCEx_DeactivateCalibrationOutPut(RTC_HandleTypeDef *hrtc);
+HAL_StatusTypeDef HAL_RTCEx_SetRefClock(RTC_HandleTypeDef *hrtc);
+HAL_StatusTypeDef HAL_RTCEx_DeactivateRefClock(RTC_HandleTypeDef *hrtc);
+HAL_StatusTypeDef HAL_RTCEx_EnableBypassShadow(RTC_HandleTypeDef *hrtc);
+HAL_StatusTypeDef HAL_RTCEx_DisableBypassShadow(RTC_HandleTypeDef *hrtc);
+/**
+  * @}
+  */
+
+/** @addtogroup RTCEx_Exported_Functions_Group4
+  * @{
+  */
+/* Extended RTC features functions *******************************************/
+void HAL_RTCEx_AlarmBEventCallback(RTC_HandleTypeDef *hrtc);
+HAL_StatusTypeDef HAL_RTCEx_PollForAlarmBEvent(RTC_HandleTypeDef *hrtc, uint32_t Timeout);
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Private types -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private constants ---------------------------------------------------------*/
+
+/** @defgroup RTCEx_Private_Constants RTCEx Private Constants
+  * @{
+  */
+#define RTC_EXTI_LINE_TAMPER_TIMESTAMP_EVENT  EXTI_IMR_IM21  /*!< External interrupt line 21 Connected to the RTC Tamper and Timestamp event */
+#define RTC_EXTI_LINE_WAKEUPTIMER_EVENT       EXTI_IMR_IM22  /*!< External interrupt line 22 Connected to the RTC Wakeup event */
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_Private_Constants RTCEx Private Constants
+  * @{
+  */
+/* Masks Definition */
+#define RTC_TAMPER_ENABLE_BITS_MASK         ((uint32_t) (RTC_TAMPER_1 | \
+                                                         RTC_TAMPER_2 | \
+                                                         RTC_TAMPER_3))
+
+#define RTC_TAMPER_FLAGS_MASK               ((uint32_t) (RTC_FLAG_TAMP1F | \
+                                                         RTC_FLAG_TAMP2F | \
+                                                         RTC_FLAG_TAMP3F))
+
+#define RTC_TAMPER_IT_ENABLE_BITS_MASK      ((uint32_t) (RTC_IT_TAMP1 | \
+                                                         RTC_IT_TAMP2 | \
+                                                         RTC_IT_TAMP3 | \
+                                                         RTC_IT_TAMP))
+/**
+  * @}
+  */
+
+/* Private macros ------------------------------------------------------------*/
+
+/** @defgroup RTCEx_Private_Macros RTCEx Private Macros
+  * @{
+  */
+
+/** @defgroup RTCEx_IS_RTC_Definitions Private macros to check input parameters
+  * @{
+  */
+#define IS_RTC_BKP(BKP)     ((BKP) < (uint32_t) RTC_BKP_NUMBER)
+
+#define IS_TIMESTAMP_EDGE(EDGE) (((EDGE) == RTC_TIMESTAMPEDGE_RISING) || \
+                                 ((EDGE) == RTC_TIMESTAMPEDGE_FALLING))
+
+#define IS_RTC_TAMPER(TAMPER) ((((TAMPER) & ((uint32_t)~RTC_TAMPER_ENABLE_BITS_MASK)) == 0x00U) && ((TAMPER) != 0U))
+
+#define IS_RTC_TAMPER_PIN(PIN) ((PIN) == RTC_TAMPERPIN_DEFAULT)
+
+#define IS_RTC_TIMESTAMP_PIN(PIN) (((PIN) == RTC_TIMESTAMPPIN_DEFAULT) || \
+                                   ((PIN) == RTC_TIMESTAMPPIN_POS1)    || \
+                                   ((PIN) == RTC_TIMESTAMPPIN_POS2))
+
+#define IS_RTC_TAMPER_INTERRUPT(INTERRUPT) ((((INTERRUPT) & ((uint32_t)~RTC_TAMPER_IT_ENABLE_BITS_MASK  )) == 0x00U) && ((INTERRUPT) != 0U))
+
+#define IS_RTC_TAMPER_TRIGGER(TRIGGER) (((TRIGGER) == RTC_TAMPERTRIGGER_RISINGEDGE)  || \
+                                        ((TRIGGER) == RTC_TAMPERTRIGGER_FALLINGEDGE) || \
+                                        ((TRIGGER) == RTC_TAMPERTRIGGER_LOWLEVEL)    || \
+                                        ((TRIGGER) == RTC_TAMPERTRIGGER_HIGHLEVEL))
+
+#define IS_RTC_TAMPER_ERASE_MODE(MODE)          (((MODE) == RTC_TAMPER_ERASE_BACKUP_ENABLE) || \
+                                                 ((MODE) == RTC_TAMPER_ERASE_BACKUP_DISABLE))
+
+#define IS_RTC_TAMPER_MASKFLAG_STATE(STATE)     (((STATE) == RTC_TAMPERMASK_FLAG_ENABLE) || \
+                                                 ((STATE) == RTC_TAMPERMASK_FLAG_DISABLE))
+
+#define IS_RTC_TAMPER_FILTER(FILTER)  (((FILTER) == RTC_TAMPERFILTER_DISABLE) || \
+                                       ((FILTER) == RTC_TAMPERFILTER_2SAMPLE) || \
+                                       ((FILTER) == RTC_TAMPERFILTER_4SAMPLE) || \
+                                       ((FILTER) == RTC_TAMPERFILTER_8SAMPLE))
+
+#define IS_RTC_TAMPER_FILTER_CONFIG_CORRECT(FILTER, TRIGGER)                  \
+                        (  (  ((FILTER) != RTC_TAMPERFILTER_DISABLE)          \
+                           && (  ((TRIGGER) == RTC_TAMPERTRIGGER_LOWLEVEL)    \
+                              || ((TRIGGER) == RTC_TAMPERTRIGGER_HIGHLEVEL))) \
+                        || (  ((FILTER) == RTC_TAMPERFILTER_DISABLE)          \
+                           && (  ((TRIGGER) == RTC_TAMPERTRIGGER_RISINGEDGE)  \
+                              || ((TRIGGER) == RTC_TAMPERTRIGGER_FALLINGEDGE))))
+
+#define IS_RTC_TAMPER_SAMPLING_FREQ(FREQ) (((FREQ) == RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV32768)|| \
+                                           ((FREQ) == RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV16384)|| \
+                                           ((FREQ) == RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV8192) || \
+                                           ((FREQ) == RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV4096) || \
+                                           ((FREQ) == RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV2048) || \
+                                           ((FREQ) == RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV1024) || \
+                                           ((FREQ) == RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV512)  || \
+                                           ((FREQ) == RTC_TAMPERSAMPLINGFREQ_RTCCLK_DIV256))
+
+#define IS_RTC_TAMPER_PRECHARGE_DURATION(DURATION) (((DURATION) == RTC_TAMPERPRECHARGEDURATION_1RTCCLK) || \
+                                                    ((DURATION) == RTC_TAMPERPRECHARGEDURATION_2RTCCLK) || \
+                                                    ((DURATION) == RTC_TAMPERPRECHARGEDURATION_4RTCCLK) || \
+                                                    ((DURATION) == RTC_TAMPERPRECHARGEDURATION_8RTCCLK))
+
+#define IS_RTC_TAMPER_PULLUP_STATE(STATE) (((STATE) == RTC_TAMPER_PULLUP_ENABLE) || \
+                                           ((STATE) == RTC_TAMPER_PULLUP_DISABLE))
+
+#define IS_RTC_TAMPER_TIMESTAMPONTAMPER_DETECTION(DETECTION) (((DETECTION) == RTC_TIMESTAMPONTAMPERDETECTION_ENABLE) || \
+                                                              ((DETECTION) == RTC_TIMESTAMPONTAMPERDETECTION_DISABLE))
+
+#define IS_RTC_WAKEUP_CLOCK(CLOCK) (((CLOCK) == RTC_WAKEUPCLOCK_RTCCLK_DIV16)   || \
+                                    ((CLOCK) == RTC_WAKEUPCLOCK_RTCCLK_DIV8)    || \
+                                    ((CLOCK) == RTC_WAKEUPCLOCK_RTCCLK_DIV4)    || \
+                                    ((CLOCK) == RTC_WAKEUPCLOCK_RTCCLK_DIV2)    || \
+                                    ((CLOCK) == RTC_WAKEUPCLOCK_CK_SPRE_16BITS) || \
+                                    ((CLOCK) == RTC_WAKEUPCLOCK_CK_SPRE_17BITS))
+
+#define IS_RTC_WAKEUP_COUNTER(COUNTER)  ((COUNTER) <= RTC_WUTR_WUT)
+
+#define IS_RTC_SMOOTH_CALIB_PERIOD(PERIOD) (((PERIOD) == RTC_SMOOTHCALIB_PERIOD_32SEC) || \
+                                            ((PERIOD) == RTC_SMOOTHCALIB_PERIOD_16SEC) || \
+                                            ((PERIOD) == RTC_SMOOTHCALIB_PERIOD_8SEC))
+
+#define IS_RTC_SMOOTH_CALIB_PLUS(PLUS) (((PLUS) == RTC_SMOOTHCALIB_PLUSPULSES_SET) || \
+                                        ((PLUS) == RTC_SMOOTHCALIB_PLUSPULSES_RESET))
+
+#define  IS_RTC_SMOOTH_CALIB_MINUS(VALUE) ((VALUE) <= RTC_CALR_CALM)
+
+#define IS_RTC_SHIFT_ADD1S(SEL) (((SEL) == RTC_SHIFTADD1S_RESET) || \
+                                 ((SEL) == RTC_SHIFTADD1S_SET))
+
+#define IS_RTC_SHIFT_SUBFS(FS) ((FS) <= RTC_SHIFTR_SUBFS)
+
+#define IS_RTC_CALIB_OUTPUT(OUTPUT)  (((OUTPUT) == RTC_CALIBOUTPUT_512HZ) || \
+                                      ((OUTPUT) == RTC_CALIBOUTPUT_1HZ))
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* STM32F7xx_HAL_RTC_EX_H */

--- a/lib/STM32F7xx_HAL_Driver/Inc/stm32f7xx_hal_spi_ex.h
+++ b/lib/STM32F7xx_HAL_Driver/Inc/stm32f7xx_hal_spi_ex.h
@@ -48,7 +48,7 @@ extern "C" {
 /** @addtogroup SPIEx_Exported_Functions_Group1
   * @{
   */
-HAL_StatusTypeDef HAL_SPIEx_FlushRxFifo(SPI_HandleTypeDef *hspi);
+HAL_StatusTypeDef HAL_SPIEx_FlushRxFifo(const SPI_HandleTypeDef *hspi);
 /**
   * @}
   */

--- a/lib/STM32F7xx_HAL_Driver/Inc/stm32f7xx_hal_tim.h
+++ b/lib/STM32F7xx_HAL_Driver/Inc/stm32f7xx_hal_tim.h
@@ -398,29 +398,28 @@ typedef struct
   */
 typedef enum
 {
-  HAL_TIM_BASE_MSPINIT_CB_ID              = 0x00U   /*!< TIM Base MspInit Callback ID                              */
-  , HAL_TIM_BASE_MSPDEINIT_CB_ID          = 0x01U   /*!< TIM Base MspDeInit Callback ID                            */
-  , HAL_TIM_IC_MSPINIT_CB_ID              = 0x02U   /*!< TIM IC MspInit Callback ID                                */
-  , HAL_TIM_IC_MSPDEINIT_CB_ID            = 0x03U   /*!< TIM IC MspDeInit Callback ID                              */
-  , HAL_TIM_OC_MSPINIT_CB_ID              = 0x04U   /*!< TIM OC MspInit Callback ID                                */
-  , HAL_TIM_OC_MSPDEINIT_CB_ID            = 0x05U   /*!< TIM OC MspDeInit Callback ID                              */
-  , HAL_TIM_PWM_MSPINIT_CB_ID             = 0x06U   /*!< TIM PWM MspInit Callback ID                               */
-  , HAL_TIM_PWM_MSPDEINIT_CB_ID           = 0x07U   /*!< TIM PWM MspDeInit Callback ID                             */
-  , HAL_TIM_ONE_PULSE_MSPINIT_CB_ID       = 0x08U   /*!< TIM One Pulse MspInit Callback ID                         */
-  , HAL_TIM_ONE_PULSE_MSPDEINIT_CB_ID     = 0x09U   /*!< TIM One Pulse MspDeInit Callback ID                       */
-  , HAL_TIM_ENCODER_MSPINIT_CB_ID         = 0x0AU   /*!< TIM Encoder MspInit Callback ID                           */
-  , HAL_TIM_ENCODER_MSPDEINIT_CB_ID       = 0x0BU   /*!< TIM Encoder MspDeInit Callback ID                         */
-  , HAL_TIM_HALL_SENSOR_MSPINIT_CB_ID     = 0x0CU   /*!< TIM Hall Sensor MspDeInit Callback ID                     */
-  , HAL_TIM_HALL_SENSOR_MSPDEINIT_CB_ID   = 0x0DU   /*!< TIM Hall Sensor MspDeInit Callback ID                     */
+  HAL_TIM_BASE_MSPINIT_CB_ID              = 0x00U   /*!< TIM Base MspInit Callback ID                               */
+  , HAL_TIM_BASE_MSPDEINIT_CB_ID          = 0x01U   /*!< TIM Base MspDeInit Callback ID                             */
+  , HAL_TIM_IC_MSPINIT_CB_ID              = 0x02U   /*!< TIM IC MspInit Callback ID                                 */
+  , HAL_TIM_IC_MSPDEINIT_CB_ID            = 0x03U   /*!< TIM IC MspDeInit Callback ID                               */
+  , HAL_TIM_OC_MSPINIT_CB_ID              = 0x04U   /*!< TIM OC MspInit Callback ID                                 */
+  , HAL_TIM_OC_MSPDEINIT_CB_ID            = 0x05U   /*!< TIM OC MspDeInit Callback ID                               */
+  , HAL_TIM_PWM_MSPINIT_CB_ID             = 0x06U   /*!< TIM PWM MspInit Callback ID                                */
+  , HAL_TIM_PWM_MSPDEINIT_CB_ID           = 0x07U   /*!< TIM PWM MspDeInit Callback ID                              */
+  , HAL_TIM_ONE_PULSE_MSPINIT_CB_ID       = 0x08U   /*!< TIM One Pulse MspInit Callback ID                          */
+  , HAL_TIM_ONE_PULSE_MSPDEINIT_CB_ID     = 0x09U   /*!< TIM One Pulse MspDeInit Callback ID                        */
+  , HAL_TIM_ENCODER_MSPINIT_CB_ID         = 0x0AU   /*!< TIM Encoder MspInit Callback ID                            */
+  , HAL_TIM_ENCODER_MSPDEINIT_CB_ID       = 0x0BU   /*!< TIM Encoder MspDeInit Callback ID                          */
+  , HAL_TIM_HALL_SENSOR_MSPINIT_CB_ID     = 0x0CU   /*!< TIM Hall Sensor MspDeInit Callback ID                      */
+  , HAL_TIM_HALL_SENSOR_MSPDEINIT_CB_ID   = 0x0DU   /*!< TIM Hall Sensor MspDeInit Callback ID                      */
   , HAL_TIM_PERIOD_ELAPSED_CB_ID          = 0x0EU   /*!< TIM Period Elapsed Callback ID                             */
   , HAL_TIM_PERIOD_ELAPSED_HALF_CB_ID     = 0x0FU   /*!< TIM Period Elapsed half complete Callback ID               */
   , HAL_TIM_TRIGGER_CB_ID                 = 0x10U   /*!< TIM Trigger Callback ID                                    */
   , HAL_TIM_TRIGGER_HALF_CB_ID            = 0x11U   /*!< TIM Trigger half complete Callback ID                      */
-
   , HAL_TIM_IC_CAPTURE_CB_ID              = 0x12U   /*!< TIM Input Capture Callback ID                              */
   , HAL_TIM_IC_CAPTURE_HALF_CB_ID         = 0x13U   /*!< TIM Input Capture half complete Callback ID                */
   , HAL_TIM_OC_DELAY_ELAPSED_CB_ID        = 0x14U   /*!< TIM Output Compare Delay Elapsed Callback ID               */
-  , HAL_TIM_PWM_PULSE_FINISHED_CB_ID      = 0x15U   /*!< TIM PWM Pulse Finished Callback ID           */
+  , HAL_TIM_PWM_PULSE_FINISHED_CB_ID      = 0x15U   /*!< TIM PWM Pulse Finished Callback ID                         */
   , HAL_TIM_PWM_PULSE_FINISHED_HALF_CB_ID = 0x16U   /*!< TIM PWM Pulse Finished half complete Callback ID           */
   , HAL_TIM_ERROR_CB_ID                   = 0x17U   /*!< TIM Error Callback ID                                      */
   , HAL_TIM_COMMUTATION_CB_ID             = 0x18U   /*!< TIM Commutation Callback ID                                */
@@ -1002,8 +1001,8 @@ typedef  void (*pTIM_CallbackTypeDef)(TIM_HandleTypeDef *htim);  /*!< pointer to
 #define TIM_OCMODE_RETRIGERRABLE_OPM2      (TIM_CCMR1_OC1M_3 | TIM_CCMR1_OC1M_0)                     /*!< Retrigerrable OPM mode 2               */
 #define TIM_OCMODE_COMBINED_PWM1           (TIM_CCMR1_OC1M_3 | TIM_CCMR1_OC1M_2)                     /*!< Combined PWM mode 1                    */
 #define TIM_OCMODE_COMBINED_PWM2           (TIM_CCMR1_OC1M_3 | TIM_CCMR1_OC1M_0 | TIM_CCMR1_OC1M_2)  /*!< Combined PWM mode 2                    */
-#define TIM_OCMODE_ASSYMETRIC_PWM1         (TIM_CCMR1_OC1M_3 | TIM_CCMR1_OC1M_1 | TIM_CCMR1_OC1M_2)  /*!< Asymmetric PWM mode 1                  */
-#define TIM_OCMODE_ASSYMETRIC_PWM2         TIM_CCMR1_OC1M                                            /*!< Asymmetric PWM mode 2                  */
+#define TIM_OCMODE_ASYMMETRIC_PWM1         (TIM_CCMR1_OC1M_3 | TIM_CCMR1_OC1M_1 | TIM_CCMR1_OC1M_2)  /*!< Asymmetric PWM mode 1                  */
+#define TIM_OCMODE_ASYMMETRIC_PWM2         TIM_CCMR1_OC1M                                            /*!< Asymmetric PWM mode 2                  */
 /**
   * @}
   */
@@ -1843,6 +1842,10 @@ mode.
                                             ((__PRESCALER__) == TIM_ICPSC_DIV4) || \
                                             ((__PRESCALER__) == TIM_ICPSC_DIV8))
 
+#define IS_TIM_CCX_CHANNEL(__INSTANCE__, __CHANNEL__) (IS_TIM_CCX_INSTANCE(__INSTANCE__, __CHANNEL__) && \
+                                                       ((__CHANNEL__) != (TIM_CHANNEL_5)) && \
+                                                       ((__CHANNEL__) != (TIM_CHANNEL_6)))
+
 #define IS_TIM_OPM_MODE(__MODE__)          (((__MODE__) == TIM_OPMODE_SINGLE) || \
                                             ((__MODE__) == TIM_OPMODE_REPETITIVE))
 
@@ -1863,8 +1866,9 @@ mode.
 #define IS_TIM_OPM_CHANNELS(__CHANNEL__)   (((__CHANNEL__) == TIM_CHANNEL_1) || \
                                             ((__CHANNEL__) == TIM_CHANNEL_2))
 
-#define IS_TIM_PERIOD(__HANDLE__, __PERIOD__) \
-  ((IS_TIM_32B_COUNTER_INSTANCE(((__HANDLE__)->Instance)) == 0U) ? (((__PERIOD__) > 0U) && ((__PERIOD__) <= 0x0000FFFFU)) : ((__PERIOD__) > 0U))
+#define IS_TIM_PERIOD(__HANDLE__, __PERIOD__) ((IS_TIM_32B_COUNTER_INSTANCE(((__HANDLE__)->Instance)) == 0U) ? \
+                                               (((__PERIOD__) > 0U) && ((__PERIOD__) <= 0x0000FFFFU)) :        \
+                                               ((__PERIOD__) > 0U))
 
 #define IS_TIM_COMPLEMENTARY_CHANNELS(__CHANNEL__) (((__CHANNEL__) == TIM_CHANNEL_1) || \
                                                     ((__CHANNEL__) == TIM_CHANNEL_2) || \
@@ -1916,7 +1920,6 @@ mode.
                                             ((__LEVEL__) == TIM_LOCKLEVEL_3))
 
 #define IS_TIM_BREAK_FILTER(__BRKFILTER__) ((__BRKFILTER__) <= 0xFUL)
-
 
 #define IS_TIM_BREAK_STATE(__STATE__)      (((__STATE__) == TIM_BREAK_ENABLE) || \
                                             ((__STATE__) == TIM_BREAK_DISABLE))
@@ -1976,8 +1979,8 @@ mode.
                                    ((__MODE__) == TIM_OCMODE_PWM2)               || \
                                    ((__MODE__) == TIM_OCMODE_COMBINED_PWM1)      || \
                                    ((__MODE__) == TIM_OCMODE_COMBINED_PWM2)      || \
-                                   ((__MODE__) == TIM_OCMODE_ASSYMETRIC_PWM1)    || \
-                                   ((__MODE__) == TIM_OCMODE_ASSYMETRIC_PWM2))
+                                   ((__MODE__) == TIM_OCMODE_ASYMMETRIC_PWM1)    || \
+                                   ((__MODE__) == TIM_OCMODE_ASYMMETRIC_PWM2))
 
 #define IS_TIM_OC_MODE(__MODE__)  (((__MODE__) == TIM_OCMODE_TIMING)             || \
                                    ((__MODE__) == TIM_OCMODE_ACTIVE)             || \
@@ -2257,7 +2260,7 @@ HAL_StatusTypeDef HAL_TIM_OnePulse_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Out
   * @{
   */
 /* Timer Encoder functions ****************************************************/
-HAL_StatusTypeDef HAL_TIM_Encoder_Init(TIM_HandleTypeDef *htim,  TIM_Encoder_InitTypeDef *sConfig);
+HAL_StatusTypeDef HAL_TIM_Encoder_Init(TIM_HandleTypeDef *htim, const TIM_Encoder_InitTypeDef *sConfig);
 HAL_StatusTypeDef HAL_TIM_Encoder_DeInit(TIM_HandleTypeDef *htim);
 void HAL_TIM_Encoder_MspInit(TIM_HandleTypeDef *htim);
 void HAL_TIM_Encoder_MspDeInit(TIM_HandleTypeDef *htim);
@@ -2306,7 +2309,8 @@ HAL_StatusTypeDef HAL_TIM_ConfigTI1Input(TIM_HandleTypeDef *htim, uint32_t TI1_S
 HAL_StatusTypeDef HAL_TIM_SlaveConfigSynchro(TIM_HandleTypeDef *htim, const TIM_SlaveConfigTypeDef *sSlaveConfig);
 HAL_StatusTypeDef HAL_TIM_SlaveConfigSynchro_IT(TIM_HandleTypeDef *htim, const TIM_SlaveConfigTypeDef *sSlaveConfig);
 HAL_StatusTypeDef HAL_TIM_DMABurst_WriteStart(TIM_HandleTypeDef *htim, uint32_t BurstBaseAddress,
-                                              uint32_t BurstRequestSrc, const uint32_t  *BurstBuffer, uint32_t  BurstLength);
+                                              uint32_t BurstRequestSrc, const uint32_t  *BurstBuffer,
+                                              uint32_t  BurstLength);
 HAL_StatusTypeDef HAL_TIM_DMABurst_MultiWriteStart(TIM_HandleTypeDef *htim, uint32_t BurstBaseAddress,
                                                    uint32_t BurstRequestSrc, const uint32_t *BurstBuffer,
                                                    uint32_t BurstLength,  uint32_t DataLength);

--- a/lib/STM32F7xx_HAL_Driver/Inc/stm32f7xx_hal_tim_ex.h
+++ b/lib/STM32F7xx_HAL_Driver/Inc/stm32f7xx_hal_tim_ex.h
@@ -117,8 +117,8 @@ typedef struct
 /** @defgroup TIMEx_Break_Input_Source TIM Extended Break input source
   * @{
   */
-#define TIM_BREAKINPUTSOURCE_BKIN     (0x00000001U)                  /* !< An external source (GPIO) is connected to the BKIN pin  */
-#define TIM_BREAKINPUTSOURCE_DFSDM1   (0x00000008U)                  /* !< The analog watchdog output of the DFSDM1 peripheral is connected to the break input */
+#define TIM_BREAKINPUTSOURCE_BKIN     (0x00000001U)                  /*!< An external source (GPIO) is connected to the BKIN pin  */
+#define TIM_BREAKINPUTSOURCE_DFSDM1   (0x00000008U)                  /*!< The analog watchdog output of the DFSDM1 peripheral is connected to the break input */
 /**
   * @}
   */

--- a/lib/STM32F7xx_HAL_Driver/Inc/stm32f7xx_ll_adc.h
+++ b/lib/STM32F7xx_HAL_Driver/Inc/stm32f7xx_ll_adc.h
@@ -3970,7 +3970,7 @@ __STATIC_INLINE uint16_t LL_ADC_REG_ReadConversionData10(ADC_TypeDef *ADCx)
   */
 __STATIC_INLINE uint8_t LL_ADC_REG_ReadConversionData8(ADC_TypeDef *ADCx)
 {
-  return (uint16_t)(READ_BIT(ADCx->DR, ADC_DR_DATA));
+  return (uint8_t)(READ_BIT(ADCx->DR, ADC_DR_DATA) & 0x000000FFUL);
 }
 
 /**
@@ -3985,7 +3985,7 @@ __STATIC_INLINE uint8_t LL_ADC_REG_ReadConversionData8(ADC_TypeDef *ADCx)
   */
 __STATIC_INLINE uint8_t LL_ADC_REG_ReadConversionData6(ADC_TypeDef *ADCx)
 {
-  return (uint16_t)(READ_BIT(ADCx->DR, ADC_DR_DATA));
+  return (uint8_t)(READ_BIT(ADCx->DR, ADC_DR_DATA) & 0x000000FFUL);
 }
 
 /**
@@ -4188,7 +4188,7 @@ __STATIC_INLINE uint8_t LL_ADC_INJ_ReadConversionData8(ADC_TypeDef *ADCx, uint32
   __IO uint32_t *preg = __ADC_PTR_REG_OFFSET(ADCx->JDR1, __ADC_MASK_SHIFT(Rank, ADC_INJ_JDRX_REGOFFSET_MASK));
   
   return (uint8_t)(READ_BIT(*preg,
-                            ADC_JDR1_JDATA)
+                            ADC_JDR1_JDATA) & 0x000000FFUL
                   );
 }
 
@@ -4215,7 +4215,7 @@ __STATIC_INLINE uint8_t LL_ADC_INJ_ReadConversionData6(ADC_TypeDef *ADCx, uint32
   __IO uint32_t *preg = __ADC_PTR_REG_OFFSET(ADCx->JDR1, __ADC_MASK_SHIFT(Rank, ADC_INJ_JDRX_REGOFFSET_MASK));
   
   return (uint8_t)(READ_BIT(*preg,
-                            ADC_JDR1_JDATA)
+                            ADC_JDR1_JDATA) & 0x000000FFUL
                   );
 }
 

--- a/lib/STM32F7xx_HAL_Driver/Inc/stm32f7xx_ll_cortex.h
+++ b/lib/STM32F7xx_HAL_Driver/Inc/stm32f7xx_ll_cortex.h
@@ -588,7 +588,7 @@ __STATIC_INLINE void LL_MPU_ConfigRegion(uint32_t Region, uint32_t SubRegionDisa
   /* Set base address */
   WRITE_REG(MPU->RBAR, (Address & 0xFFFFFFE0U));
   /* Configure MPU */
-  WRITE_REG(MPU->RASR, (MPU_RASR_ENABLE_Msk | Attributes | SubRegionDisable << MPU_RASR_SRD_Pos));
+  WRITE_REG(MPU->RASR, (MPU_RASR_ENABLE_Msk | Attributes | (SubRegionDisable << MPU_RASR_SRD_Pos)));
 }
 
 /**

--- a/lib/STM32F7xx_HAL_Driver/Inc/stm32f7xx_ll_rtc.h
+++ b/lib/STM32F7xx_HAL_Driver/Inc/stm32f7xx_ll_rtc.h
@@ -1,0 +1,3834 @@
+/**
+  ******************************************************************************
+  * @file    stm32f7xx_ll_rtc.h
+  * @author  MCD Application Team
+  * @brief   Header file of RTC LL module.
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2017 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef STM32F7xx_LL_RTC_H
+#define STM32F7xx_LL_RTC_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f7xx.h"
+
+/** @addtogroup STM32F7xx_LL_Driver
+  * @{
+  */
+
+#if defined(RTC)
+
+/** @defgroup RTC_LL RTC
+  * @{
+  */
+
+/* Private types -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private constants ---------------------------------------------------------*/
+/** @defgroup RTC_LL_Private_Constants RTC Private Constants
+  * @{
+  */
+/* Masks Definition */
+#define RTC_INIT_MASK                 0xFFFFFFFFU
+#define RTC_RSF_MASK                  ((uint32_t)~(RTC_ISR_INIT | RTC_ISR_RSF))
+
+/* Write protection defines */
+#define RTC_WRITE_PROTECTION_DISABLE  ((uint8_t)0xFFU)
+#define RTC_WRITE_PROTECTION_ENABLE_1 ((uint8_t)0xCAU)
+#define RTC_WRITE_PROTECTION_ENABLE_2 ((uint8_t)0x53U)
+
+/* Defines used to combine date & time */
+#define RTC_OFFSET_WEEKDAY            24U
+#define RTC_OFFSET_DAY                16U
+#define RTC_OFFSET_MONTH              8U
+#define RTC_OFFSET_HOUR               16U
+#define RTC_OFFSET_MINUTE             8U
+
+/**
+  * @}
+  */
+
+/* Private macros ------------------------------------------------------------*/
+#if defined(USE_FULL_LL_DRIVER)
+/** @defgroup RTC_LL_Private_Macros RTC Private Macros
+  * @{
+  */
+/**
+  * @}
+  */
+#endif /*USE_FULL_LL_DRIVER*/
+
+/* Exported types ------------------------------------------------------------*/
+#if defined(USE_FULL_LL_DRIVER)
+/** @defgroup RTC_LL_ES_INIT RTC Exported Init structure
+  * @{
+  */
+
+/**
+  * @brief  RTC Init structures definition
+  */
+typedef struct
+{
+  uint32_t HourFormat;   /*!< Specifies the RTC Hours Format.
+                              This parameter can be a value of @ref RTC_LL_EC_HOURFORMAT
+
+                              This feature can be modified afterwards using unitary function
+                              @ref LL_RTC_SetHourFormat(). */
+
+  uint32_t AsynchPrescaler; /*!< Specifies the RTC Asynchronous Predivider value.
+                              This parameter must be a number between Min_Data = 0x00 and Max_Data = 0x7F
+
+                              This feature can be modified afterwards using unitary function
+                              @ref LL_RTC_SetAsynchPrescaler(). */
+
+  uint32_t SynchPrescaler;  /*!< Specifies the RTC Synchronous Predivider value.
+                              This parameter must be a number between Min_Data = 0x00 and Max_Data = 0x7FFF
+
+                              This feature can be modified afterwards using unitary function
+                              @ref LL_RTC_SetSynchPrescaler(). */
+} LL_RTC_InitTypeDef;
+
+/**
+  * @brief  RTC Time structure definition
+  */
+typedef struct
+{
+  uint32_t TimeFormat; /*!< Specifies the RTC AM/PM Time.
+                            This parameter can be a value of @ref RTC_LL_EC_TIME_FORMAT
+
+                            This feature can be modified afterwards using unitary function @ref LL_RTC_TIME_SetFormat(). */
+
+  uint8_t Hours;       /*!< Specifies the RTC Time Hours.
+                            This parameter must be a number between Min_Data = 0 and Max_Data = 12 if the @ref LL_RTC_TIME_FORMAT_PM is selected.
+                            This parameter must be a number between Min_Data = 0 and Max_Data = 23 if the @ref LL_RTC_TIME_FORMAT_AM_OR_24 is selected.
+
+                            This feature can be modified afterwards using unitary function @ref LL_RTC_TIME_SetHour(). */
+
+  uint8_t Minutes;     /*!< Specifies the RTC Time Minutes.
+                            This parameter must be a number between Min_Data = 0 and Max_Data = 59
+
+                            This feature can be modified afterwards using unitary function @ref LL_RTC_TIME_SetMinute(). */
+
+  uint8_t Seconds;     /*!< Specifies the RTC Time Seconds.
+                            This parameter must be a number between Min_Data = 0 and Max_Data = 59
+
+                            This feature can be modified afterwards using unitary function @ref LL_RTC_TIME_SetSecond(). */
+} LL_RTC_TimeTypeDef;
+
+/**
+  * @brief  RTC Date structure definition
+  */
+typedef struct
+{
+  uint8_t WeekDay;  /*!< Specifies the RTC Date WeekDay.
+                         This parameter can be a value of @ref RTC_LL_EC_WEEKDAY
+
+                         This feature can be modified afterwards using unitary function @ref LL_RTC_DATE_SetWeekDay(). */
+
+  uint8_t Month;    /*!< Specifies the RTC Date Month.
+                         This parameter can be a value of @ref RTC_LL_EC_MONTH
+
+                         This feature can be modified afterwards using unitary function @ref LL_RTC_DATE_SetMonth(). */
+
+  uint8_t Day;      /*!< Specifies the RTC Date Day.
+                         This parameter must be a number between Min_Data = 1 and Max_Data = 31
+
+                         This feature can be modified afterwards using unitary function @ref LL_RTC_DATE_SetDay(). */
+
+  uint8_t Year;     /*!< Specifies the RTC Date Year.
+                         This parameter must be a number between Min_Data = 0 and Max_Data = 99
+
+                         This feature can be modified afterwards using unitary function @ref LL_RTC_DATE_SetYear(). */
+} LL_RTC_DateTypeDef;
+
+/**
+  * @brief  RTC Alarm structure definition
+  */
+typedef struct
+{
+  LL_RTC_TimeTypeDef AlarmTime;  /*!< Specifies the RTC Alarm Time members. */
+
+  uint32_t AlarmMask;            /*!< Specifies the RTC Alarm Masks.
+                                      This parameter can be a value of @ref RTC_LL_EC_ALMA_MASK for ALARM A or @ref RTC_LL_EC_ALMB_MASK for ALARM B.
+
+                                      This feature can be modified afterwards using unitary function @ref LL_RTC_ALMA_SetMask() for ALARM A
+                                      or @ref LL_RTC_ALMB_SetMask() for ALARM B.
+                                 */
+
+  uint32_t AlarmDateWeekDaySel;  /*!< Specifies the RTC Alarm is on day or WeekDay.
+                                      This parameter can be a value of @ref RTC_LL_EC_ALMA_WEEKDAY_SELECTION for ALARM A or @ref RTC_LL_EC_ALMB_WEEKDAY_SELECTION for ALARM B
+
+                                      This feature can be modified afterwards using unitary function @ref LL_RTC_ALMA_EnableWeekday() or @ref LL_RTC_ALMA_DisableWeekday()
+                                      for ALARM A or @ref LL_RTC_ALMB_EnableWeekday() or @ref LL_RTC_ALMB_DisableWeekday() for ALARM B
+                                 */
+
+  uint8_t AlarmDateWeekDay;      /*!< Specifies the RTC Alarm Day/WeekDay.
+                                      If AlarmDateWeekDaySel set to day, this parameter  must be a number between Min_Data = 1 and Max_Data = 31.
+
+                                      This feature can be modified afterwards using unitary function @ref LL_RTC_ALMA_SetDay()
+                                      for ALARM A or @ref LL_RTC_ALMB_SetDay() for ALARM B.
+
+                                      If AlarmDateWeekDaySel set to Weekday, this parameter can be a value of @ref RTC_LL_EC_WEEKDAY.
+
+                                      This feature can be modified afterwards using unitary function @ref LL_RTC_ALMA_SetWeekDay()
+                                      for ALARM A or @ref LL_RTC_ALMB_SetWeekDay() for ALARM B.
+                                 */
+} LL_RTC_AlarmTypeDef;
+
+/**
+  * @}
+  */
+#endif /* USE_FULL_LL_DRIVER */
+
+/* Exported constants --------------------------------------------------------*/
+/** @defgroup RTC_LL_Exported_Constants RTC Exported Constants
+  * @{
+  */
+
+#if defined(USE_FULL_LL_DRIVER)
+/** @defgroup RTC_LL_EC_FORMAT FORMAT
+  * @{
+  */
+#define LL_RTC_FORMAT_BIN                  0x00000000U /*!< Binary data format */
+#define LL_RTC_FORMAT_BCD                  0x00000001U /*!< BCD data format */
+/**
+  * @}
+  */
+
+/** @defgroup RTC_LL_EC_ALMA_WEEKDAY_SELECTION RTC Alarm A Date WeekDay
+  * @{
+  */
+#define LL_RTC_ALMA_DATEWEEKDAYSEL_DATE    0x00000000U             /*!< Alarm A Date is selected */
+#define LL_RTC_ALMA_DATEWEEKDAYSEL_WEEKDAY RTC_ALRMAR_WDSEL        /*!< Alarm A WeekDay is selected */
+/**
+  * @}
+  */
+
+/** @defgroup RTC_LL_EC_ALMB_WEEKDAY_SELECTION RTC Alarm B Date WeekDay
+  * @{
+  */
+#define LL_RTC_ALMB_DATEWEEKDAYSEL_DATE    0x00000000U             /*!< Alarm B Date is selected */
+#define LL_RTC_ALMB_DATEWEEKDAYSEL_WEEKDAY RTC_ALRMBR_WDSEL        /*!< Alarm B WeekDay is selected */
+/**
+  * @}
+  */
+
+#endif /* USE_FULL_LL_DRIVER */
+
+/** @defgroup RTC_LL_EC_GET_FLAG Get Flags Defines
+  * @brief    Flags defines which can be used with LL_RTC_ReadReg function
+  * @{
+  */
+#define LL_RTC_ISR_ITSF                    RTC_ISR_ITSF
+#define LL_RTC_ISR_RECALPF                 RTC_ISR_RECALPF
+#define LL_RTC_ISR_TAMP3F                  RTC_ISR_TAMP3F
+#define LL_RTC_ISR_TAMP2F                  RTC_ISR_TAMP2F
+#define LL_RTC_ISR_TAMP1F                  RTC_ISR_TAMP1F
+#define LL_RTC_ISR_TSOVF                   RTC_ISR_TSOVF
+#define LL_RTC_ISR_TSF                     RTC_ISR_TSF
+#define LL_RTC_ISR_WUTF                    RTC_ISR_WUTF
+#define LL_RTC_ISR_ALRBF                   RTC_ISR_ALRBF
+#define LL_RTC_ISR_ALRAF                   RTC_ISR_ALRAF
+#define LL_RTC_ISR_INITF                   RTC_ISR_INITF
+#define LL_RTC_ISR_RSF                     RTC_ISR_RSF
+#define LL_RTC_ISR_INITS                   RTC_ISR_INITS
+#define LL_RTC_ISR_SHPF                    RTC_ISR_SHPF
+#define LL_RTC_ISR_WUTWF                   RTC_ISR_WUTWF
+#define LL_RTC_ISR_ALRBWF                  RTC_ISR_ALRBWF
+#define LL_RTC_ISR_ALRAWF                  RTC_ISR_ALRAWF
+/**
+  * @}
+  */
+
+/** @defgroup RTC_LL_EC_IT IT Defines
+  * @brief    IT defines which can be used with LL_RTC_ReadReg and  LL_RTC_WriteReg functions
+  * @{
+  */
+#define LL_RTC_CR_TSIE                     RTC_CR_TSIE
+#define LL_RTC_CR_WUTIE                    RTC_CR_WUTIE
+#define LL_RTC_CR_ALRBIE                   RTC_CR_ALRBIE
+#define LL_RTC_CR_ALRAIE                   RTC_CR_ALRAIE
+#define LL_RTC_TAMPCR_TAMP3IE              RTC_TAMPCR_TAMP3IE
+#define LL_RTC_TAMPCR_TAMP2IE              RTC_TAMPCR_TAMP2IE
+#define LL_RTC_TAMPCR_TAMP1IE              RTC_TAMPCR_TAMP1IE
+#define LL_RTC_TAMPCR_TAMPIE               RTC_TAMPCR_TAMPIE
+/**
+  * @}
+  */
+
+/** @defgroup RTC_LL_EC_WEEKDAY  WEEK DAY
+  * @{
+  */
+#define LL_RTC_WEEKDAY_MONDAY              ((uint8_t)0x01U) /*!< Monday    */
+#define LL_RTC_WEEKDAY_TUESDAY             ((uint8_t)0x02U) /*!< Tuesday   */
+#define LL_RTC_WEEKDAY_WEDNESDAY           ((uint8_t)0x03U) /*!< Wednesday */
+#define LL_RTC_WEEKDAY_THURSDAY            ((uint8_t)0x04U) /*!< Thrusday  */
+#define LL_RTC_WEEKDAY_FRIDAY              ((uint8_t)0x05U) /*!< Friday    */
+#define LL_RTC_WEEKDAY_SATURDAY            ((uint8_t)0x06U) /*!< Saturday  */
+#define LL_RTC_WEEKDAY_SUNDAY              ((uint8_t)0x07U) /*!< Sunday    */
+/**
+  * @}
+  */
+
+/** @defgroup RTC_LL_EC_MONTH  MONTH
+  * @{
+  */
+#define LL_RTC_MONTH_JANUARY               ((uint8_t)0x01U)  /*!< January   */
+#define LL_RTC_MONTH_FEBRUARY              ((uint8_t)0x02U)  /*!< February  */
+#define LL_RTC_MONTH_MARCH                 ((uint8_t)0x03U)  /*!< March     */
+#define LL_RTC_MONTH_APRIL                 ((uint8_t)0x04U)  /*!< April     */
+#define LL_RTC_MONTH_MAY                   ((uint8_t)0x05U)  /*!< May       */
+#define LL_RTC_MONTH_JUNE                  ((uint8_t)0x06U)  /*!< June      */
+#define LL_RTC_MONTH_JULY                  ((uint8_t)0x07U)  /*!< July      */
+#define LL_RTC_MONTH_AUGUST                ((uint8_t)0x08U)  /*!< August    */
+#define LL_RTC_MONTH_SEPTEMBER             ((uint8_t)0x09U)  /*!< September */
+#define LL_RTC_MONTH_OCTOBER               ((uint8_t)0x10U)  /*!< October   */
+#define LL_RTC_MONTH_NOVEMBER              ((uint8_t)0x11U)  /*!< November  */
+#define LL_RTC_MONTH_DECEMBER              ((uint8_t)0x12U)  /*!< December  */
+/**
+  * @}
+  */
+
+/** @defgroup RTC_LL_EC_HOURFORMAT  HOUR FORMAT
+  * @{
+  */
+#define LL_RTC_HOURFORMAT_24HOUR           0x00000000U           /*!< 24 hour/day format */
+#define LL_RTC_HOURFORMAT_AMPM             RTC_CR_FMT            /*!< AM/PM hour format */
+/**
+  * @}
+  */
+
+/** @defgroup RTC_LL_EC_ALARMOUT  ALARM OUTPUT
+  * @{
+  */
+#define LL_RTC_ALARMOUT_DISABLE            0x00000000U             /*!< Output disabled */
+#define LL_RTC_ALARMOUT_ALMA               RTC_CR_OSEL_0           /*!< Alarm A output enabled */
+#define LL_RTC_ALARMOUT_ALMB               RTC_CR_OSEL_1           /*!< Alarm B output enabled */
+#define LL_RTC_ALARMOUT_WAKEUP             RTC_CR_OSEL             /*!< Wakeup output enabled */
+/**
+  * @}
+  */
+
+/** @defgroup RTC_LL_EC_ALARM_OUTPUTTYPE  ALARM OUTPUT TYPE
+  * @{
+  */
+#define LL_RTC_ALARM_OUTPUTTYPE_OPENDRAIN  0x00000000U                          /*!< RTC_ALARM, when mapped on PC13, is open-drain output */
+#define LL_RTC_ALARM_OUTPUTTYPE_PUSHPULL   RTC_OR_ALARMOUTTYPE /*!< RTC_ALARM, when mapped on PC13, is push-pull output */
+/**
+  * @}
+  */
+
+/** @defgroup RTC_LL_EC_OUTPUTPOLARITY_PIN  OUTPUT POLARITY PIN
+  * @{
+  */
+#define LL_RTC_OUTPUTPOLARITY_PIN_HIGH     0x00000000U           /*!< Pin is high when ALRAF/ALRBF/WUTF is asserted (depending on OSEL)*/
+#define LL_RTC_OUTPUTPOLARITY_PIN_LOW      RTC_CR_POL            /*!< Pin is low when ALRAF/ALRBF/WUTF is asserted (depending on OSEL) */
+/**
+  * @}
+  */
+
+/** @defgroup RTC_LL_EC_TIME_FORMAT TIME FORMAT
+  * @{
+  */
+#define LL_RTC_TIME_FORMAT_AM_OR_24        0x00000000U           /*!< AM or 24-hour format */
+#define LL_RTC_TIME_FORMAT_PM              RTC_TR_PM             /*!< PM */
+/**
+  * @}
+  */
+
+/** @defgroup RTC_LL_EC_SHIFT_SECOND  SHIFT SECOND
+  * @{
+  */
+#define LL_RTC_SHIFT_SECOND_DELAY          0x00000000U           /* Delay (seconds) = SUBFS / (PREDIV_S + 1) */
+#define LL_RTC_SHIFT_SECOND_ADVANCE        RTC_SHIFTR_ADD1S      /* Advance (seconds) = (1 - (SUBFS / (PREDIV_S + 1))) */
+/**
+  * @}
+  */
+
+/** @defgroup RTC_LL_EC_ALMA_MASK  ALARMA MASK
+  * @{
+  */
+#define LL_RTC_ALMA_MASK_NONE              0x00000000U             /*!< No masks applied on Alarm A*/
+#define LL_RTC_ALMA_MASK_DATEWEEKDAY       RTC_ALRMAR_MSK4         /*!< Date/day do not care in Alarm A comparison */
+#define LL_RTC_ALMA_MASK_HOURS             RTC_ALRMAR_MSK3         /*!< Hours do not care in Alarm A comparison */
+#define LL_RTC_ALMA_MASK_MINUTES           RTC_ALRMAR_MSK2         /*!< Minutes do not care in Alarm A comparison */
+#define LL_RTC_ALMA_MASK_SECONDS           RTC_ALRMAR_MSK1         /*!< Seconds do not care in Alarm A comparison */
+#define LL_RTC_ALMA_MASK_ALL               (RTC_ALRMAR_MSK4 | RTC_ALRMAR_MSK3 | RTC_ALRMAR_MSK2 | RTC_ALRMAR_MSK1) /*!< Masks all */
+/**
+  * @}
+  */
+
+/** @defgroup RTC_LL_EC_ALMA_TIME_FORMAT  ALARMA TIME FORMAT
+  * @{
+  */
+#define LL_RTC_ALMA_TIME_FORMAT_AM         0x00000000U           /*!< AM or 24-hour format */
+#define LL_RTC_ALMA_TIME_FORMAT_PM         RTC_ALRMAR_PM         /*!< PM */
+/**
+  * @}
+  */
+
+/** @defgroup RTC_LL_EC_ALMB_MASK  ALARMB MASK
+  * @{
+  */
+#define LL_RTC_ALMB_MASK_NONE              0x00000000U             /*!< No masks applied on Alarm B                */
+#define LL_RTC_ALMB_MASK_DATEWEEKDAY       RTC_ALRMBR_MSK4         /*!< Date/day do not care in Alarm B comparison */
+#define LL_RTC_ALMB_MASK_HOURS             RTC_ALRMBR_MSK3         /*!< Hours do not care in Alarm B comparison    */
+#define LL_RTC_ALMB_MASK_MINUTES           RTC_ALRMBR_MSK2         /*!< Minutes do not care in Alarm B comparison  */
+#define LL_RTC_ALMB_MASK_SECONDS           RTC_ALRMBR_MSK1         /*!< Seconds do not care in Alarm B comparison  */
+#define LL_RTC_ALMB_MASK_ALL               (RTC_ALRMBR_MSK4 | RTC_ALRMBR_MSK3 | RTC_ALRMBR_MSK2 | RTC_ALRMBR_MSK1) /*!< Masks all */
+/**
+  * @}
+  */
+
+/** @defgroup RTC_LL_EC_ALMB_TIME_FORMAT  ALARMB TIME FORMAT
+  * @{
+  */
+#define LL_RTC_ALMB_TIME_FORMAT_AM         0x00000000U           /*!< AM or 24-hour format */
+#define LL_RTC_ALMB_TIME_FORMAT_PM         RTC_ALRMBR_PM         /*!< PM */
+/**
+  * @}
+  */
+
+/** @defgroup RTC_LL_EC_TIMESTAMP_EDGE  TIMESTAMP EDGE
+  * @{
+  */
+#define LL_RTC_TIMESTAMP_EDGE_RISING       0x00000000U           /*!< RTC_TS input rising edge generates a time-stamp event */
+#define LL_RTC_TIMESTAMP_EDGE_FALLING      RTC_CR_TSEDGE         /*!< RTC_TS input falling edge generates a time-stamp even */
+/**
+  * @}
+  */
+
+/** @defgroup RTC_LL_EC_TS_TIME_FORMAT  TIMESTAMP TIME FORMAT
+  * @{
+  */
+#define LL_RTC_TS_TIME_FORMAT_AM           0x00000000U           /*!< AM or 24-hour format */
+#define LL_RTC_TS_TIME_FORMAT_PM           RTC_TSTR_PM           /*!< PM */
+/**
+  * @}
+  */
+
+/** @defgroup RTC_LL_EC_TAMPER  TAMPER
+  * @{
+  */
+#define LL_RTC_TAMPER_1                    RTC_TAMPCR_TAMP1E /*!< RTC_TAMP1 input detection */
+#define LL_RTC_TAMPER_2                    RTC_TAMPCR_TAMP2E /*!< RTC_TAMP2 input detection */
+#define LL_RTC_TAMPER_3                    RTC_TAMPCR_TAMP3E /*!< RTC_TAMP3 input detection */
+/**
+  * @}
+  */
+
+/** @defgroup RTC_LL_EC_TAMPER_MASK  TAMPER MASK
+  * @{
+  */
+#define LL_RTC_TAMPER_MASK_TAMPER1         RTC_TAMPCR_TAMP1MF /*!< Tamper 1 event generates a trigger event. TAMP1F is masked and internally cleared by hardware.The backup registers are not erased */
+#define LL_RTC_TAMPER_MASK_TAMPER2         RTC_TAMPCR_TAMP2MF /*!< Tamper 2 event generates a trigger event. TAMP2F is masked and internally cleared by hardware. The backup registers are not erased. */
+#define LL_RTC_TAMPER_MASK_TAMPER3         RTC_TAMPCR_TAMP3MF /*!< Tamper 3 event generates a trigger event. TAMP3F is masked and internally cleared by hardware. The backup registers are not erased */
+/**
+  * @}
+  */
+
+/** @defgroup RTC_LL_EC_TAMPER_NOERASE  TAMPER NO ERASE
+  * @{
+  */
+#define LL_RTC_TAMPER_NOERASE_TAMPER1      RTC_TAMPCR_TAMP1NOERASE /*!< Tamper 1 event does not erase the backup registers. */
+#define LL_RTC_TAMPER_NOERASE_TAMPER2      RTC_TAMPCR_TAMP2NOERASE /*!< Tamper 2 event does not erase the backup registers. */
+#define LL_RTC_TAMPER_NOERASE_TAMPER3      RTC_TAMPCR_TAMP3NOERASE /*!< Tamper 3 event does not erase the backup registers. */
+/**
+  * @}
+  */
+
+/** @defgroup RTC_LL_EC_TAMPER_DURATION  TAMPER DURATION
+  * @{
+  */
+#define LL_RTC_TAMPER_DURATION_1RTCCLK     0x00000000U                             /*!< Tamper pins are pre-charged before sampling during 1 RTCCLK cycle  */
+#define LL_RTC_TAMPER_DURATION_2RTCCLK     RTC_TAMPCR_TAMPPRCH_0  /*!< Tamper pins are pre-charged before sampling during 2 RTCCLK cycles */
+#define LL_RTC_TAMPER_DURATION_4RTCCLK     RTC_TAMPCR_TAMPPRCH_1  /*!< Tamper pins are pre-charged before sampling during 4 RTCCLK cycles */
+#define LL_RTC_TAMPER_DURATION_8RTCCLK     RTC_TAMPCR_TAMPPRCH    /*!< Tamper pins are pre-charged before sampling during 8 RTCCLK cycles */
+/**
+  * @}
+  */
+
+/** @defgroup RTC_LL_EC_TAMPER_FILTER  TAMPER FILTER
+  * @{
+  */
+#define LL_RTC_TAMPER_FILTER_DISABLE       0x00000000U                              /*!< Tamper filter is disabled */
+#define LL_RTC_TAMPER_FILTER_2SAMPLE       RTC_TAMPCR_TAMPFLT_0    /*!< Tamper is activated after 2 consecutive samples at the active level */
+#define LL_RTC_TAMPER_FILTER_4SAMPLE       RTC_TAMPCR_TAMPFLT_1    /*!< Tamper is activated after 4 consecutive samples at the active level */
+#define LL_RTC_TAMPER_FILTER_8SAMPLE       RTC_TAMPCR_TAMPFLT      /*!< Tamper is activated after 8 consecutive samples at the active level. */
+/**
+  * @}
+  */
+
+/** @defgroup RTC_LL_EC_TAMPER_SAMPLFREQDIV  TAMPER SAMPLING FREQUENCY DIVIDER
+  * @{
+  */
+#define LL_RTC_TAMPER_SAMPLFREQDIV_32768   0x00000000U                                                      /*!< Each of the tamper inputs are sampled with a frequency =  RTCCLK / 32768 */
+#define LL_RTC_TAMPER_SAMPLFREQDIV_16384   RTC_TAMPCR_TAMPFREQ_0                           /*!< Each of the tamper inputs are sampled with a frequency =  RTCCLK / 16384 */
+#define LL_RTC_TAMPER_SAMPLFREQDIV_8192    RTC_TAMPCR_TAMPFREQ_1                           /*!< Each of the tamper inputs are sampled with a frequency =  RTCCLK / 8192 */
+#define LL_RTC_TAMPER_SAMPLFREQDIV_4096    (RTC_TAMPCR_TAMPFREQ_1 | RTC_TAMPCR_TAMPFREQ_0) /*!< Each of the tamper inputs are sampled with a frequency =  RTCCLK / 4096 */
+#define LL_RTC_TAMPER_SAMPLFREQDIV_2048    RTC_TAMPCR_TAMPFREQ_2                           /*!< Each of the tamper inputs are sampled with a frequency =  RTCCLK / 2048 */
+#define LL_RTC_TAMPER_SAMPLFREQDIV_1024    (RTC_TAMPCR_TAMPFREQ_2 | RTC_TAMPCR_TAMPFREQ_0) /*!< Each of the tamper inputs are sampled with a frequency =  RTCCLK / 1024 */
+#define LL_RTC_TAMPER_SAMPLFREQDIV_512     (RTC_TAMPCR_TAMPFREQ_2 | RTC_TAMPCR_TAMPFREQ_1) /*!< Each of the tamper inputs are sampled with a frequency =  RTCCLK / 512 */
+#define LL_RTC_TAMPER_SAMPLFREQDIV_256     RTC_TAMPCR_TAMPFREQ                             /*!< Each of the tamper inputs are sampled with a frequency =  RTCCLK / 256 */
+/**
+  * @}
+  */
+
+/** @defgroup RTC_LL_EC_TAMPER_ACTIVELEVEL  TAMPER ACTIVE LEVEL
+  * @{
+  */
+#define LL_RTC_TAMPER_ACTIVELEVEL_TAMP1    RTC_TAMPCR_TAMP1TRG /*!< RTC_TAMP1 input falling edge (if TAMPFLT = 00) or staying high (if TAMPFLT != 00) triggers a tamper detection event */
+#define LL_RTC_TAMPER_ACTIVELEVEL_TAMP2    RTC_TAMPCR_TAMP2TRG /*!< RTC_TAMP2 input falling edge (if TAMPFLT = 00) or staying high (if TAMPFLT != 00) triggers a tamper detection event */
+#define LL_RTC_TAMPER_ACTIVELEVEL_TAMP3    RTC_TAMPCR_TAMP3TRG /*!< RTC_TAMP3 input falling edge (if TAMPFLT = 00) or staying high (if TAMPFLT != 00) triggers a tamper detection event */
+/**
+  * @}
+  */
+
+/** @defgroup RTC_LL_EC_WAKEUPCLOCK_DIV  WAKEUP CLOCK DIV
+  * @{
+  */
+#define LL_RTC_WAKEUPCLOCK_DIV_16          0x00000000U                           /*!< RTC/16 clock is selected */
+#define LL_RTC_WAKEUPCLOCK_DIV_8           (RTC_CR_WUCKSEL_0)                    /*!< RTC/8 clock is selected */
+#define LL_RTC_WAKEUPCLOCK_DIV_4           (RTC_CR_WUCKSEL_1)                    /*!< RTC/4 clock is selected */
+#define LL_RTC_WAKEUPCLOCK_DIV_2           (RTC_CR_WUCKSEL_1 | RTC_CR_WUCKSEL_0) /*!< RTC/2 clock is selected */
+#define LL_RTC_WAKEUPCLOCK_CKSPRE          (RTC_CR_WUCKSEL_2)                    /*!< ck_spre (usually 1 Hz) clock is selected */
+#define LL_RTC_WAKEUPCLOCK_CKSPRE_WUT      (RTC_CR_WUCKSEL_2 | RTC_CR_WUCKSEL_1) /*!< ck_spre (usually 1 Hz) clock is selected and 2exp16 is added to the WUT counter value*/
+/**
+  * @}
+  */
+
+/** @defgroup RTC_LL_EC_BKP  BACKUP
+  * @{
+  */
+#define LL_RTC_BKP_DR0                     0x00000000U
+#define LL_RTC_BKP_DR1                     0x00000001U
+#define LL_RTC_BKP_DR2                     0x00000002U
+#define LL_RTC_BKP_DR3                     0x00000003U
+#define LL_RTC_BKP_DR4                     0x00000004U
+#define LL_RTC_BKP_DR5                     0x00000005U
+#define LL_RTC_BKP_DR6                     0x00000006U
+#define LL_RTC_BKP_DR7                     0x00000007U
+#define LL_RTC_BKP_DR8                     0x00000008U
+#define LL_RTC_BKP_DR9                     0x00000009U
+#define LL_RTC_BKP_DR10                    0x0000000AU
+#define LL_RTC_BKP_DR11                    0x0000000BU
+#define LL_RTC_BKP_DR12                    0x0000000CU
+#define LL_RTC_BKP_DR13                    0x0000000DU
+#define LL_RTC_BKP_DR14                    0x0000000EU
+#define LL_RTC_BKP_DR15                    0x0000000FU
+#define LL_RTC_BKP_DR16                    0x00000010U
+#define LL_RTC_BKP_DR17                    0x00000011U
+#define LL_RTC_BKP_DR18                    0x00000012U
+#define LL_RTC_BKP_DR19                    0x00000013U
+#define LL_RTC_BKP_DR20                    0x00000014U
+#define LL_RTC_BKP_DR21                    0x00000015U
+#define LL_RTC_BKP_DR22                    0x00000016U
+#define LL_RTC_BKP_DR23                    0x00000017U
+#define LL_RTC_BKP_DR24                    0x00000018U
+#define LL_RTC_BKP_DR25                    0x00000019U
+#define LL_RTC_BKP_DR26                    0x0000001AU
+#define LL_RTC_BKP_DR27                    0x0000001BU
+#define LL_RTC_BKP_DR28                    0x0000001CU
+#define LL_RTC_BKP_DR29                    0x0000001DU
+#define LL_RTC_BKP_DR30                    0x0000001EU
+#define LL_RTC_BKP_DR31                    0x0000001FU
+/**
+  * @}
+  */
+
+/** @defgroup RTC_LL_EC_CALIB_OUTPUT  Calibration output
+  * @{
+  */
+#define LL_RTC_CALIB_OUTPUT_NONE           0x00000000U                 /*!< Calibration output disabled */
+#define LL_RTC_CALIB_OUTPUT_1HZ            (RTC_CR_COE | RTC_CR_COSEL) /*!< Calibration output is 1 Hz */
+#define LL_RTC_CALIB_OUTPUT_512HZ          (RTC_CR_COE)                /*!< Calibration output is 512 Hz */
+/**
+  * @}
+  */
+
+/** @defgroup RTC_LL_EC_CALIB_INSERTPULSE  Calibration pulse insertion
+  * @{
+  */
+#define LL_RTC_CALIB_INSERTPULSE_NONE      0x00000000U           /*!< No RTCCLK pulses are added */
+#define LL_RTC_CALIB_INSERTPULSE_SET       RTC_CALR_CALP         /*!< One RTCCLK pulse is effectively inserted every 2exp11 pulses (frequency increased by 488.5 ppm) */
+/**
+  * @}
+  */
+
+/** @defgroup RTC_LL_EC_CALIB_PERIOD  Calibration period
+  * @{
+  */
+#define LL_RTC_CALIB_PERIOD_32SEC          0x00000000U           /*!< Use a 32-second calibration cycle period */
+#define LL_RTC_CALIB_PERIOD_16SEC          RTC_CALR_CALW16       /*!< Use a 16-second calibration cycle period */
+#define LL_RTC_CALIB_PERIOD_8SEC           RTC_CALR_CALW8        /*!< Use a 8-second calibration cycle period */
+/**
+  * @}
+  */
+
+/** @defgroup RTC_LL_EC_TSINSEL  TIMESTAMP mapping
+  * @{
+  */
+#define LL_RTC_TimeStampPin_Default        0x00000000U           /*!< Use RTC_AF1 as TIMESTAMP */
+#define LL_RTC_TimeStampPin_Pos1           RTC_OR_TSINSEL        /*!< Use RTC_AF2 as TIMESTAMP */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Exported macro ------------------------------------------------------------*/
+/** @defgroup RTC_LL_Exported_Macros RTC Exported Macros
+  * @{
+  */
+
+/** @defgroup RTC_LL_EM_WRITE_READ Common Write and read registers Macros
+  * @{
+  */
+
+/**
+  * @brief  Write a value in RTC register
+  * @param  __INSTANCE__ RTC Instance
+  * @param  __REG__ Register to be written
+  * @param  __VALUE__ Value to be written in the register
+  * @retval None
+  */
+#define LL_RTC_WriteReg(__INSTANCE__, __REG__, __VALUE__) WRITE_REG(__INSTANCE__->__REG__, (__VALUE__))
+
+/**
+  * @brief  Read a value in RTC register
+  * @param  __INSTANCE__ RTC Instance
+  * @param  __REG__ Register to be read
+  * @retval Register value
+  */
+#define LL_RTC_ReadReg(__INSTANCE__, __REG__) READ_REG(__INSTANCE__->__REG__)
+/**
+  * @}
+  */
+
+/** @defgroup RTC_LL_EM_Convert Convert helper Macros
+  * @{
+  */
+
+/**
+  * @brief  Helper macro to convert a value from 2 digit decimal format to BCD format
+  * @param  __VALUE__ Byte to be converted
+  * @retval Converted byte
+  */
+#define __LL_RTC_CONVERT_BIN2BCD(__VALUE__) (uint8_t)((((__VALUE__) / 10U) << 4U) | ((__VALUE__) % 10U))
+
+/**
+  * @brief  Helper macro to convert a value from BCD format to 2 digit decimal format
+  * @param  __VALUE__ BCD value to be converted
+  * @retval Converted byte
+  */
+#define __LL_RTC_CONVERT_BCD2BIN(__VALUE__) (uint8_t)(((uint8_t)((__VALUE__) & (uint8_t)0xF0U) >> (uint8_t)0x4U) * 10U + ((__VALUE__) & (uint8_t)0x0FU))
+
+/**
+  * @}
+  */
+
+/** @defgroup RTC_LL_EM_Date Date helper Macros
+  * @{
+  */
+
+/**
+  * @brief  Helper macro to retrieve weekday.
+  * @param  __RTC_DATE__ Date returned by @ref  LL_RTC_DATE_Get function.
+  * @retval Returned value can be one of the following values:
+  *         @arg @ref LL_RTC_WEEKDAY_MONDAY
+  *         @arg @ref LL_RTC_WEEKDAY_TUESDAY
+  *         @arg @ref LL_RTC_WEEKDAY_WEDNESDAY
+  *         @arg @ref LL_RTC_WEEKDAY_THURSDAY
+  *         @arg @ref LL_RTC_WEEKDAY_FRIDAY
+  *         @arg @ref LL_RTC_WEEKDAY_SATURDAY
+  *         @arg @ref LL_RTC_WEEKDAY_SUNDAY
+  */
+#define __LL_RTC_GET_WEEKDAY(__RTC_DATE__) (((__RTC_DATE__) >> RTC_OFFSET_WEEKDAY) & 0x000000FFU)
+
+/**
+  * @brief  Helper macro to retrieve Year in BCD format
+  * @param  __RTC_DATE__ Value returned by @ref  LL_RTC_DATE_Get
+  * @retval Year in BCD format (0x00 . . . 0x99)
+  */
+#define __LL_RTC_GET_YEAR(__RTC_DATE__) ((__RTC_DATE__) & 0x000000FFU)
+
+/**
+  * @brief  Helper macro to retrieve Month in BCD format
+  * @param  __RTC_DATE__ Value returned by @ref  LL_RTC_DATE_Get
+  * @retval Returned value can be one of the following values:
+  *         @arg @ref LL_RTC_MONTH_JANUARY
+  *         @arg @ref LL_RTC_MONTH_FEBRUARY
+  *         @arg @ref LL_RTC_MONTH_MARCH
+  *         @arg @ref LL_RTC_MONTH_APRIL
+  *         @arg @ref LL_RTC_MONTH_MAY
+  *         @arg @ref LL_RTC_MONTH_JUNE
+  *         @arg @ref LL_RTC_MONTH_JULY
+  *         @arg @ref LL_RTC_MONTH_AUGUST
+  *         @arg @ref LL_RTC_MONTH_SEPTEMBER
+  *         @arg @ref LL_RTC_MONTH_OCTOBER
+  *         @arg @ref LL_RTC_MONTH_NOVEMBER
+  *         @arg @ref LL_RTC_MONTH_DECEMBER
+  */
+#define __LL_RTC_GET_MONTH(__RTC_DATE__) (((__RTC_DATE__) >>RTC_OFFSET_MONTH) & 0x000000FFU)
+
+/**
+  * @brief  Helper macro to retrieve Day in BCD format
+  * @param  __RTC_DATE__ Value returned by @ref  LL_RTC_DATE_Get
+  * @retval Day in BCD format (0x01 . . . 0x31)
+  */
+#define __LL_RTC_GET_DAY(__RTC_DATE__) (((__RTC_DATE__) >>RTC_OFFSET_DAY) & 0x000000FFU)
+
+/**
+  * @}
+  */
+
+/** @defgroup RTC_LL_EM_Time Time helper Macros
+  * @{
+  */
+
+/**
+  * @brief  Helper macro to retrieve hour in BCD format
+  * @param  __RTC_TIME__ RTC time returned by @ref LL_RTC_TIME_Get function
+  * @retval Hours in BCD format (0x01. . .0x12 or between Min_Data=0x00 and Max_Data=0x23)
+  */
+#define __LL_RTC_GET_HOUR(__RTC_TIME__) (((__RTC_TIME__) >> RTC_OFFSET_HOUR) & 0x000000FFU)
+
+/**
+  * @brief  Helper macro to retrieve minute in BCD format
+  * @param  __RTC_TIME__ RTC time returned by @ref LL_RTC_TIME_Get function
+  * @retval Minutes in BCD format (0x00. . .0x59)
+  */
+#define __LL_RTC_GET_MINUTE(__RTC_TIME__) (((__RTC_TIME__) >> RTC_OFFSET_MINUTE) & 0x000000FFU)
+
+/**
+  * @brief  Helper macro to retrieve second in BCD format
+  * @param  __RTC_TIME__ RTC time returned by @ref LL_RTC_TIME_Get function
+  * @retval Seconds in  format (0x00. . .0x59)
+  */
+#define __LL_RTC_GET_SECOND(__RTC_TIME__) ((__RTC_TIME__) & 0x000000FFU)
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/* Exported functions --------------------------------------------------------*/
+/** @defgroup RTC_LL_Exported_Functions RTC Exported Functions
+  * @{
+  */
+
+/** @defgroup RTC_LL_EF_Configuration Configuration
+  * @{
+  */
+
+/**
+  * @brief  Set Hours format (24 hour/day or AM/PM hour format)
+  * @note   Bit is write-protected. @ref LL_RTC_DisableWriteProtection function should be called before.
+  * @note   It can be written in initialization mode only (@ref LL_RTC_EnableInitMode function)
+  * @rmtoll CR           FMT           LL_RTC_SetHourFormat
+  * @param  RTCx RTC Instance
+  * @param  HourFormat This parameter can be one of the following values:
+  *         @arg @ref LL_RTC_HOURFORMAT_24HOUR
+  *         @arg @ref LL_RTC_HOURFORMAT_AMPM
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_SetHourFormat(RTC_TypeDef *RTCx, uint32_t HourFormat)
+{
+  MODIFY_REG(RTCx->CR, RTC_CR_FMT, HourFormat);
+}
+
+/**
+  * @brief  Get Hours format (24 hour/day or AM/PM hour format)
+  * @rmtoll CR           FMT           LL_RTC_GetHourFormat
+  * @param  RTCx RTC Instance
+  * @retval Returned value can be one of the following values:
+  *         @arg @ref LL_RTC_HOURFORMAT_24HOUR
+  *         @arg @ref LL_RTC_HOURFORMAT_AMPM
+  */
+__STATIC_INLINE uint32_t LL_RTC_GetHourFormat(RTC_TypeDef *RTCx)
+{
+  return (uint32_t)(READ_BIT(RTCx->CR, RTC_CR_FMT));
+}
+
+/**
+  * @brief  Select the flag to be routed to RTC_ALARM output
+  * @note   Bit is write-protected. @ref LL_RTC_DisableWriteProtection function should be called before.
+  * @rmtoll CR           OSEL          LL_RTC_SetAlarmOutEvent
+  * @param  RTCx RTC Instance
+  * @param  AlarmOutput This parameter can be one of the following values:
+  *         @arg @ref LL_RTC_ALARMOUT_DISABLE
+  *         @arg @ref LL_RTC_ALARMOUT_ALMA
+  *         @arg @ref LL_RTC_ALARMOUT_ALMB
+  *         @arg @ref LL_RTC_ALARMOUT_WAKEUP
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_SetAlarmOutEvent(RTC_TypeDef *RTCx, uint32_t AlarmOutput)
+{
+  MODIFY_REG(RTCx->CR, RTC_CR_OSEL, AlarmOutput);
+}
+
+/**
+  * @brief  Get the flag to be routed to RTC_ALARM output
+  * @rmtoll CR           OSEL          LL_RTC_GetAlarmOutEvent
+  * @param  RTCx RTC Instance
+  * @retval Returned value can be one of the following values:
+  *         @arg @ref LL_RTC_ALARMOUT_DISABLE
+  *         @arg @ref LL_RTC_ALARMOUT_ALMA
+  *         @arg @ref LL_RTC_ALARMOUT_ALMB
+  *         @arg @ref LL_RTC_ALARMOUT_WAKEUP
+  */
+__STATIC_INLINE uint32_t LL_RTC_GetAlarmOutEvent(RTC_TypeDef *RTCx)
+{
+  return (uint32_t)(READ_BIT(RTCx->CR, RTC_CR_OSEL));
+}
+
+/**
+  * @brief  Set RTC_ALARM output type (ALARM in push-pull or open-drain output)
+  * @note   Used only when RTC_ALARM is mapped on PC13
+  * @rmtoll OR        ALARMOUTTYPE  LL_RTC_SetAlarmOutputType
+  * @param  RTCx RTC Instance
+  * @param  Output This parameter can be one of the following values:
+  *         @arg @ref LL_RTC_ALARM_OUTPUTTYPE_OPENDRAIN
+  *         @arg @ref LL_RTC_ALARM_OUTPUTTYPE_PUSHPULL
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_SetAlarmOutputType(RTC_TypeDef *RTCx, uint32_t Output)
+{
+  MODIFY_REG(RTCx->OR, RTC_OR_ALARMOUTTYPE, Output);
+}
+
+/**
+  * @brief  Get RTC_ALARM output type (ALARM in push-pull or open-drain output)
+  * @note   used only when RTC_ALARM is mapped on PC13
+  * @rmtoll OR        ALARMOUTTYPE  LL_RTC_GetAlarmOutputType
+  * @param  RTCx RTC Instance
+  * @retval Returned value can be one of the following values:
+  *         @arg @ref LL_RTC_ALARM_OUTPUTTYPE_OPENDRAIN
+  *         @arg @ref LL_RTC_ALARM_OUTPUTTYPE_PUSHPULL
+  */
+__STATIC_INLINE uint32_t LL_RTC_GetAlarmOutputType(RTC_TypeDef *RTCx)
+{
+  return (uint32_t)(READ_BIT(RTCx->OR, RTC_OR_ALARMOUTTYPE));
+}
+
+/**
+  * @brief  Enable initialization mode
+  * @note   Initialization mode is used to program time and date register (RTC_TR and RTC_DR)
+  *         and prescaler register (RTC_PRER).
+  *         Counters are stopped and start counting from the new value when INIT is reset.
+  * @rmtoll ISR          INIT          LL_RTC_EnableInitMode
+  * @param  RTCx RTC Instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_EnableInitMode(RTC_TypeDef *RTCx)
+{
+  /* Set the Initialization mode */
+  WRITE_REG(RTCx->ISR, RTC_INIT_MASK);
+}
+
+/**
+  * @brief  Disable initialization mode (Free running mode)
+  * @rmtoll ISR          INIT          LL_RTC_DisableInitMode
+  * @param  RTCx RTC Instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_DisableInitMode(RTC_TypeDef *RTCx)
+{
+  /* Exit Initialization mode */
+  WRITE_REG(RTCx->ISR, (uint32_t)~RTC_ISR_INIT);
+}
+
+/**
+  * @brief  Set Output polarity (pin is low when ALRAF/ALRBF/WUTF is asserted)
+  * @note   Bit is write-protected. @ref LL_RTC_DisableWriteProtection function should be called before.
+  * @rmtoll CR           POL           LL_RTC_SetOutputPolarity
+  * @param  RTCx RTC Instance
+  * @param  Polarity This parameter can be one of the following values:
+  *         @arg @ref LL_RTC_OUTPUTPOLARITY_PIN_HIGH
+  *         @arg @ref LL_RTC_OUTPUTPOLARITY_PIN_LOW
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_SetOutputPolarity(RTC_TypeDef *RTCx, uint32_t Polarity)
+{
+  MODIFY_REG(RTCx->CR, RTC_CR_POL, Polarity);
+}
+
+/**
+  * @brief  Get Output polarity
+  * @rmtoll CR           POL           LL_RTC_GetOutputPolarity
+  * @param  RTCx RTC Instance
+  * @retval Returned value can be one of the following values:
+  *         @arg @ref LL_RTC_OUTPUTPOLARITY_PIN_HIGH
+  *         @arg @ref LL_RTC_OUTPUTPOLARITY_PIN_LOW
+  */
+__STATIC_INLINE uint32_t LL_RTC_GetOutputPolarity(RTC_TypeDef *RTCx)
+{
+  return (uint32_t)(READ_BIT(RTCx->CR, RTC_CR_POL));
+}
+
+/**
+  * @brief  Enable Bypass the shadow registers
+  * @note   Bit is write-protected. @ref LL_RTC_DisableWriteProtection function should be called before.
+  * @rmtoll CR           BYPSHAD       LL_RTC_EnableShadowRegBypass
+  * @param  RTCx RTC Instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_EnableShadowRegBypass(RTC_TypeDef *RTCx)
+{
+  SET_BIT(RTCx->CR, RTC_CR_BYPSHAD);
+}
+
+/**
+  * @brief  Disable Bypass the shadow registers
+  * @rmtoll CR           BYPSHAD       LL_RTC_DisableShadowRegBypass
+  * @param  RTCx RTC Instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_DisableShadowRegBypass(RTC_TypeDef *RTCx)
+{
+  CLEAR_BIT(RTCx->CR, RTC_CR_BYPSHAD);
+}
+
+/**
+  * @brief  Check if Shadow registers bypass is enabled or not.
+  * @rmtoll CR           BYPSHAD       LL_RTC_IsShadowRegBypassEnabled
+  * @param  RTCx RTC Instance
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_RTC_IsShadowRegBypassEnabled(RTC_TypeDef *RTCx)
+{
+  return ((READ_BIT(RTCx->CR, RTC_CR_BYPSHAD) == (RTC_CR_BYPSHAD)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Enable RTC_REFIN reference clock detection (50 or 60 Hz)
+  * @note   Bit is write-protected. @ref LL_RTC_DisableWriteProtection function should be called before.
+  * @note   It can be written in initialization mode only (@ref LL_RTC_EnableInitMode function)
+  * @rmtoll CR           REFCKON       LL_RTC_EnableRefClock
+  * @param  RTCx RTC Instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_EnableRefClock(RTC_TypeDef *RTCx)
+{
+  SET_BIT(RTCx->CR, RTC_CR_REFCKON);
+}
+
+/**
+  * @brief  Disable RTC_REFIN reference clock detection (50 or 60 Hz)
+  * @note   Bit is write-protected. @ref LL_RTC_DisableWriteProtection function should be called before.
+  * @note   It can be written in initialization mode only (@ref LL_RTC_EnableInitMode function)
+  * @rmtoll CR           REFCKON       LL_RTC_DisableRefClock
+  * @param  RTCx RTC Instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_DisableRefClock(RTC_TypeDef *RTCx)
+{
+  CLEAR_BIT(RTCx->CR, RTC_CR_REFCKON);
+}
+
+/**
+  * @brief  Set Asynchronous prescaler factor
+  * @rmtoll PRER         PREDIV_A      LL_RTC_SetAsynchPrescaler
+  * @param  RTCx RTC Instance
+  * @param  AsynchPrescaler Value between Min_Data = 0 and Max_Data = 0x7F
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_SetAsynchPrescaler(RTC_TypeDef *RTCx, uint32_t AsynchPrescaler)
+{
+  MODIFY_REG(RTCx->PRER, RTC_PRER_PREDIV_A, AsynchPrescaler << RTC_PRER_PREDIV_A_Pos);
+}
+
+/**
+  * @brief  Set Synchronous prescaler factor
+  * @rmtoll PRER         PREDIV_S      LL_RTC_SetSynchPrescaler
+  * @param  RTCx RTC Instance
+  * @param  SynchPrescaler Value between Min_Data = 0 and Max_Data = 0x7FFF
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_SetSynchPrescaler(RTC_TypeDef *RTCx, uint32_t SynchPrescaler)
+{
+  MODIFY_REG(RTCx->PRER, RTC_PRER_PREDIV_S, SynchPrescaler);
+}
+
+/**
+  * @brief  Get Asynchronous prescaler factor
+  * @rmtoll PRER         PREDIV_A      LL_RTC_GetAsynchPrescaler
+  * @param  RTCx RTC Instance
+  * @retval Value between Min_Data = 0 and Max_Data = 0x7F
+  */
+__STATIC_INLINE uint32_t LL_RTC_GetAsynchPrescaler(RTC_TypeDef *RTCx)
+{
+  return (uint32_t)(READ_BIT(RTCx->PRER, RTC_PRER_PREDIV_A) >> RTC_PRER_PREDIV_A_Pos);
+}
+
+/**
+  * @brief  Get Synchronous prescaler factor
+  * @rmtoll PRER         PREDIV_S      LL_RTC_GetSynchPrescaler
+  * @param  RTCx RTC Instance
+  * @retval Value between Min_Data = 0 and Max_Data = 0x7FFF
+  */
+__STATIC_INLINE uint32_t LL_RTC_GetSynchPrescaler(RTC_TypeDef *RTCx)
+{
+  return (uint32_t)(READ_BIT(RTCx->PRER, RTC_PRER_PREDIV_S));
+}
+
+/**
+  * @brief  Enable the write protection for RTC registers.
+  * @rmtoll WPR          KEY           LL_RTC_EnableWriteProtection
+  * @param  RTCx RTC Instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_EnableWriteProtection(RTC_TypeDef *RTCx)
+{
+  WRITE_REG(RTCx->WPR, RTC_WRITE_PROTECTION_DISABLE);
+}
+
+/**
+  * @brief  Disable the write protection for RTC registers.
+  * @rmtoll WPR          KEY           LL_RTC_DisableWriteProtection
+  * @param  RTCx RTC Instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_DisableWriteProtection(RTC_TypeDef *RTCx)
+{
+  WRITE_REG(RTCx->WPR, RTC_WRITE_PROTECTION_ENABLE_1);
+  WRITE_REG(RTCx->WPR, RTC_WRITE_PROTECTION_ENABLE_2);
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup RTC_LL_EF_Time Time
+  * @{
+  */
+
+/**
+  * @brief  Set time format (AM/24-hour or PM notation)
+  * @note   Bit is write-protected. @ref LL_RTC_DisableWriteProtection function should be called before.
+  * @note   It can be written in initialization mode only (@ref LL_RTC_EnableInitMode function)
+  * @rmtoll TR           PM            LL_RTC_TIME_SetFormat
+  * @param  RTCx RTC Instance
+  * @param  TimeFormat This parameter can be one of the following values:
+  *         @arg @ref LL_RTC_TIME_FORMAT_AM_OR_24
+  *         @arg @ref LL_RTC_TIME_FORMAT_PM
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_TIME_SetFormat(RTC_TypeDef *RTCx, uint32_t TimeFormat)
+{
+  MODIFY_REG(RTCx->TR, RTC_TR_PM, TimeFormat);
+}
+
+/**
+  * @brief  Get time format (AM or PM notation)
+  * @note if RTC shadow registers are not bypassed (BYPSHAD=0), need to check if RSF flag is set
+  *       before reading this bit
+  * @note Read either RTC_SSR or RTC_TR locks the values in the higher-order calendar
+  *       shadow registers until RTC_DR is read (LL_RTC_ReadReg(RTC, DR)).
+  * @rmtoll TR           PM            LL_RTC_TIME_GetFormat
+  * @param  RTCx RTC Instance
+  * @retval Returned value can be one of the following values:
+  *         @arg @ref LL_RTC_TIME_FORMAT_AM_OR_24
+  *         @arg @ref LL_RTC_TIME_FORMAT_PM
+  */
+__STATIC_INLINE uint32_t LL_RTC_TIME_GetFormat(RTC_TypeDef *RTCx)
+{
+  return (uint32_t)(READ_BIT(RTCx->TR, RTC_TR_PM));
+}
+
+/**
+  * @brief  Set Hours in BCD format
+  * @note   Bit is write-protected. @ref LL_RTC_DisableWriteProtection function should be called before.
+  * @note   It can be written in initialization mode only (@ref LL_RTC_EnableInitMode function)
+  * @note helper macro __LL_RTC_CONVERT_BIN2BCD is available to convert hour from binary to BCD format
+  * @rmtoll TR           HT            LL_RTC_TIME_SetHour\n
+  *         TR           HU            LL_RTC_TIME_SetHour
+  * @param  RTCx RTC Instance
+  * @param  Hours Value between Min_Data=0x01 and Max_Data=0x12 or between Min_Data=0x00 and Max_Data=0x23
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_TIME_SetHour(RTC_TypeDef *RTCx, uint32_t Hours)
+{
+  MODIFY_REG(RTCx->TR, (RTC_TR_HT | RTC_TR_HU),
+             (((Hours & 0xF0U) << (RTC_TR_HT_Pos - 4U)) | ((Hours & 0x0FU) << RTC_TR_HU_Pos)));
+}
+
+/**
+  * @brief  Get Hours in BCD format
+  * @note if RTC shadow registers are not bypassed (BYPSHAD=0), need to check if RSF flag is set
+  *       before reading this bit
+  * @note Read either RTC_SSR or RTC_TR locks the values in the higher-order calendar
+  *       shadow registers until RTC_DR is read (LL_RTC_ReadReg(RTC, DR)).
+  * @note helper macro __LL_RTC_CONVERT_BCD2BIN is available to convert hour from BCD to
+  *       Binary format
+  * @rmtoll TR           HT            LL_RTC_TIME_GetHour\n
+  *         TR           HU            LL_RTC_TIME_GetHour
+  * @param  RTCx RTC Instance
+  * @retval Value between Min_Data=0x01 and Max_Data=0x12 or between Min_Data=0x00 and Max_Data=0x23
+  */
+__STATIC_INLINE uint32_t LL_RTC_TIME_GetHour(RTC_TypeDef *RTCx)
+{
+  return (uint32_t)((READ_BIT(RTCx->TR, (RTC_TR_HT | RTC_TR_HU))) >> RTC_TR_HU_Pos);
+}
+
+/**
+  * @brief  Set Minutes in BCD format
+  * @note   Bit is write-protected. @ref LL_RTC_DisableWriteProtection function should be called before.
+  * @note   It can be written in initialization mode only (@ref LL_RTC_EnableInitMode function)
+  * @note helper macro __LL_RTC_CONVERT_BIN2BCD is available to convert Minutes from binary to BCD format
+  * @rmtoll TR           MNT           LL_RTC_TIME_SetMinute\n
+  *         TR           MNU           LL_RTC_TIME_SetMinute
+  * @param  RTCx RTC Instance
+  * @param  Minutes Value between Min_Data=0x00 and Max_Data=0x59
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_TIME_SetMinute(RTC_TypeDef *RTCx, uint32_t Minutes)
+{
+  MODIFY_REG(RTCx->TR, (RTC_TR_MNT | RTC_TR_MNU),
+             (((Minutes & 0xF0U) << (RTC_TR_MNT_Pos - 4U)) | ((Minutes & 0x0FU) << RTC_TR_MNU_Pos)));
+}
+
+/**
+  * @brief  Get Minutes in BCD format
+  * @note if RTC shadow registers are not bypassed (BYPSHAD=0), need to check if RSF flag is set
+  *       before reading this bit
+  * @note Read either RTC_SSR or RTC_TR locks the values in the higher-order calendar
+  *       shadow registers until RTC_DR is read (LL_RTC_ReadReg(RTC, DR)).
+  * @note helper macro __LL_RTC_CONVERT_BCD2BIN is available to convert minute from BCD
+  *       to Binary format
+  * @rmtoll TR           MNT           LL_RTC_TIME_GetMinute\n
+  *         TR           MNU           LL_RTC_TIME_GetMinute
+  * @param  RTCx RTC Instance
+  * @retval Value between Min_Data=0x00 and Max_Data=0x59
+  */
+__STATIC_INLINE uint32_t LL_RTC_TIME_GetMinute(RTC_TypeDef *RTCx)
+{
+  return (uint32_t)(READ_BIT(RTCx->TR, (RTC_TR_MNT | RTC_TR_MNU)) >> RTC_TR_MNU_Pos);
+}
+
+/**
+  * @brief  Set Seconds in BCD format
+  * @note   Bit is write-protected. @ref LL_RTC_DisableWriteProtection function should be called before.
+  * @note   It can be written in initialization mode only (@ref LL_RTC_EnableInitMode function)
+  * @note helper macro __LL_RTC_CONVERT_BIN2BCD is available to convert Seconds from binary to BCD format
+  * @rmtoll TR           ST            LL_RTC_TIME_SetSecond\n
+  *         TR           SU            LL_RTC_TIME_SetSecond
+  * @param  RTCx RTC Instance
+  * @param  Seconds Value between Min_Data=0x00 and Max_Data=0x59
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_TIME_SetSecond(RTC_TypeDef *RTCx, uint32_t Seconds)
+{
+  MODIFY_REG(RTCx->TR, (RTC_TR_ST | RTC_TR_SU),
+             (((Seconds & 0xF0U) << (RTC_TR_ST_Pos - 4U)) | ((Seconds & 0x0FU) << RTC_TR_SU_Pos)));
+}
+
+/**
+  * @brief  Get Seconds in BCD format
+  * @note if RTC shadow registers are not bypassed (BYPSHAD=0), need to check if RSF flag is set
+  *       before reading this bit
+  * @note Read either RTC_SSR or RTC_TR locks the values in the higher-order calendar
+  *       shadow registers until RTC_DR is read (LL_RTC_ReadReg(RTC, DR)).
+  * @note helper macro __LL_RTC_CONVERT_BCD2BIN is available to convert Seconds from BCD
+  *       to Binary format
+  * @rmtoll TR           ST            LL_RTC_TIME_GetSecond\n
+  *         TR           SU            LL_RTC_TIME_GetSecond
+  * @param  RTCx RTC Instance
+  * @retval Value between Min_Data=0x00 and Max_Data=0x59
+  */
+__STATIC_INLINE uint32_t LL_RTC_TIME_GetSecond(RTC_TypeDef *RTCx)
+{
+  return (uint32_t)(READ_BIT(RTCx->TR, (RTC_TR_ST | RTC_TR_SU)) >> RTC_TR_SU_Pos);
+}
+
+/**
+  * @brief  Set time (hour, minute and second) in BCD format
+  * @note   Bit is write-protected. @ref LL_RTC_DisableWriteProtection function should be called before.
+  * @note   It can be written in initialization mode only (@ref LL_RTC_EnableInitMode function)
+  * @note TimeFormat and Hours should follow the same format
+  * @rmtoll TR           PM            LL_RTC_TIME_Config\n
+  *         TR           HT            LL_RTC_TIME_Config\n
+  *         TR           HU            LL_RTC_TIME_Config\n
+  *         TR           MNT           LL_RTC_TIME_Config\n
+  *         TR           MNU           LL_RTC_TIME_Config\n
+  *         TR           ST            LL_RTC_TIME_Config\n
+  *         TR           SU            LL_RTC_TIME_Config
+  * @param  RTCx RTC Instance
+  * @param  Format12_24 This parameter can be one of the following values:
+  *         @arg @ref LL_RTC_TIME_FORMAT_AM_OR_24
+  *         @arg @ref LL_RTC_TIME_FORMAT_PM
+  * @param  Hours Value between Min_Data=0x01 and Max_Data=0x12 or between Min_Data=0x00 and Max_Data=0x23
+  * @param  Minutes Value between Min_Data=0x00 and Max_Data=0x59
+  * @param  Seconds Value between Min_Data=0x00 and Max_Data=0x59
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_TIME_Config(RTC_TypeDef *RTCx, uint32_t Format12_24, uint32_t Hours, uint32_t Minutes, uint32_t Seconds)
+{
+  uint32_t temp;
+
+  temp = Format12_24                                                                            | \
+         (((Hours   & 0xF0U) << (RTC_TR_HT_Pos  - 4U)) | ((Hours & 0x0FU) << RTC_TR_HU_Pos))    | \
+         (((Minutes & 0xF0U) << (RTC_TR_MNT_Pos - 4U)) | ((Minutes & 0x0FU) << RTC_TR_MNU_Pos)) | \
+         (((Seconds & 0xF0U) << (RTC_TR_ST_Pos  - 4U)) | ((Seconds & 0x0FU) << RTC_TR_SU_Pos));
+  MODIFY_REG(RTCx->TR, (RTC_TR_PM | RTC_TR_HT | RTC_TR_HU | RTC_TR_MNT | RTC_TR_MNU | RTC_TR_ST | RTC_TR_SU), temp);
+}
+
+/**
+  * @brief  Get time (hour, minute and second) in BCD format
+  * @note if RTC shadow registers are not bypassed (BYPSHAD=0), need to check if RSF flag is set
+  *       before reading this bit
+  * @note Read either RTC_SSR or RTC_TR locks the values in the higher-order calendar
+  *       shadow registers until RTC_DR is read (LL_RTC_ReadReg(RTC, DR)).
+  * @note helper macros __LL_RTC_GET_HOUR, __LL_RTC_GET_MINUTE and __LL_RTC_GET_SECOND
+  *       are available to get independently each parameter.
+  * @rmtoll TR           HT            LL_RTC_TIME_Get\n
+  *         TR           HU            LL_RTC_TIME_Get\n
+  *         TR           MNT           LL_RTC_TIME_Get\n
+  *         TR           MNU           LL_RTC_TIME_Get\n
+  *         TR           ST            LL_RTC_TIME_Get\n
+  *         TR           SU            LL_RTC_TIME_Get
+  * @param  RTCx RTC Instance
+  * @retval Combination of hours, minutes and seconds (Format: 0x00HHMMSS).
+  */
+__STATIC_INLINE uint32_t LL_RTC_TIME_Get(RTC_TypeDef *RTCx)
+{
+  return (uint32_t)(READ_BIT(RTCx->TR, (RTC_TR_HT | RTC_TR_HU | RTC_TR_MNT | RTC_TR_MNU | RTC_TR_ST | RTC_TR_SU)));
+}
+
+/**
+  * @brief  Memorize whether the daylight saving time change has been performed
+  * @note   Bit is write-protected. @ref LL_RTC_DisableWriteProtection function should be called before.
+  * @rmtoll CR           BKP           LL_RTC_TIME_EnableDayLightStore
+  * @param  RTCx RTC Instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_TIME_EnableDayLightStore(RTC_TypeDef *RTCx)
+{
+  SET_BIT(RTCx->CR, RTC_CR_BKP);
+}
+
+/**
+  * @brief  Disable memorization whether the daylight saving time change has been performed.
+  * @note   Bit is write-protected. @ref LL_RTC_DisableWriteProtection function should be called before.
+  * @rmtoll CR           BKP           LL_RTC_TIME_DisableDayLightStore
+  * @param  RTCx RTC Instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_TIME_DisableDayLightStore(RTC_TypeDef *RTCx)
+{
+  CLEAR_BIT(RTCx->CR, RTC_CR_BKP);
+}
+
+/**
+  * @brief  Check if RTC Day Light Saving stored operation has been enabled or not
+  * @rmtoll CR           BKP           LL_RTC_TIME_IsDayLightStoreEnabled
+  * @param  RTCx RTC Instance
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_RTC_TIME_IsDayLightStoreEnabled(RTC_TypeDef *RTCx)
+{
+  return ((READ_BIT(RTCx->CR, RTC_CR_BKP) == (RTC_CR_BKP)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Subtract 1 hour (winter time change)
+  * @note   Bit is write-protected. @ref LL_RTC_DisableWriteProtection function should be called before.
+  * @rmtoll CR           SUB1H         LL_RTC_TIME_DecHour
+  * @param  RTCx RTC Instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_TIME_DecHour(RTC_TypeDef *RTCx)
+{
+  SET_BIT(RTCx->CR, RTC_CR_SUB1H);
+}
+
+/**
+  * @brief  Add 1 hour (summer time change)
+  * @note   Bit is write-protected. @ref LL_RTC_DisableWriteProtection function should be called before.
+  * @rmtoll CR           ADD1H         LL_RTC_TIME_IncHour
+  * @param  RTCx RTC Instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_TIME_IncHour(RTC_TypeDef *RTCx)
+{
+  SET_BIT(RTCx->CR, RTC_CR_ADD1H);
+}
+
+/**
+  * @brief  Get subseconds value in the synchronous prescaler counter.
+  * @note  You can use both SubSeconds value and SecondFraction (PREDIV_S through
+  *        LL_RTC_GetSynchPrescaler function) terms returned to convert Calendar
+  *        SubSeconds value in second fraction ratio with time unit following
+  *        generic formula:
+  *          ==> Seconds fraction ratio * time_unit =
+  *                 [(SecondFraction-SubSeconds)/(SecondFraction+1)] * time_unit
+  *        This conversion can be performed only if no shift operation is pending
+  *        (ie. SHFP=0) when PREDIV_S >= SS.
+  * @rmtoll SSR          SS            LL_RTC_TIME_GetSubSecond
+  * @param  RTCx RTC Instance
+  * @retval Subseconds value (number between 0 and 65535)
+  */
+__STATIC_INLINE uint32_t LL_RTC_TIME_GetSubSecond(RTC_TypeDef *RTCx)
+{
+  return (uint32_t)(READ_BIT(RTCx->SSR, RTC_SSR_SS));
+}
+
+/**
+  * @brief  Synchronize to a remote clock with a high degree of precision.
+  * @note   This operation effectively subtracts from (delays) or advance the clock of a fraction of a second.
+  * @note   Bit is write-protected. @ref LL_RTC_DisableWriteProtection function should be called before.
+  * @note   When REFCKON is set, firmware must not write to Shift control register.
+  * @rmtoll SHIFTR       ADD1S         LL_RTC_TIME_Synchronize\n
+  *         SHIFTR       SUBFS         LL_RTC_TIME_Synchronize
+  * @param  RTCx RTC Instance
+  * @param  ShiftSecond This parameter can be one of the following values:
+  *         @arg @ref LL_RTC_SHIFT_SECOND_DELAY
+  *         @arg @ref LL_RTC_SHIFT_SECOND_ADVANCE
+  * @param  Fraction Number of Seconds Fractions (any value from 0 to 0x7FFF)
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_TIME_Synchronize(RTC_TypeDef *RTCx, uint32_t ShiftSecond, uint32_t Fraction)
+{
+  WRITE_REG(RTCx->SHIFTR, ShiftSecond | Fraction);
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup RTC_LL_EF_Date Date
+  * @{
+  */
+
+/**
+  * @brief  Set Year in BCD format
+  * @note helper macro __LL_RTC_CONVERT_BIN2BCD is available to convert Year from binary to BCD format
+  * @rmtoll DR           YT            LL_RTC_DATE_SetYear\n
+  *         DR           YU            LL_RTC_DATE_SetYear
+  * @param  RTCx RTC Instance
+  * @param  Year Value between Min_Data=0x00 and Max_Data=0x99
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_DATE_SetYear(RTC_TypeDef *RTCx, uint32_t Year)
+{
+  MODIFY_REG(RTCx->DR, (RTC_DR_YT | RTC_DR_YU),
+             (((Year & 0xF0U) << (RTC_DR_YT_Pos - 4U)) | ((Year & 0x0FU) << RTC_DR_YU_Pos)));
+}
+
+/**
+  * @brief  Get Year in BCD format
+  * @note if RTC shadow registers are not bypassed (BYPSHAD=0), need to check if RSF flag is set
+  *       before reading this bit
+  * @note helper macro __LL_RTC_CONVERT_BCD2BIN is available to convert Year from BCD to Binary format
+  * @rmtoll DR           YT            LL_RTC_DATE_GetYear\n
+  *         DR           YU            LL_RTC_DATE_GetYear
+  * @param  RTCx RTC Instance
+  * @retval Value between Min_Data=0x00 and Max_Data=0x99
+  */
+__STATIC_INLINE uint32_t LL_RTC_DATE_GetYear(RTC_TypeDef *RTCx)
+{
+  return (uint32_t)((READ_BIT(RTCx->DR, (RTC_DR_YT | RTC_DR_YU))) >> RTC_DR_YU_Pos);
+}
+
+/**
+  * @brief  Set Week day
+  * @rmtoll DR           WDU           LL_RTC_DATE_SetWeekDay
+  * @param  RTCx RTC Instance
+  * @param  WeekDay This parameter can be one of the following values:
+  *         @arg @ref LL_RTC_WEEKDAY_MONDAY
+  *         @arg @ref LL_RTC_WEEKDAY_TUESDAY
+  *         @arg @ref LL_RTC_WEEKDAY_WEDNESDAY
+  *         @arg @ref LL_RTC_WEEKDAY_THURSDAY
+  *         @arg @ref LL_RTC_WEEKDAY_FRIDAY
+  *         @arg @ref LL_RTC_WEEKDAY_SATURDAY
+  *         @arg @ref LL_RTC_WEEKDAY_SUNDAY
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_DATE_SetWeekDay(RTC_TypeDef *RTCx, uint32_t WeekDay)
+{
+  MODIFY_REG(RTCx->DR, RTC_DR_WDU, WeekDay << RTC_DR_WDU_Pos);
+}
+
+/**
+  * @brief  Get Week day
+  * @note if RTC shadow registers are not bypassed (BYPSHAD=0), need to check if RSF flag is set
+  *       before reading this bit
+  * @rmtoll DR           WDU           LL_RTC_DATE_GetWeekDay
+  * @param  RTCx RTC Instance
+  * @retval Returned value can be one of the following values:
+  *         @arg @ref LL_RTC_WEEKDAY_MONDAY
+  *         @arg @ref LL_RTC_WEEKDAY_TUESDAY
+  *         @arg @ref LL_RTC_WEEKDAY_WEDNESDAY
+  *         @arg @ref LL_RTC_WEEKDAY_THURSDAY
+  *         @arg @ref LL_RTC_WEEKDAY_FRIDAY
+  *         @arg @ref LL_RTC_WEEKDAY_SATURDAY
+  *         @arg @ref LL_RTC_WEEKDAY_SUNDAY
+  */
+__STATIC_INLINE uint32_t LL_RTC_DATE_GetWeekDay(RTC_TypeDef *RTCx)
+{
+  return (uint32_t)(READ_BIT(RTCx->DR, RTC_DR_WDU) >> RTC_DR_WDU_Pos);
+}
+
+/**
+  * @brief  Set Month in BCD format
+  * @note helper macro __LL_RTC_CONVERT_BIN2BCD is available to convert Month from binary to BCD format
+  * @rmtoll DR           MT            LL_RTC_DATE_SetMonth\n
+  *         DR           MU            LL_RTC_DATE_SetMonth
+  * @param  RTCx RTC Instance
+  * @param  Month This parameter can be one of the following values:
+  *         @arg @ref LL_RTC_MONTH_JANUARY
+  *         @arg @ref LL_RTC_MONTH_FEBRUARY
+  *         @arg @ref LL_RTC_MONTH_MARCH
+  *         @arg @ref LL_RTC_MONTH_APRIL
+  *         @arg @ref LL_RTC_MONTH_MAY
+  *         @arg @ref LL_RTC_MONTH_JUNE
+  *         @arg @ref LL_RTC_MONTH_JULY
+  *         @arg @ref LL_RTC_MONTH_AUGUST
+  *         @arg @ref LL_RTC_MONTH_SEPTEMBER
+  *         @arg @ref LL_RTC_MONTH_OCTOBER
+  *         @arg @ref LL_RTC_MONTH_NOVEMBER
+  *         @arg @ref LL_RTC_MONTH_DECEMBER
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_DATE_SetMonth(RTC_TypeDef *RTCx, uint32_t Month)
+{
+  MODIFY_REG(RTCx->DR, (RTC_DR_MT | RTC_DR_MU),
+             (((Month & 0xF0U) << (RTC_DR_MT_Pos - 4U)) | ((Month & 0x0FU) << RTC_DR_MU_Pos)));
+}
+
+/**
+  * @brief  Get Month in BCD format
+  * @note if RTC shadow registers are not bypassed (BYPSHAD=0), need to check if RSF flag is set
+  *       before reading this bit
+  * @note helper macro __LL_RTC_CONVERT_BCD2BIN is available to convert Month from BCD to Binary format
+  * @rmtoll DR           MT            LL_RTC_DATE_GetMonth\n
+  *         DR           MU            LL_RTC_DATE_GetMonth
+  * @param  RTCx RTC Instance
+  * @retval Returned value can be one of the following values:
+  *         @arg @ref LL_RTC_MONTH_JANUARY
+  *         @arg @ref LL_RTC_MONTH_FEBRUARY
+  *         @arg @ref LL_RTC_MONTH_MARCH
+  *         @arg @ref LL_RTC_MONTH_APRIL
+  *         @arg @ref LL_RTC_MONTH_MAY
+  *         @arg @ref LL_RTC_MONTH_JUNE
+  *         @arg @ref LL_RTC_MONTH_JULY
+  *         @arg @ref LL_RTC_MONTH_AUGUST
+  *         @arg @ref LL_RTC_MONTH_SEPTEMBER
+  *         @arg @ref LL_RTC_MONTH_OCTOBER
+  *         @arg @ref LL_RTC_MONTH_NOVEMBER
+  *         @arg @ref LL_RTC_MONTH_DECEMBER
+  */
+__STATIC_INLINE uint32_t LL_RTC_DATE_GetMonth(RTC_TypeDef *RTCx)
+{
+  return (uint32_t)((READ_BIT(RTCx->DR, (RTC_DR_MT | RTC_DR_MU))) >> RTC_DR_MU_Pos);
+}
+
+/**
+  * @brief  Set Day in BCD format
+  * @note helper macro __LL_RTC_CONVERT_BIN2BCD is available to convert Day from binary to BCD format
+  * @rmtoll DR           DT            LL_RTC_DATE_SetDay\n
+  *         DR           DU            LL_RTC_DATE_SetDay
+  * @param  RTCx RTC Instance
+  * @param  Day Value between Min_Data=0x01 and Max_Data=0x31
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_DATE_SetDay(RTC_TypeDef *RTCx, uint32_t Day)
+{
+  MODIFY_REG(RTCx->DR, (RTC_DR_DT | RTC_DR_DU),
+             (((Day & 0xF0U) << (RTC_DR_DT_Pos - 4U)) | ((Day & 0x0FU) << RTC_DR_DU_Pos)));
+}
+
+/**
+  * @brief  Get Day in BCD format
+  * @note if RTC shadow registers are not bypassed (BYPSHAD=0), need to check if RSF flag is set
+  *       before reading this bit
+  * @note helper macro __LL_RTC_CONVERT_BCD2BIN is available to convert Day from BCD to Binary format
+  * @rmtoll DR           DT            LL_RTC_DATE_GetDay\n
+  *         DR           DU            LL_RTC_DATE_GetDay
+  * @param  RTCx RTC Instance
+  * @retval Value between Min_Data=0x01 and Max_Data=0x31
+  */
+__STATIC_INLINE uint32_t LL_RTC_DATE_GetDay(RTC_TypeDef *RTCx)
+{
+  return (uint32_t)((READ_BIT(RTCx->DR, (RTC_DR_DT | RTC_DR_DU))) >> RTC_DR_DU_Pos);
+}
+
+/**
+  * @brief  Set date (WeekDay, Day, Month and Year) in BCD format
+  * @rmtoll DR           WDU           LL_RTC_DATE_Config\n
+  *         DR           MT            LL_RTC_DATE_Config\n
+  *         DR           MU            LL_RTC_DATE_Config\n
+  *         DR           DT            LL_RTC_DATE_Config\n
+  *         DR           DU            LL_RTC_DATE_Config\n
+  *         DR           YT            LL_RTC_DATE_Config\n
+  *         DR           YU            LL_RTC_DATE_Config
+  * @param  RTCx RTC Instance
+  * @param  WeekDay This parameter can be one of the following values:
+  *         @arg @ref LL_RTC_WEEKDAY_MONDAY
+  *         @arg @ref LL_RTC_WEEKDAY_TUESDAY
+  *         @arg @ref LL_RTC_WEEKDAY_WEDNESDAY
+  *         @arg @ref LL_RTC_WEEKDAY_THURSDAY
+  *         @arg @ref LL_RTC_WEEKDAY_FRIDAY
+  *         @arg @ref LL_RTC_WEEKDAY_SATURDAY
+  *         @arg @ref LL_RTC_WEEKDAY_SUNDAY
+  * @param  Day Value between Min_Data=0x01 and Max_Data=0x31
+  * @param  Month This parameter can be one of the following values:
+  *         @arg @ref LL_RTC_MONTH_JANUARY
+  *         @arg @ref LL_RTC_MONTH_FEBRUARY
+  *         @arg @ref LL_RTC_MONTH_MARCH
+  *         @arg @ref LL_RTC_MONTH_APRIL
+  *         @arg @ref LL_RTC_MONTH_MAY
+  *         @arg @ref LL_RTC_MONTH_JUNE
+  *         @arg @ref LL_RTC_MONTH_JULY
+  *         @arg @ref LL_RTC_MONTH_AUGUST
+  *         @arg @ref LL_RTC_MONTH_SEPTEMBER
+  *         @arg @ref LL_RTC_MONTH_OCTOBER
+  *         @arg @ref LL_RTC_MONTH_NOVEMBER
+  *         @arg @ref LL_RTC_MONTH_DECEMBER
+  * @param  Year Value between Min_Data=0x00 and Max_Data=0x99
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_DATE_Config(RTC_TypeDef *RTCx, uint32_t WeekDay, uint32_t Day, uint32_t Month, uint32_t Year)
+{
+  uint32_t temp;
+
+  temp = (  WeekDay                                                    << RTC_DR_WDU_Pos) | \
+         (((Year  & 0xF0U) << (RTC_DR_YT_Pos - 4U)) | ((Year  & 0x0FU) << RTC_DR_YU_Pos)) | \
+         (((Month & 0xF0U) << (RTC_DR_MT_Pos - 4U)) | ((Month & 0x0FU) << RTC_DR_MU_Pos)) | \
+         (((Day   & 0xF0U) << (RTC_DR_DT_Pos - 4U)) | ((Day   & 0x0FU) << RTC_DR_DU_Pos));
+
+  MODIFY_REG(RTCx->DR, (RTC_DR_WDU | RTC_DR_MT | RTC_DR_MU | RTC_DR_DT | RTC_DR_DU | RTC_DR_YT | RTC_DR_YU), temp);
+}
+
+/**
+  * @brief  Get date (WeekDay, Day, Month and Year) in BCD format
+  * @note if RTC shadow registers are not bypassed (BYPSHAD=0), need to check if RSF flag is set
+  *       before reading this bit
+  * @note helper macros __LL_RTC_GET_WEEKDAY, __LL_RTC_GET_YEAR, __LL_RTC_GET_MONTH,
+  * and __LL_RTC_GET_DAY are available to get independently each parameter.
+  * @rmtoll DR           WDU           LL_RTC_DATE_Get\n
+  *         DR           MT            LL_RTC_DATE_Get\n
+  *         DR           MU            LL_RTC_DATE_Get\n
+  *         DR           DT            LL_RTC_DATE_Get\n
+  *         DR           DU            LL_RTC_DATE_Get\n
+  *         DR           YT            LL_RTC_DATE_Get\n
+  *         DR           YU            LL_RTC_DATE_Get
+  * @param  RTCx RTC Instance
+  * @retval Combination of WeekDay, Day, Month and Year (Format: 0xWWDDMMYY).
+  */
+__STATIC_INLINE uint32_t LL_RTC_DATE_Get(RTC_TypeDef *RTCx)
+{
+  uint32_t temp;
+
+  temp = READ_BIT(RTCx->DR, (RTC_DR_WDU | RTC_DR_MT | RTC_DR_MU | RTC_DR_DT | RTC_DR_DU | RTC_DR_YT | RTC_DR_YU));
+
+  return (uint32_t)((((temp &              RTC_DR_WDU) >> RTC_DR_WDU_Pos) << RTC_OFFSET_WEEKDAY) | \
+                    (((temp & (RTC_DR_DT | RTC_DR_DU)) >> RTC_DR_DU_Pos)  << RTC_OFFSET_DAY)     | \
+                    (((temp & (RTC_DR_MT | RTC_DR_MU)) >> RTC_DR_MU_Pos)  << RTC_OFFSET_MONTH)   | \
+                     ((temp & (RTC_DR_YT | RTC_DR_YU)) >> RTC_DR_YU_Pos));
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup RTC_LL_EF_ALARMA ALARMA
+  * @{
+  */
+
+/**
+  * @brief  Enable Alarm A
+  * @note   Bit is write-protected. @ref LL_RTC_DisableWriteProtection function should be called before.
+  * @rmtoll CR           ALRAE         LL_RTC_ALMA_Enable
+  * @param  RTCx RTC Instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_ALMA_Enable(RTC_TypeDef *RTCx)
+{
+  SET_BIT(RTCx->CR, RTC_CR_ALRAE);
+}
+
+/**
+  * @brief  Disable Alarm A
+  * @note   Bit is write-protected. @ref LL_RTC_DisableWriteProtection function should be called before.
+  * @rmtoll CR           ALRAE         LL_RTC_ALMA_Disable
+  * @param  RTCx RTC Instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_ALMA_Disable(RTC_TypeDef *RTCx)
+{
+  CLEAR_BIT(RTCx->CR, RTC_CR_ALRAE);
+}
+
+/**
+  * @brief  Specify the Alarm A masks.
+  * @rmtoll ALRMAR       MSK4          LL_RTC_ALMA_SetMask\n
+  *         ALRMAR       MSK3          LL_RTC_ALMA_SetMask\n
+  *         ALRMAR       MSK2          LL_RTC_ALMA_SetMask\n
+  *         ALRMAR       MSK1          LL_RTC_ALMA_SetMask
+  * @param  RTCx RTC Instance
+  * @param  Mask This parameter can be a combination of the following values:
+  *         @arg @ref LL_RTC_ALMA_MASK_NONE
+  *         @arg @ref LL_RTC_ALMA_MASK_DATEWEEKDAY
+  *         @arg @ref LL_RTC_ALMA_MASK_HOURS
+  *         @arg @ref LL_RTC_ALMA_MASK_MINUTES
+  *         @arg @ref LL_RTC_ALMA_MASK_SECONDS
+  *         @arg @ref LL_RTC_ALMA_MASK_ALL
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_ALMA_SetMask(RTC_TypeDef *RTCx, uint32_t Mask)
+{
+  MODIFY_REG(RTCx->ALRMAR, RTC_ALRMAR_MSK4 | RTC_ALRMAR_MSK3 | RTC_ALRMAR_MSK2 | RTC_ALRMAR_MSK1, Mask);
+}
+
+/**
+  * @brief  Get the Alarm A masks.
+  * @rmtoll ALRMAR       MSK4          LL_RTC_ALMA_GetMask\n
+  *         ALRMAR       MSK3          LL_RTC_ALMA_GetMask\n
+  *         ALRMAR       MSK2          LL_RTC_ALMA_GetMask\n
+  *         ALRMAR       MSK1          LL_RTC_ALMA_GetMask
+  * @param  RTCx RTC Instance
+  * @retval Returned value can be can be a combination of the following values:
+  *         @arg @ref LL_RTC_ALMA_MASK_NONE
+  *         @arg @ref LL_RTC_ALMA_MASK_DATEWEEKDAY
+  *         @arg @ref LL_RTC_ALMA_MASK_HOURS
+  *         @arg @ref LL_RTC_ALMA_MASK_MINUTES
+  *         @arg @ref LL_RTC_ALMA_MASK_SECONDS
+  *         @arg @ref LL_RTC_ALMA_MASK_ALL
+  */
+__STATIC_INLINE uint32_t LL_RTC_ALMA_GetMask(RTC_TypeDef *RTCx)
+{
+  return (uint32_t)(READ_BIT(RTCx->ALRMAR, RTC_ALRMAR_MSK4 | RTC_ALRMAR_MSK3 | RTC_ALRMAR_MSK2 | RTC_ALRMAR_MSK1));
+}
+
+/**
+  * @brief  Enable AlarmA Week day selection (DU[3:0] represents the week day. DT[1:0] is do not care)
+  * @rmtoll ALRMAR       WDSEL         LL_RTC_ALMA_EnableWeekday
+  * @param  RTCx RTC Instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_ALMA_EnableWeekday(RTC_TypeDef *RTCx)
+{
+  SET_BIT(RTCx->ALRMAR, RTC_ALRMAR_WDSEL);
+}
+
+/**
+  * @brief  Disable AlarmA Week day selection (DU[3:0] represents the date )
+  * @rmtoll ALRMAR       WDSEL         LL_RTC_ALMA_DisableWeekday
+  * @param  RTCx RTC Instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_ALMA_DisableWeekday(RTC_TypeDef *RTCx)
+{
+  CLEAR_BIT(RTCx->ALRMAR, RTC_ALRMAR_WDSEL);
+}
+
+/**
+  * @brief  Set ALARM A Day in BCD format
+  * @note helper macro __LL_RTC_CONVERT_BIN2BCD is available to convert Day from binary to BCD format
+  * @rmtoll ALRMAR       DT            LL_RTC_ALMA_SetDay\n
+  *         ALRMAR       DU            LL_RTC_ALMA_SetDay
+  * @param  RTCx RTC Instance
+  * @param  Day Value between Min_Data=0x01 and Max_Data=0x31
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_ALMA_SetDay(RTC_TypeDef *RTCx, uint32_t Day)
+{
+  MODIFY_REG(RTCx->ALRMAR, (RTC_ALRMAR_DT | RTC_ALRMAR_DU),
+             (((Day & 0xF0U) << (RTC_ALRMAR_DT_Pos - 4U)) | ((Day & 0x0FU) << RTC_ALRMAR_DU_Pos)));
+}
+
+/**
+  * @brief  Get ALARM A Day in BCD format
+  * @note helper macro __LL_RTC_CONVERT_BCD2BIN is available to convert Day from BCD to Binary format
+  * @rmtoll ALRMAR       DT            LL_RTC_ALMA_GetDay\n
+  *         ALRMAR       DU            LL_RTC_ALMA_GetDay
+  * @param  RTCx RTC Instance
+  * @retval Value between Min_Data=0x01 and Max_Data=0x31
+  */
+__STATIC_INLINE uint32_t LL_RTC_ALMA_GetDay(RTC_TypeDef *RTCx)
+{
+  return (uint32_t)((READ_BIT(RTCx->ALRMAR, (RTC_ALRMAR_DT | RTC_ALRMAR_DU))) >> RTC_ALRMAR_DU_Pos);
+}
+
+/**
+  * @brief  Set ALARM A Weekday
+  * @rmtoll ALRMAR       DU            LL_RTC_ALMA_SetWeekDay
+  * @param  RTCx RTC Instance
+  * @param  WeekDay This parameter can be one of the following values:
+  *         @arg @ref LL_RTC_WEEKDAY_MONDAY
+  *         @arg @ref LL_RTC_WEEKDAY_TUESDAY
+  *         @arg @ref LL_RTC_WEEKDAY_WEDNESDAY
+  *         @arg @ref LL_RTC_WEEKDAY_THURSDAY
+  *         @arg @ref LL_RTC_WEEKDAY_FRIDAY
+  *         @arg @ref LL_RTC_WEEKDAY_SATURDAY
+  *         @arg @ref LL_RTC_WEEKDAY_SUNDAY
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_ALMA_SetWeekDay(RTC_TypeDef *RTCx, uint32_t WeekDay)
+{
+  MODIFY_REG(RTCx->ALRMAR, RTC_ALRMAR_DU, WeekDay << RTC_ALRMAR_DU_Pos);
+}
+
+/**
+  * @brief  Get ALARM A Weekday
+  * @rmtoll ALRMAR       DU            LL_RTC_ALMA_GetWeekDay
+  * @param  RTCx RTC Instance
+  * @retval Returned value can be one of the following values:
+  *         @arg @ref LL_RTC_WEEKDAY_MONDAY
+  *         @arg @ref LL_RTC_WEEKDAY_TUESDAY
+  *         @arg @ref LL_RTC_WEEKDAY_WEDNESDAY
+  *         @arg @ref LL_RTC_WEEKDAY_THURSDAY
+  *         @arg @ref LL_RTC_WEEKDAY_FRIDAY
+  *         @arg @ref LL_RTC_WEEKDAY_SATURDAY
+  *         @arg @ref LL_RTC_WEEKDAY_SUNDAY
+  */
+__STATIC_INLINE uint32_t LL_RTC_ALMA_GetWeekDay(RTC_TypeDef *RTCx)
+{
+  return (uint32_t)(READ_BIT(RTCx->ALRMAR, RTC_ALRMAR_DU) >> RTC_ALRMAR_DU_Pos);
+}
+
+/**
+  * @brief  Set Alarm A time format (AM/24-hour or PM notation)
+  * @rmtoll ALRMAR       PM            LL_RTC_ALMA_SetTimeFormat
+  * @param  RTCx RTC Instance
+  * @param  TimeFormat This parameter can be one of the following values:
+  *         @arg @ref LL_RTC_ALMA_TIME_FORMAT_AM
+  *         @arg @ref LL_RTC_ALMA_TIME_FORMAT_PM
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_ALMA_SetTimeFormat(RTC_TypeDef *RTCx, uint32_t TimeFormat)
+{
+  MODIFY_REG(RTCx->ALRMAR, RTC_ALRMAR_PM, TimeFormat);
+}
+
+/**
+  * @brief  Get Alarm A time format (AM or PM notation)
+  * @rmtoll ALRMAR       PM            LL_RTC_ALMA_GetTimeFormat
+  * @param  RTCx RTC Instance
+  * @retval Returned value can be one of the following values:
+  *         @arg @ref LL_RTC_ALMA_TIME_FORMAT_AM
+  *         @arg @ref LL_RTC_ALMA_TIME_FORMAT_PM
+  */
+__STATIC_INLINE uint32_t LL_RTC_ALMA_GetTimeFormat(RTC_TypeDef *RTCx)
+{
+  return (uint32_t)(READ_BIT(RTCx->ALRMAR, RTC_ALRMAR_PM));
+}
+
+/**
+  * @brief  Set ALARM A Hours in BCD format
+  * @note helper macro __LL_RTC_CONVERT_BIN2BCD is available to convert Hours from binary to BCD format
+  * @rmtoll ALRMAR       HT            LL_RTC_ALMA_SetHour\n
+  *         ALRMAR       HU            LL_RTC_ALMA_SetHour
+  * @param  RTCx RTC Instance
+  * @param  Hours Value between Min_Data=0x01 and Max_Data=0x12 or between Min_Data=0x00 and Max_Data=0x23
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_ALMA_SetHour(RTC_TypeDef *RTCx, uint32_t Hours)
+{
+  MODIFY_REG(RTCx->ALRMAR, (RTC_ALRMAR_HT | RTC_ALRMAR_HU),
+             (((Hours & 0xF0U) << (RTC_ALRMAR_HT_Pos - 4U)) | ((Hours & 0x0FU) << RTC_ALRMAR_HU_Pos)));
+}
+
+/**
+  * @brief  Get ALARM A Hours in BCD format
+  * @note helper macro __LL_RTC_CONVERT_BCD2BIN is available to convert Hours from BCD to Binary format
+  * @rmtoll ALRMAR       HT            LL_RTC_ALMA_GetHour\n
+  *         ALRMAR       HU            LL_RTC_ALMA_GetHour
+  * @param  RTCx RTC Instance
+  * @retval Value between Min_Data=0x01 and Max_Data=0x12 or between Min_Data=0x00 and Max_Data=0x23
+  */
+__STATIC_INLINE uint32_t LL_RTC_ALMA_GetHour(RTC_TypeDef *RTCx)
+{
+  return (uint32_t)((READ_BIT(RTCx->ALRMAR, (RTC_ALRMAR_HT | RTC_ALRMAR_HU))) >> RTC_ALRMAR_HU_Pos);
+}
+
+/**
+  * @brief  Set ALARM A Minutes in BCD format
+  * @note helper macro __LL_RTC_CONVERT_BIN2BCD is available to convert Minutes from binary to BCD format
+  * @rmtoll ALRMAR       MNT           LL_RTC_ALMA_SetMinute\n
+  *         ALRMAR       MNU           LL_RTC_ALMA_SetMinute
+  * @param  RTCx RTC Instance
+  * @param  Minutes Value between Min_Data=0x00 and Max_Data=0x59
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_ALMA_SetMinute(RTC_TypeDef *RTCx, uint32_t Minutes)
+{
+  MODIFY_REG(RTCx->ALRMAR, (RTC_ALRMAR_MNT | RTC_ALRMAR_MNU),
+             (((Minutes & 0xF0U) << (RTC_ALRMAR_MNT_Pos - 4U)) | ((Minutes & 0x0FU) << RTC_ALRMAR_MNU_Pos)));
+}
+
+/**
+  * @brief  Get ALARM A Minutes in BCD format
+  * @note helper macro __LL_RTC_CONVERT_BCD2BIN is available to convert Minutes from BCD to Binary format
+  * @rmtoll ALRMAR       MNT           LL_RTC_ALMA_GetMinute\n
+  *         ALRMAR       MNU           LL_RTC_ALMA_GetMinute
+  * @param  RTCx RTC Instance
+  * @retval Value between Min_Data=0x00 and Max_Data=0x59
+  */
+__STATIC_INLINE uint32_t LL_RTC_ALMA_GetMinute(RTC_TypeDef *RTCx)
+{
+  return (uint32_t)((READ_BIT(RTCx->ALRMAR, (RTC_ALRMAR_MNT | RTC_ALRMAR_MNU))) >> RTC_ALRMAR_MNU_Pos);
+}
+
+/**
+  * @brief  Set ALARM A Seconds in BCD format
+  * @note helper macro __LL_RTC_CONVERT_BIN2BCD is available to convert Seconds from binary to BCD format
+  * @rmtoll ALRMAR       ST            LL_RTC_ALMA_SetSecond\n
+  *         ALRMAR       SU            LL_RTC_ALMA_SetSecond
+  * @param  RTCx RTC Instance
+  * @param  Seconds Value between Min_Data=0x00 and Max_Data=0x59
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_ALMA_SetSecond(RTC_TypeDef *RTCx, uint32_t Seconds)
+{
+  MODIFY_REG(RTCx->ALRMAR, (RTC_ALRMAR_ST | RTC_ALRMAR_SU),
+             (((Seconds & 0xF0U) << (RTC_ALRMAR_ST_Pos - 4U)) | ((Seconds & 0x0FU) << RTC_ALRMAR_SU_Pos)));
+}
+
+/**
+  * @brief  Get ALARM A Seconds in BCD format
+  * @note helper macro __LL_RTC_CONVERT_BCD2BIN is available to convert Seconds from BCD to Binary format
+  * @rmtoll ALRMAR       ST            LL_RTC_ALMA_GetSecond\n
+  *         ALRMAR       SU            LL_RTC_ALMA_GetSecond
+  * @param  RTCx RTC Instance
+  * @retval Value between Min_Data=0x00 and Max_Data=0x59
+  */
+__STATIC_INLINE uint32_t LL_RTC_ALMA_GetSecond(RTC_TypeDef *RTCx)
+{
+  return (uint32_t)((READ_BIT(RTCx->ALRMAR, (RTC_ALRMAR_ST | RTC_ALRMAR_SU))) >> RTC_ALRMAR_SU_Pos);
+}
+
+/**
+  * @brief  Set Alarm A Time (hour, minute and second) in BCD format
+  * @rmtoll ALRMAR       PM            LL_RTC_ALMA_ConfigTime\n
+  *         ALRMAR       HT            LL_RTC_ALMA_ConfigTime\n
+  *         ALRMAR       HU            LL_RTC_ALMA_ConfigTime\n
+  *         ALRMAR       MNT           LL_RTC_ALMA_ConfigTime\n
+  *         ALRMAR       MNU           LL_RTC_ALMA_ConfigTime\n
+  *         ALRMAR       ST            LL_RTC_ALMA_ConfigTime\n
+  *         ALRMAR       SU            LL_RTC_ALMA_ConfigTime
+  * @param  RTCx RTC Instance
+  * @param  Format12_24 This parameter can be one of the following values:
+  *         @arg @ref LL_RTC_ALMA_TIME_FORMAT_AM
+  *         @arg @ref LL_RTC_ALMA_TIME_FORMAT_PM
+  * @param  Hours Value between Min_Data=0x01 and Max_Data=0x12 or between Min_Data=0x00 and Max_Data=0x23
+  * @param  Minutes Value between Min_Data=0x00 and Max_Data=0x59
+  * @param  Seconds Value between Min_Data=0x00 and Max_Data=0x59
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_ALMA_ConfigTime(RTC_TypeDef *RTCx, uint32_t Format12_24, uint32_t Hours, uint32_t Minutes, uint32_t Seconds)
+{
+  uint32_t temp;
+
+  temp = Format12_24                                                                                    | \
+         (((Hours   & 0xF0U) << (RTC_ALRMAR_HT_Pos  - 4U)) | ((Hours   & 0x0FU) << RTC_ALRMAR_HU_Pos))  | \
+         (((Minutes & 0xF0U) << (RTC_ALRMAR_MNT_Pos - 4U)) | ((Minutes & 0x0FU) << RTC_ALRMAR_MNU_Pos)) | \
+         (((Seconds & 0xF0U) << (RTC_ALRMAR_ST_Pos  - 4U)) | ((Seconds & 0x0FU) << RTC_ALRMAR_SU_Pos));
+
+  MODIFY_REG(RTCx->ALRMAR, RTC_ALRMAR_PM | RTC_ALRMAR_HT | RTC_ALRMAR_HU | RTC_ALRMAR_MNT | RTC_ALRMAR_MNU | RTC_ALRMAR_ST | RTC_ALRMAR_SU, temp);
+}
+
+/**
+  * @brief  Get Alarm B Time (hour, minute and second) in BCD format
+  * @note helper macros __LL_RTC_GET_HOUR, __LL_RTC_GET_MINUTE and __LL_RTC_GET_SECOND
+  * are available to get independently each parameter.
+  * @rmtoll ALRMAR       HT            LL_RTC_ALMA_GetTime\n
+  *         ALRMAR       HU            LL_RTC_ALMA_GetTime\n
+  *         ALRMAR       MNT           LL_RTC_ALMA_GetTime\n
+  *         ALRMAR       MNU           LL_RTC_ALMA_GetTime\n
+  *         ALRMAR       ST            LL_RTC_ALMA_GetTime\n
+  *         ALRMAR       SU            LL_RTC_ALMA_GetTime
+  * @param  RTCx RTC Instance
+  * @retval Combination of hours, minutes and seconds.
+  */
+__STATIC_INLINE uint32_t LL_RTC_ALMA_GetTime(RTC_TypeDef *RTCx)
+{
+  return (uint32_t)((LL_RTC_ALMA_GetHour(RTCx) << RTC_OFFSET_HOUR) | (LL_RTC_ALMA_GetMinute(RTCx) << RTC_OFFSET_MINUTE) | LL_RTC_ALMA_GetSecond(RTCx));
+}
+
+/**
+  * @brief  Mask the most-significant bits of the subseconds field starting from
+  *         the bit specified in parameter Mask
+  * @note This register can be written only when ALRAE is reset in RTC_CR register,
+  *       or in initialization mode.
+  * @rmtoll ALRMASSR     MASKSS        LL_RTC_ALMA_SetSubSecondMask
+  * @param  RTCx RTC Instance
+  * @param  Mask Value between Min_Data=0x00 and Max_Data=0xF
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_ALMA_SetSubSecondMask(RTC_TypeDef *RTCx, uint32_t Mask)
+{
+  MODIFY_REG(RTCx->ALRMASSR, RTC_ALRMASSR_MASKSS, Mask << RTC_ALRMASSR_MASKSS_Pos);
+}
+
+/**
+  * @brief  Get Alarm A subseconds mask
+  * @rmtoll ALRMASSR     MASKSS        LL_RTC_ALMA_GetSubSecondMask
+  * @param  RTCx RTC Instance
+  * @retval Value between Min_Data=0x00 and Max_Data=0xF
+  */
+__STATIC_INLINE uint32_t LL_RTC_ALMA_GetSubSecondMask(RTC_TypeDef *RTCx)
+{
+  return (uint32_t)(READ_BIT(RTCx->ALRMASSR, RTC_ALRMASSR_MASKSS) >> RTC_ALRMASSR_MASKSS_Pos);
+}
+
+/**
+  * @brief  Set Alarm A subseconds value
+  * @rmtoll ALRMASSR     SS            LL_RTC_ALMA_SetSubSecond
+  * @param  RTCx RTC Instance
+  * @param  Subsecond Value between Min_Data=0x00 and Max_Data=0x7FFF
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_ALMA_SetSubSecond(RTC_TypeDef *RTCx, uint32_t Subsecond)
+{
+  MODIFY_REG(RTCx->ALRMASSR, RTC_ALRMASSR_SS, Subsecond);
+}
+
+/**
+  * @brief  Get Alarm A subseconds value
+  * @rmtoll ALRMASSR     SS            LL_RTC_ALMA_GetSubSecond
+  * @param  RTCx RTC Instance
+  * @retval Value between Min_Data=0x00 and Max_Data=0x7FFF
+  */
+__STATIC_INLINE uint32_t LL_RTC_ALMA_GetSubSecond(RTC_TypeDef *RTCx)
+{
+  return (uint32_t)(READ_BIT(RTCx->ALRMASSR, RTC_ALRMASSR_SS));
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup RTC_LL_EF_ALARMB ALARMB
+  * @{
+  */
+
+/**
+  * @brief  Enable Alarm B
+  * @note   Bit is write-protected. @ref LL_RTC_DisableWriteProtection function should be called before.
+  * @rmtoll CR           ALRBE         LL_RTC_ALMB_Enable
+  * @param  RTCx RTC Instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_ALMB_Enable(RTC_TypeDef *RTCx)
+{
+  SET_BIT(RTCx->CR, RTC_CR_ALRBE);
+}
+
+/**
+  * @brief  Disable Alarm B
+  * @note   Bit is write-protected. @ref LL_RTC_DisableWriteProtection function should be called before.
+  * @rmtoll CR           ALRBE         LL_RTC_ALMB_Disable
+  * @param  RTCx RTC Instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_ALMB_Disable(RTC_TypeDef *RTCx)
+{
+  CLEAR_BIT(RTCx->CR, RTC_CR_ALRBE);
+}
+
+/**
+  * @brief  Specify the Alarm B masks.
+  * @rmtoll ALRMBR       MSK4          LL_RTC_ALMB_SetMask\n
+  *         ALRMBR       MSK3          LL_RTC_ALMB_SetMask\n
+  *         ALRMBR       MSK2          LL_RTC_ALMB_SetMask\n
+  *         ALRMBR       MSK1          LL_RTC_ALMB_SetMask
+  * @param  RTCx RTC Instance
+  * @param  Mask This parameter can be a combination of the following values:
+  *         @arg @ref LL_RTC_ALMB_MASK_NONE
+  *         @arg @ref LL_RTC_ALMB_MASK_DATEWEEKDAY
+  *         @arg @ref LL_RTC_ALMB_MASK_HOURS
+  *         @arg @ref LL_RTC_ALMB_MASK_MINUTES
+  *         @arg @ref LL_RTC_ALMB_MASK_SECONDS
+  *         @arg @ref LL_RTC_ALMB_MASK_ALL
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_ALMB_SetMask(RTC_TypeDef *RTCx, uint32_t Mask)
+{
+  MODIFY_REG(RTCx->ALRMBR, RTC_ALRMBR_MSK4 | RTC_ALRMBR_MSK3 | RTC_ALRMBR_MSK2 | RTC_ALRMBR_MSK1, Mask);
+}
+
+/**
+  * @brief  Get the Alarm B masks.
+  * @rmtoll ALRMBR       MSK4          LL_RTC_ALMB_GetMask\n
+  *         ALRMBR       MSK3          LL_RTC_ALMB_GetMask\n
+  *         ALRMBR       MSK2          LL_RTC_ALMB_GetMask\n
+  *         ALRMBR       MSK1          LL_RTC_ALMB_GetMask
+  * @param  RTCx RTC Instance
+  * @retval Returned value can be can be a combination of the following values:
+  *         @arg @ref LL_RTC_ALMB_MASK_NONE
+  *         @arg @ref LL_RTC_ALMB_MASK_DATEWEEKDAY
+  *         @arg @ref LL_RTC_ALMB_MASK_HOURS
+  *         @arg @ref LL_RTC_ALMB_MASK_MINUTES
+  *         @arg @ref LL_RTC_ALMB_MASK_SECONDS
+  *         @arg @ref LL_RTC_ALMB_MASK_ALL
+  */
+__STATIC_INLINE uint32_t LL_RTC_ALMB_GetMask(RTC_TypeDef *RTCx)
+{
+  return (uint32_t)(READ_BIT(RTCx->ALRMBR, RTC_ALRMBR_MSK4 | RTC_ALRMBR_MSK3 | RTC_ALRMBR_MSK2 | RTC_ALRMBR_MSK1));
+}
+
+/**
+  * @brief  Enable AlarmB Week day selection (DU[3:0] represents the week day. DT[1:0] is do not care)
+  * @rmtoll ALRMBR       WDSEL         LL_RTC_ALMB_EnableWeekday
+  * @param  RTCx RTC Instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_ALMB_EnableWeekday(RTC_TypeDef *RTCx)
+{
+  SET_BIT(RTCx->ALRMBR, RTC_ALRMBR_WDSEL);
+}
+
+/**
+  * @brief  Disable AlarmB Week day selection (DU[3:0] represents the date )
+  * @rmtoll ALRMBR       WDSEL         LL_RTC_ALMB_DisableWeekday
+  * @param  RTCx RTC Instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_ALMB_DisableWeekday(RTC_TypeDef *RTCx)
+{
+  CLEAR_BIT(RTCx->ALRMBR, RTC_ALRMBR_WDSEL);
+}
+
+/**
+  * @brief  Set ALARM B Day in BCD format
+  * @note helper macro __LL_RTC_CONVERT_BIN2BCD is available to convert Day from binary to BCD format
+  * @rmtoll ALRMBR       DT            LL_RTC_ALMB_SetDay\n
+  *         ALRMBR       DU            LL_RTC_ALMB_SetDay
+  * @param  RTCx RTC Instance
+  * @param  Day Value between Min_Data=0x01 and Max_Data=0x31
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_ALMB_SetDay(RTC_TypeDef *RTCx, uint32_t Day)
+{
+  MODIFY_REG(RTCx->ALRMBR, (RTC_ALRMBR_DT | RTC_ALRMBR_DU),
+             (((Day & 0xF0U) << (RTC_ALRMBR_DT_Pos - 4U)) | ((Day & 0x0FU) << RTC_ALRMBR_DU_Pos)));
+}
+
+/**
+  * @brief  Get ALARM B Day in BCD format
+  * @note helper macro __LL_RTC_CONVERT_BCD2BIN is available to convert Day from BCD to Binary format
+  * @rmtoll ALRMBR       DT            LL_RTC_ALMB_GetDay\n
+  *         ALRMBR       DU            LL_RTC_ALMB_GetDay
+  * @param  RTCx RTC Instance
+  * @retval Value between Min_Data=0x01 and Max_Data=0x31
+  */
+__STATIC_INLINE uint32_t LL_RTC_ALMB_GetDay(RTC_TypeDef *RTCx)
+{
+  return (uint32_t)((READ_BIT(RTCx->ALRMBR, (RTC_ALRMBR_DT | RTC_ALRMBR_DU))) >> RTC_ALRMBR_DU_Pos);
+}
+
+/**
+  * @brief  Set ALARM B Weekday
+  * @rmtoll ALRMBR       DU            LL_RTC_ALMB_SetWeekDay
+  * @param  RTCx RTC Instance
+  * @param  WeekDay This parameter can be one of the following values:
+  *         @arg @ref LL_RTC_WEEKDAY_MONDAY
+  *         @arg @ref LL_RTC_WEEKDAY_TUESDAY
+  *         @arg @ref LL_RTC_WEEKDAY_WEDNESDAY
+  *         @arg @ref LL_RTC_WEEKDAY_THURSDAY
+  *         @arg @ref LL_RTC_WEEKDAY_FRIDAY
+  *         @arg @ref LL_RTC_WEEKDAY_SATURDAY
+  *         @arg @ref LL_RTC_WEEKDAY_SUNDAY
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_ALMB_SetWeekDay(RTC_TypeDef *RTCx, uint32_t WeekDay)
+{
+  MODIFY_REG(RTCx->ALRMBR, RTC_ALRMBR_DU, WeekDay << RTC_ALRMBR_DU_Pos);
+}
+
+/**
+  * @brief  Get ALARM B Weekday
+  * @rmtoll ALRMBR       DU            LL_RTC_ALMB_GetWeekDay
+  * @param  RTCx RTC Instance
+  * @retval Returned value can be one of the following values:
+  *         @arg @ref LL_RTC_WEEKDAY_MONDAY
+  *         @arg @ref LL_RTC_WEEKDAY_TUESDAY
+  *         @arg @ref LL_RTC_WEEKDAY_WEDNESDAY
+  *         @arg @ref LL_RTC_WEEKDAY_THURSDAY
+  *         @arg @ref LL_RTC_WEEKDAY_FRIDAY
+  *         @arg @ref LL_RTC_WEEKDAY_SATURDAY
+  *         @arg @ref LL_RTC_WEEKDAY_SUNDAY
+  */
+__STATIC_INLINE uint32_t LL_RTC_ALMB_GetWeekDay(RTC_TypeDef *RTCx)
+{
+  return (uint32_t)(READ_BIT(RTCx->ALRMBR, RTC_ALRMBR_DU) >> RTC_ALRMBR_DU_Pos);
+}
+
+/**
+  * @brief  Set ALARM B time format (AM/24-hour or PM notation)
+  * @rmtoll ALRMBR       PM            LL_RTC_ALMB_SetTimeFormat
+  * @param  RTCx RTC Instance
+  * @param  TimeFormat This parameter can be one of the following values:
+  *         @arg @ref LL_RTC_ALMB_TIME_FORMAT_AM
+  *         @arg @ref LL_RTC_ALMB_TIME_FORMAT_PM
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_ALMB_SetTimeFormat(RTC_TypeDef *RTCx, uint32_t TimeFormat)
+{
+  MODIFY_REG(RTCx->ALRMBR, RTC_ALRMBR_PM, TimeFormat);
+}
+
+/**
+  * @brief  Get ALARM B time format (AM or PM notation)
+  * @rmtoll ALRMBR       PM            LL_RTC_ALMB_GetTimeFormat
+  * @param  RTCx RTC Instance
+  * @retval Returned value can be one of the following values:
+  *         @arg @ref LL_RTC_ALMB_TIME_FORMAT_AM
+  *         @arg @ref LL_RTC_ALMB_TIME_FORMAT_PM
+  */
+__STATIC_INLINE uint32_t LL_RTC_ALMB_GetTimeFormat(RTC_TypeDef *RTCx)
+{
+  return (uint32_t)(READ_BIT(RTCx->ALRMBR, RTC_ALRMBR_PM));
+}
+
+/**
+  * @brief  Set ALARM B Hours in BCD format
+  * @note helper macro __LL_RTC_CONVERT_BIN2BCD is available to convert Hours from binary to BCD format
+  * @rmtoll ALRMBR       HT            LL_RTC_ALMB_SetHour\n
+  *         ALRMBR       HU            LL_RTC_ALMB_SetHour
+  * @param  RTCx RTC Instance
+  * @param  Hours Value between Min_Data=0x01 and Max_Data=0x12 or between Min_Data=0x00 and Max_Data=0x23
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_ALMB_SetHour(RTC_TypeDef *RTCx, uint32_t Hours)
+{
+  MODIFY_REG(RTCx->ALRMBR, (RTC_ALRMBR_HT | RTC_ALRMBR_HU),
+             (((Hours & 0xF0U) << (RTC_ALRMBR_HT_Pos - 4U)) | ((Hours & 0x0FU) << RTC_ALRMBR_HU_Pos)));
+}
+
+/**
+  * @brief  Get ALARM B Hours in BCD format
+  * @note helper macro __LL_RTC_CONVERT_BCD2BIN is available to convert Hours from BCD to Binary format
+  * @rmtoll ALRMBR       HT            LL_RTC_ALMB_GetHour\n
+  *         ALRMBR       HU            LL_RTC_ALMB_GetHour
+  * @param  RTCx RTC Instance
+  * @retval Value between Min_Data=0x01 and Max_Data=0x12 or between Min_Data=0x00 and Max_Data=0x23
+  */
+__STATIC_INLINE uint32_t LL_RTC_ALMB_GetHour(RTC_TypeDef *RTCx)
+{
+  return (uint32_t)((READ_BIT(RTCx->ALRMBR, (RTC_ALRMBR_HT | RTC_ALRMBR_HU))) >> RTC_ALRMBR_HU_Pos);
+}
+
+/**
+  * @brief  Set ALARM B Minutes in BCD format
+  * @note helper macro __LL_RTC_CONVERT_BIN2BCD is available to convert Minutes from binary to BCD format
+  * @rmtoll ALRMBR       MNT           LL_RTC_ALMB_SetMinute\n
+  *         ALRMBR       MNU           LL_RTC_ALMB_SetMinute
+  * @param  RTCx RTC Instance
+  * @param  Minutes between Min_Data=0x00 and Max_Data=0x59
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_ALMB_SetMinute(RTC_TypeDef *RTCx, uint32_t Minutes)
+{
+  MODIFY_REG(RTCx->ALRMBR, (RTC_ALRMBR_MNT | RTC_ALRMBR_MNU),
+             (((Minutes & 0xF0U) << (RTC_ALRMBR_MNT_Pos - 4U)) | ((Minutes & 0x0FU) << RTC_ALRMBR_MNU_Pos)));
+}
+
+/**
+  * @brief  Get ALARM B Minutes in BCD format
+  * @note helper macro __LL_RTC_CONVERT_BCD2BIN is available to convert Minutes from BCD to Binary format
+  * @rmtoll ALRMBR       MNT           LL_RTC_ALMB_GetMinute\n
+  *         ALRMBR       MNU           LL_RTC_ALMB_GetMinute
+  * @param  RTCx RTC Instance
+  * @retval Value between Min_Data=0x00 and Max_Data=0x59
+  */
+__STATIC_INLINE uint32_t LL_RTC_ALMB_GetMinute(RTC_TypeDef *RTCx)
+{
+  return (uint32_t)((READ_BIT(RTCx->ALRMBR, (RTC_ALRMBR_MNT | RTC_ALRMBR_MNU))) >> RTC_ALRMBR_MNU_Pos);
+}
+
+/**
+  * @brief  Set ALARM B Seconds in BCD format
+  * @note helper macro __LL_RTC_CONVERT_BIN2BCD is available to convert Seconds from binary to BCD format
+  * @rmtoll ALRMBR       ST            LL_RTC_ALMB_SetSecond\n
+  *         ALRMBR       SU            LL_RTC_ALMB_SetSecond
+  * @param  RTCx RTC Instance
+  * @param  Seconds Value between Min_Data=0x00 and Max_Data=0x59
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_ALMB_SetSecond(RTC_TypeDef *RTCx, uint32_t Seconds)
+{
+  MODIFY_REG(RTCx->ALRMBR, (RTC_ALRMBR_ST | RTC_ALRMBR_SU),
+             (((Seconds & 0xF0U) << (RTC_ALRMBR_ST_Pos - 4U)) | ((Seconds & 0x0FU) << RTC_ALRMBR_SU_Pos)));
+}
+
+/**
+  * @brief  Get ALARM B Seconds in BCD format
+  * @note helper macro __LL_RTC_CONVERT_BCD2BIN is available to convert Seconds from BCD to Binary format
+  * @rmtoll ALRMBR       ST            LL_RTC_ALMB_GetSecond\n
+  *         ALRMBR       SU            LL_RTC_ALMB_GetSecond
+  * @param  RTCx RTC Instance
+  * @retval Value between Min_Data=0x00 and Max_Data=0x59
+  */
+__STATIC_INLINE uint32_t LL_RTC_ALMB_GetSecond(RTC_TypeDef *RTCx)
+{
+  return (uint32_t)((READ_BIT(RTCx->ALRMBR, (RTC_ALRMBR_ST | RTC_ALRMBR_SU))) >> RTC_ALRMBR_SU_Pos);
+}
+
+/**
+  * @brief  Set Alarm B Time (hour, minute and second) in BCD format
+  * @rmtoll ALRMBR       PM            LL_RTC_ALMB_ConfigTime\n
+  *         ALRMBR       HT            LL_RTC_ALMB_ConfigTime\n
+  *         ALRMBR       HU            LL_RTC_ALMB_ConfigTime\n
+  *         ALRMBR       MNT           LL_RTC_ALMB_ConfigTime\n
+  *         ALRMBR       MNU           LL_RTC_ALMB_ConfigTime\n
+  *         ALRMBR       ST            LL_RTC_ALMB_ConfigTime\n
+  *         ALRMBR       SU            LL_RTC_ALMB_ConfigTime
+  * @param  RTCx RTC Instance
+  * @param  Format12_24 This parameter can be one of the following values:
+  *         @arg @ref LL_RTC_ALMB_TIME_FORMAT_AM
+  *         @arg @ref LL_RTC_ALMB_TIME_FORMAT_PM
+  * @param  Hours Value between Min_Data=0x01 and Max_Data=0x12 or between Min_Data=0x00 and Max_Data=0x23
+  * @param  Minutes Value between Min_Data=0x00 and Max_Data=0x59
+  * @param  Seconds Value between Min_Data=0x00 and Max_Data=0x59
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_ALMB_ConfigTime(RTC_TypeDef *RTCx, uint32_t Format12_24, uint32_t Hours, uint32_t Minutes, uint32_t Seconds)
+{
+  uint32_t temp;
+
+  temp = Format12_24                                                                                    | \
+         (((Hours   & 0xF0U) << (RTC_ALRMBR_HT_Pos  - 4U)) | ((Hours   & 0x0FU) << RTC_ALRMBR_HU_Pos))  | \
+         (((Minutes & 0xF0U) << (RTC_ALRMBR_MNT_Pos - 4U)) | ((Minutes & 0x0FU) << RTC_ALRMBR_MNU_Pos)) | \
+         (((Seconds & 0xF0U) << (RTC_ALRMBR_ST_Pos  - 4U)) | ((Seconds & 0x0FU) << RTC_ALRMBR_SU_Pos));
+
+  MODIFY_REG(RTCx->ALRMBR, RTC_ALRMBR_PM | RTC_ALRMBR_HT | RTC_ALRMBR_HU | RTC_ALRMBR_MNT | RTC_ALRMBR_MNU | RTC_ALRMBR_ST | RTC_ALRMBR_SU, temp);
+}
+
+/**
+  * @brief  Get Alarm B Time (hour, minute and second) in BCD format
+  * @note helper macros __LL_RTC_GET_HOUR, __LL_RTC_GET_MINUTE and __LL_RTC_GET_SECOND
+  * are available to get independently each parameter.
+  * @rmtoll ALRMBR       HT            LL_RTC_ALMB_GetTime\n
+  *         ALRMBR       HU            LL_RTC_ALMB_GetTime\n
+  *         ALRMBR       MNT           LL_RTC_ALMB_GetTime\n
+  *         ALRMBR       MNU           LL_RTC_ALMB_GetTime\n
+  *         ALRMBR       ST            LL_RTC_ALMB_GetTime\n
+  *         ALRMBR       SU            LL_RTC_ALMB_GetTime
+  * @param  RTCx RTC Instance
+  * @retval Combination of hours, minutes and seconds.
+  */
+__STATIC_INLINE uint32_t LL_RTC_ALMB_GetTime(RTC_TypeDef *RTCx)
+{
+  return (uint32_t)((LL_RTC_ALMB_GetHour(RTCx) << RTC_OFFSET_HOUR) | (LL_RTC_ALMB_GetMinute(RTCx) << RTC_OFFSET_MINUTE) | LL_RTC_ALMB_GetSecond(RTCx));
+}
+
+/**
+  * @brief  Mask the most-significant bits of the subseconds field starting from
+  *         the bit specified in parameter Mask
+  * @note This register can be written only when ALRBE is reset in RTC_CR register,
+  *       or in initialization mode.
+  * @rmtoll ALRMBSSR     MASKSS        LL_RTC_ALMB_SetSubSecondMask
+  * @param  RTCx RTC Instance
+  * @param  Mask Value between Min_Data=0x00 and Max_Data=0xF
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_ALMB_SetSubSecondMask(RTC_TypeDef *RTCx, uint32_t Mask)
+{
+  MODIFY_REG(RTCx->ALRMBSSR, RTC_ALRMBSSR_MASKSS, Mask << RTC_ALRMBSSR_MASKSS_Pos);
+}
+
+/**
+  * @brief  Get Alarm B subseconds mask
+  * @rmtoll ALRMBSSR     MASKSS        LL_RTC_ALMB_GetSubSecondMask
+  * @param  RTCx RTC Instance
+  * @retval Value between Min_Data=0x00 and Max_Data=0xF
+  */
+__STATIC_INLINE uint32_t LL_RTC_ALMB_GetSubSecondMask(RTC_TypeDef *RTCx)
+{
+  return (uint32_t)(READ_BIT(RTCx->ALRMBSSR, RTC_ALRMBSSR_MASKSS)  >> RTC_ALRMBSSR_MASKSS_Pos);
+}
+
+/**
+  * @brief  Set Alarm B subseconds value
+  * @rmtoll ALRMBSSR     SS            LL_RTC_ALMB_SetSubSecond
+  * @param  RTCx RTC Instance
+  * @param  Subsecond Value between Min_Data=0x00 and Max_Data=0x7FFF
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_ALMB_SetSubSecond(RTC_TypeDef *RTCx, uint32_t Subsecond)
+{
+  MODIFY_REG(RTCx->ALRMBSSR, RTC_ALRMBSSR_SS, Subsecond);
+}
+
+/**
+  * @brief  Get Alarm B subseconds value
+  * @rmtoll ALRMBSSR     SS            LL_RTC_ALMB_GetSubSecond
+  * @param  RTCx RTC Instance
+  * @retval Value between Min_Data=0x00 and Max_Data=0x7FFF
+  */
+__STATIC_INLINE uint32_t LL_RTC_ALMB_GetSubSecond(RTC_TypeDef *RTCx)
+{
+  return (uint32_t)(READ_BIT(RTCx->ALRMBSSR, RTC_ALRMBSSR_SS));
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup RTC_LL_EF_Timestamp Timestamp
+  * @{
+  */
+
+/**
+  * @brief  Enable internal event timestamp
+  * @note   Bit is write-protected. @ref LL_RTC_DisableWriteProtection function should be called before.
+  * @rmtoll CR           ITSE          LL_RTC_TS_EnableInternalEvent
+  * @param  RTCx RTC Instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_TS_EnableInternalEvent(RTC_TypeDef *RTCx)
+{
+  SET_BIT(RTCx->CR, RTC_CR_ITSE);
+}
+
+/**
+  * @brief  Disable internal event timestamp
+  * @note   Bit is write-protected. @ref LL_RTC_DisableWriteProtection function should be called before.
+  * @rmtoll CR           ITSE          LL_RTC_TS_DisableInternalEvent
+  * @param  RTCx RTC Instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_TS_DisableInternalEvent(RTC_TypeDef *RTCx)
+{
+  CLEAR_BIT(RTCx->CR, RTC_CR_ITSE);
+}
+
+/**
+  * @brief  Enable Timestamp
+  * @note   Bit is write-protected. @ref LL_RTC_DisableWriteProtection function should be called before.
+  * @rmtoll CR           TSE           LL_RTC_TS_Enable
+  * @param  RTCx RTC Instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_TS_Enable(RTC_TypeDef *RTCx)
+{
+  SET_BIT(RTCx->CR, RTC_CR_TSE);
+}
+
+/**
+  * @brief  Disable Timestamp
+  * @note   Bit is write-protected. @ref LL_RTC_DisableWriteProtection function should be called before.
+  * @rmtoll CR           TSE           LL_RTC_TS_Disable
+  * @param  RTCx RTC Instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_TS_Disable(RTC_TypeDef *RTCx)
+{
+  CLEAR_BIT(RTCx->CR, RTC_CR_TSE);
+}
+
+/**
+  * @brief  Set Time-stamp event active edge
+  * @note   Bit is write-protected. @ref LL_RTC_DisableWriteProtection function should be called before.
+  * @note TSE must be reset when TSEDGE is changed to avoid unwanted TSF setting
+  * @rmtoll CR           TSEDGE        LL_RTC_TS_SetActiveEdge
+  * @param  RTCx RTC Instance
+  * @param  Edge This parameter can be one of the following values:
+  *         @arg @ref LL_RTC_TIMESTAMP_EDGE_RISING
+  *         @arg @ref LL_RTC_TIMESTAMP_EDGE_FALLING
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_TS_SetActiveEdge(RTC_TypeDef *RTCx, uint32_t Edge)
+{
+  MODIFY_REG(RTCx->CR, RTC_CR_TSEDGE, Edge);
+}
+
+/**
+  * @brief  Get Time-stamp event active edge
+  * @note   Bit is write-protected. @ref LL_RTC_DisableWriteProtection function should be called before.
+  * @rmtoll CR           TSEDGE        LL_RTC_TS_GetActiveEdge
+  * @param  RTCx RTC Instance
+  * @retval Returned value can be one of the following values:
+  *         @arg @ref LL_RTC_TIMESTAMP_EDGE_RISING
+  *         @arg @ref LL_RTC_TIMESTAMP_EDGE_FALLING
+  */
+__STATIC_INLINE uint32_t LL_RTC_TS_GetActiveEdge(RTC_TypeDef *RTCx)
+{
+  return (uint32_t)(READ_BIT(RTCx->CR, RTC_CR_TSEDGE));
+}
+
+/**
+  * @brief  Get Timestamp AM/PM notation (AM or 24-hour format)
+  * @rmtoll TSTR         PM            LL_RTC_TS_GetTimeFormat
+  * @param  RTCx RTC Instance
+  * @retval Returned value can be one of the following values:
+  *         @arg @ref LL_RTC_TS_TIME_FORMAT_AM
+  *         @arg @ref LL_RTC_TS_TIME_FORMAT_PM
+  */
+__STATIC_INLINE uint32_t LL_RTC_TS_GetTimeFormat(RTC_TypeDef *RTCx)
+{
+  return (uint32_t)(READ_BIT(RTCx->TSTR, RTC_TSTR_PM));
+}
+
+/**
+  * @brief  Get Timestamp Hours in BCD format
+  * @note helper macro __LL_RTC_CONVERT_BCD2BIN is available to convert Hours from BCD to Binary format
+  * @rmtoll TSTR         HT            LL_RTC_TS_GetHour\n
+  *         TSTR         HU            LL_RTC_TS_GetHour
+  * @param  RTCx RTC Instance
+  * @retval Value between Min_Data=0x01 and Max_Data=0x12 or between Min_Data=0x00 and Max_Data=0x23
+  */
+__STATIC_INLINE uint32_t LL_RTC_TS_GetHour(RTC_TypeDef *RTCx)
+{
+  return (uint32_t)(READ_BIT(RTCx->TSTR, RTC_TSTR_HT | RTC_TSTR_HU) >> RTC_TSTR_HU_Pos);
+}
+
+/**
+  * @brief  Get Timestamp Minutes in BCD format
+  * @note helper macro __LL_RTC_CONVERT_BCD2BIN is available to convert Minutes from BCD to Binary format
+  * @rmtoll TSTR         MNT           LL_RTC_TS_GetMinute\n
+  *         TSTR         MNU           LL_RTC_TS_GetMinute
+  * @param  RTCx RTC Instance
+  * @retval Value between Min_Data=0x00 and Max_Data=0x59
+  */
+__STATIC_INLINE uint32_t LL_RTC_TS_GetMinute(RTC_TypeDef *RTCx)
+{
+  return (uint32_t)(READ_BIT(RTCx->TSTR, RTC_TSTR_MNT | RTC_TSTR_MNU) >> RTC_TSTR_MNU_Pos);
+}
+
+/**
+  * @brief  Get Timestamp Seconds in BCD format
+  * @note helper macro __LL_RTC_CONVERT_BCD2BIN is available to convert Seconds from BCD to Binary format
+  * @rmtoll TSTR         ST            LL_RTC_TS_GetSecond\n
+  *         TSTR         SU            LL_RTC_TS_GetSecond
+  * @param  RTCx RTC Instance
+  * @retval Value between Min_Data=0x00 and Max_Data=0x59
+  */
+__STATIC_INLINE uint32_t LL_RTC_TS_GetSecond(RTC_TypeDef *RTCx)
+{
+  return (uint32_t)(READ_BIT(RTCx->TSTR, RTC_TSTR_ST | RTC_TSTR_SU));
+}
+
+/**
+  * @brief  Get Timestamp time (hour, minute and second) in BCD format
+  * @note helper macros __LL_RTC_GET_HOUR, __LL_RTC_GET_MINUTE and __LL_RTC_GET_SECOND
+  * are available to get independently each parameter.
+  * @rmtoll TSTR         HT            LL_RTC_TS_GetTime\n
+  *         TSTR         HU            LL_RTC_TS_GetTime\n
+  *         TSTR         MNT           LL_RTC_TS_GetTime\n
+  *         TSTR         MNU           LL_RTC_TS_GetTime\n
+  *         TSTR         ST            LL_RTC_TS_GetTime\n
+  *         TSTR         SU            LL_RTC_TS_GetTime
+  * @param  RTCx RTC Instance
+  * @retval Combination of hours, minutes and seconds.
+  */
+__STATIC_INLINE uint32_t LL_RTC_TS_GetTime(RTC_TypeDef *RTCx)
+{
+  return (uint32_t)(READ_BIT(RTCx->TSTR,
+                             RTC_TSTR_HT | RTC_TSTR_HU | RTC_TSTR_MNT | RTC_TSTR_MNU | RTC_TSTR_ST | RTC_TSTR_SU));
+}
+
+/**
+  * @brief  Get Timestamp Week day
+  * @rmtoll TSDR         WDU           LL_RTC_TS_GetWeekDay
+  * @param  RTCx RTC Instance
+  * @retval Returned value can be one of the following values:
+  *         @arg @ref LL_RTC_WEEKDAY_MONDAY
+  *         @arg @ref LL_RTC_WEEKDAY_TUESDAY
+  *         @arg @ref LL_RTC_WEEKDAY_WEDNESDAY
+  *         @arg @ref LL_RTC_WEEKDAY_THURSDAY
+  *         @arg @ref LL_RTC_WEEKDAY_FRIDAY
+  *         @arg @ref LL_RTC_WEEKDAY_SATURDAY
+  *         @arg @ref LL_RTC_WEEKDAY_SUNDAY
+  */
+__STATIC_INLINE uint32_t LL_RTC_TS_GetWeekDay(RTC_TypeDef *RTCx)
+{
+  return (uint32_t)(READ_BIT(RTCx->TSDR, RTC_TSDR_WDU) >> RTC_TSDR_WDU_Pos);
+}
+
+/**
+  * @brief  Get Timestamp Month in BCD format
+  * @note helper macro __LL_RTC_CONVERT_BCD2BIN is available to convert Month from BCD to Binary format
+  * @rmtoll TSDR         MT            LL_RTC_TS_GetMonth\n
+  *         TSDR         MU            LL_RTC_TS_GetMonth
+  * @param  RTCx RTC Instance
+  * @retval Returned value can be one of the following values:
+  *         @arg @ref LL_RTC_MONTH_JANUARY
+  *         @arg @ref LL_RTC_MONTH_FEBRUARY
+  *         @arg @ref LL_RTC_MONTH_MARCH
+  *         @arg @ref LL_RTC_MONTH_APRIL
+  *         @arg @ref LL_RTC_MONTH_MAY
+  *         @arg @ref LL_RTC_MONTH_JUNE
+  *         @arg @ref LL_RTC_MONTH_JULY
+  *         @arg @ref LL_RTC_MONTH_AUGUST
+  *         @arg @ref LL_RTC_MONTH_SEPTEMBER
+  *         @arg @ref LL_RTC_MONTH_OCTOBER
+  *         @arg @ref LL_RTC_MONTH_NOVEMBER
+  *         @arg @ref LL_RTC_MONTH_DECEMBER
+  */
+__STATIC_INLINE uint32_t LL_RTC_TS_GetMonth(RTC_TypeDef *RTCx)
+{
+  return (uint32_t)(READ_BIT(RTCx->TSDR, RTC_TSDR_MT | RTC_TSDR_MU) >> RTC_TSDR_MU_Pos);
+}
+
+/**
+  * @brief  Get Timestamp Day in BCD format
+  * @note helper macro __LL_RTC_CONVERT_BCD2BIN is available to convert Day from BCD to Binary format
+  * @rmtoll TSDR         DT            LL_RTC_TS_GetDay\n
+  *         TSDR         DU            LL_RTC_TS_GetDay
+  * @param  RTCx RTC Instance
+  * @retval Value between Min_Data=0x01 and Max_Data=0x31
+  */
+__STATIC_INLINE uint32_t LL_RTC_TS_GetDay(RTC_TypeDef *RTCx)
+{
+  return (uint32_t)(READ_BIT(RTCx->TSDR, RTC_TSDR_DT | RTC_TSDR_DU));
+}
+
+/**
+  * @brief  Get Timestamp date (WeekDay, Day and Month) in BCD format
+  * @note helper macros __LL_RTC_GET_WEEKDAY, __LL_RTC_GET_MONTH,
+  * and __LL_RTC_GET_DAY are available to get independently each parameter.
+  * @rmtoll TSDR         WDU           LL_RTC_TS_GetDate\n
+  *         TSDR         MT            LL_RTC_TS_GetDate\n
+  *         TSDR         MU            LL_RTC_TS_GetDate\n
+  *         TSDR         DT            LL_RTC_TS_GetDate\n
+  *         TSDR         DU            LL_RTC_TS_GetDate
+  * @param  RTCx RTC Instance
+  * @retval Combination of Weekday, Day and Month
+  */
+__STATIC_INLINE uint32_t LL_RTC_TS_GetDate(RTC_TypeDef *RTCx)
+{
+  return (uint32_t)(READ_BIT(RTCx->TSDR, RTC_TSDR_WDU | RTC_TSDR_MT | RTC_TSDR_MU | RTC_TSDR_DT | RTC_TSDR_DU));
+}
+
+/**
+  * @brief  Get time-stamp subseconds value
+  * @rmtoll TSSSR        SS            LL_RTC_TS_GetSubSecond
+  * @param  RTCx RTC Instance
+  * @retval Value between Min_Data=0x00 and Max_Data=0xFFFF
+  */
+__STATIC_INLINE uint32_t LL_RTC_TS_GetSubSecond(RTC_TypeDef *RTCx)
+{
+  return (uint32_t)(READ_BIT(RTCx->TSSSR, RTC_TSSSR_SS));
+}
+
+#if defined(RTC_TAMPCR_TAMPTS)
+/**
+  * @brief  Activate timestamp on tamper detection event
+  * @rmtoll TAMPCR       TAMPTS        LL_RTC_TS_EnableOnTamper
+  * @param  RTCx RTC Instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_TS_EnableOnTamper(RTC_TypeDef *RTCx)
+{
+  SET_BIT(RTCx->TAMPCR, RTC_TAMPCR_TAMPTS);
+}
+
+/**
+  * @brief  Disable timestamp on tamper detection event
+  * @rmtoll TAMPCR       TAMPTS        LL_RTC_TS_DisableOnTamper
+  * @param  RTCx RTC Instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_TS_DisableOnTamper(RTC_TypeDef *RTCx)
+{
+  CLEAR_BIT(RTCx->TAMPCR, RTC_TAMPCR_TAMPTS);
+}
+#endif /* RTC_TAMPCR_TAMPTS */
+
+/**
+  * @brief  Set timestamp Pin
+  * @rmtoll TAMPCR       TSINSEL      LL_RTC_TS_SetPin
+  * @param  RTCx RTC Instance
+  * @param  TSPin specifies the RTC Timestamp Pin.
+  *          This parameter can be one of the following values:
+  *            @arg LL_RTC_TimeStampPin_Default: RTC_AF1 is used as RTC Timestamp Pin.
+  *            @arg LL_RTC_TimeStampPin_Pos1: RTC_AF2 is used as RTC Timestamp Pin.
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_TS_SetPin(RTC_TypeDef *RTCx, uint32_t TSPin)
+{
+  MODIFY_REG(RTCx->OR, RTC_OR_TSINSEL, TSPin);
+}
+
+/**
+  * @brief  Get timestamp Pin
+  * @rmtoll TAMPCR       TSINSEL      LL_RTC_TS_GetPin
+  * @param  RTCx RTC Instance
+  * @retval Returned value can be one of the following values:
+  *            @arg LL_RTC_TimeStampPin_Default: RTC_AF1 is used as RTC Timestamp Pin.
+  *            @arg LL_RTC_TimeStampPin_Pos1: RTC_AF2 is used as RTC Timestamp Pin.
+  * @retval None
+  */
+__STATIC_INLINE uint32_t LL_RTC_TS_GetPin(RTC_TypeDef *RTCx)
+{
+  return (uint32_t)(READ_BIT(RTCx->OR, RTC_OR_TSINSEL));
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup RTC_LL_EF_Tamper Tamper
+  * @{
+  */
+
+/**
+  * @brief  Enable RTC_TAMPx input detection
+  * @rmtoll TAMPCR       TAMP1E        LL_RTC_TAMPER_Enable\n
+  *         TAMPCR       TAMP2E        LL_RTC_TAMPER_Enable\n
+  *         TAMPCR       TAMP3E        LL_RTC_TAMPER_Enable
+  * @param  RTCx RTC Instance
+  * @param  Tamper This parameter can be a combination of the following values:
+  *         @arg @ref LL_RTC_TAMPER_1
+  *         @arg @ref LL_RTC_TAMPER_2
+  *         @arg @ref LL_RTC_TAMPER_3
+  *
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_TAMPER_Enable(RTC_TypeDef *RTCx, uint32_t Tamper)
+{
+  SET_BIT(RTCx->TAMPCR, Tamper);
+}
+
+/**
+  * @brief  Clear RTC_TAMPx input detection
+  * @rmtoll TAMPCR       TAMP1E        LL_RTC_TAMPER_Disable\n
+  *         TAMPCR       TAMP2E        LL_RTC_TAMPER_Disable\n
+  *         TAMPCR       TAMP3E        LL_RTC_TAMPER_Disable
+  * @param  RTCx RTC Instance
+  * @param  Tamper This parameter can be a combination of the following values:
+  *         @arg @ref LL_RTC_TAMPER_1
+  *         @arg @ref LL_RTC_TAMPER_2
+  *         @arg @ref LL_RTC_TAMPER_3
+  *
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_TAMPER_Disable(RTC_TypeDef *RTCx, uint32_t Tamper)
+{
+  CLEAR_BIT(RTCx->TAMPCR, Tamper);
+}
+
+/**
+  * @brief  Enable Tamper mask flag
+  * @note Associated Tamper IT must not enabled when tamper mask is set.
+  * @rmtoll TAMPCR       TAMP1MF       LL_RTC_TAMPER_EnableMask\n
+  *         TAMPCR       TAMP2MF       LL_RTC_TAMPER_EnableMask\n
+  *         TAMPCR       TAMP3MF       LL_RTC_TAMPER_EnableMask
+  * @param  RTCx RTC Instance
+  * @param  Mask This parameter can be a combination of the following values:
+  *         @arg @ref LL_RTC_TAMPER_MASK_TAMPER1
+  *         @arg @ref LL_RTC_TAMPER_MASK_TAMPER2
+  *         @arg @ref LL_RTC_TAMPER_MASK_TAMPER3
+  *
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_TAMPER_EnableMask(RTC_TypeDef *RTCx, uint32_t Mask)
+{
+  SET_BIT(RTCx->TAMPCR, Mask);
+}
+
+/**
+  * @brief  Disable Tamper mask flag
+  * @rmtoll TAMPCR       TAMP1MF       LL_RTC_TAMPER_DisableMask\n
+  *         TAMPCR       TAMP2MF       LL_RTC_TAMPER_DisableMask\n
+  *         TAMPCR       TAMP3MF       LL_RTC_TAMPER_DisableMask
+  * @param  RTCx RTC Instance
+  * @param  Mask This parameter can be a combination of the following values:
+  *         @arg @ref LL_RTC_TAMPER_MASK_TAMPER1
+  *         @arg @ref LL_RTC_TAMPER_MASK_TAMPER2
+  *         @arg @ref LL_RTC_TAMPER_MASK_TAMPER3
+  *
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_TAMPER_DisableMask(RTC_TypeDef *RTCx, uint32_t Mask)
+{
+  CLEAR_BIT(RTCx->TAMPCR, Mask);
+}
+
+/**
+  * @brief  Enable backup register erase after Tamper event detection
+  * @rmtoll TAMPCR       TAMP1NOERASE  LL_RTC_TAMPER_EnableEraseBKP\n
+  *         TAMPCR       TAMP2NOERASE  LL_RTC_TAMPER_EnableEraseBKP\n
+  *         TAMPCR       TAMP3NOERASE  LL_RTC_TAMPER_EnableEraseBKP
+  * @param  RTCx RTC Instance
+  * @param  Tamper This parameter can be a combination of the following values:
+  *         @arg @ref LL_RTC_TAMPER_NOERASE_TAMPER1
+  *         @arg @ref LL_RTC_TAMPER_NOERASE_TAMPER2
+  *         @arg @ref LL_RTC_TAMPER_NOERASE_TAMPER3
+  *
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_TAMPER_EnableEraseBKP(RTC_TypeDef *RTCx, uint32_t Tamper)
+{
+  CLEAR_BIT(RTCx->TAMPCR, Tamper);
+}
+
+/**
+  * @brief  Disable backup register erase after Tamper event detection
+  * @rmtoll TAMPCR       TAMP1NOERASE  LL_RTC_TAMPER_DisableEraseBKP\n
+  *         TAMPCR       TAMP2NOERASE  LL_RTC_TAMPER_DisableEraseBKP\n
+  *         TAMPCR       TAMP3NOERASE  LL_RTC_TAMPER_DisableEraseBKP
+  * @param  RTCx RTC Instance
+  * @param  Tamper This parameter can be a combination of the following values:
+  *         @arg @ref LL_RTC_TAMPER_NOERASE_TAMPER1
+  *         @arg @ref LL_RTC_TAMPER_NOERASE_TAMPER2
+  *         @arg @ref LL_RTC_TAMPER_NOERASE_TAMPER3
+  *
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_TAMPER_DisableEraseBKP(RTC_TypeDef *RTCx, uint32_t Tamper)
+{
+  SET_BIT(RTCx->TAMPCR, Tamper);
+}
+
+/**
+  * @brief  Disable RTC_TAMPx pull-up disable (Disable precharge of RTC_TAMPx pins)
+  * @rmtoll TAMPCR       TAMPPUDIS     LL_RTC_TAMPER_DisablePullUp
+  * @param  RTCx RTC Instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_TAMPER_DisablePullUp(RTC_TypeDef *RTCx)
+{
+  SET_BIT(RTCx->TAMPCR, RTC_TAMPCR_TAMPPUDIS);
+}
+
+/**
+  * @brief  Enable RTC_TAMPx pull-up disable ( Precharge RTC_TAMPx pins before sampling)
+  * @rmtoll TAMPCR       TAMPPUDIS     LL_RTC_TAMPER_EnablePullUp
+  * @param  RTCx RTC Instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_TAMPER_EnablePullUp(RTC_TypeDef *RTCx)
+{
+  CLEAR_BIT(RTCx->TAMPCR, RTC_TAMPCR_TAMPPUDIS);
+}
+
+/**
+  * @brief  Set RTC_TAMPx precharge duration
+  * @rmtoll TAMPCR       TAMPPRCH      LL_RTC_TAMPER_SetPrecharge
+  * @param  RTCx RTC Instance
+  * @param  Duration This parameter can be one of the following values:
+  *         @arg @ref LL_RTC_TAMPER_DURATION_1RTCCLK
+  *         @arg @ref LL_RTC_TAMPER_DURATION_2RTCCLK
+  *         @arg @ref LL_RTC_TAMPER_DURATION_4RTCCLK
+  *         @arg @ref LL_RTC_TAMPER_DURATION_8RTCCLK
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_TAMPER_SetPrecharge(RTC_TypeDef *RTCx, uint32_t Duration)
+{
+  MODIFY_REG(RTCx->TAMPCR, RTC_TAMPCR_TAMPPRCH, Duration);
+}
+
+/**
+  * @brief  Get RTC_TAMPx precharge duration
+  * @rmtoll TAMPCR       TAMPPRCH      LL_RTC_TAMPER_GetPrecharge
+  * @param  RTCx RTC Instance
+  * @retval Returned value can be one of the following values:
+  *         @arg @ref LL_RTC_TAMPER_DURATION_1RTCCLK
+  *         @arg @ref LL_RTC_TAMPER_DURATION_2RTCCLK
+  *         @arg @ref LL_RTC_TAMPER_DURATION_4RTCCLK
+  *         @arg @ref LL_RTC_TAMPER_DURATION_8RTCCLK
+  */
+__STATIC_INLINE uint32_t LL_RTC_TAMPER_GetPrecharge(RTC_TypeDef *RTCx)
+{
+  return (uint32_t)(READ_BIT(RTCx->TAMPCR, RTC_TAMPCR_TAMPPRCH));
+}
+
+/**
+  * @brief  Set RTC_TAMPx filter count
+  * @rmtoll TAMPCR       TAMPFLT       LL_RTC_TAMPER_SetFilterCount
+  * @param  RTCx RTC Instance
+  * @param  FilterCount This parameter can be one of the following values:
+  *         @arg @ref LL_RTC_TAMPER_FILTER_DISABLE
+  *         @arg @ref LL_RTC_TAMPER_FILTER_2SAMPLE
+  *         @arg @ref LL_RTC_TAMPER_FILTER_4SAMPLE
+  *         @arg @ref LL_RTC_TAMPER_FILTER_8SAMPLE
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_TAMPER_SetFilterCount(RTC_TypeDef *RTCx, uint32_t FilterCount)
+{
+  MODIFY_REG(RTCx->TAMPCR, RTC_TAMPCR_TAMPFLT, FilterCount);
+}
+
+/**
+  * @brief  Get RTC_TAMPx filter count
+  * @rmtoll TAMPCR       TAMPFLT       LL_RTC_TAMPER_GetFilterCount
+  * @param  RTCx RTC Instance
+  * @retval Returned value can be one of the following values:
+  *         @arg @ref LL_RTC_TAMPER_FILTER_DISABLE
+  *         @arg @ref LL_RTC_TAMPER_FILTER_2SAMPLE
+  *         @arg @ref LL_RTC_TAMPER_FILTER_4SAMPLE
+  *         @arg @ref LL_RTC_TAMPER_FILTER_8SAMPLE
+  */
+__STATIC_INLINE uint32_t LL_RTC_TAMPER_GetFilterCount(RTC_TypeDef *RTCx)
+{
+  return (uint32_t)(READ_BIT(RTCx->TAMPCR, RTC_TAMPCR_TAMPFLT));
+}
+
+/**
+  * @brief  Set Tamper sampling frequency
+  * @rmtoll TAMPCR       TAMPFREQ      LL_RTC_TAMPER_SetSamplingFreq
+  * @param  RTCx RTC Instance
+  * @param  SamplingFreq This parameter can be one of the following values:
+  *         @arg @ref LL_RTC_TAMPER_SAMPLFREQDIV_32768
+  *         @arg @ref LL_RTC_TAMPER_SAMPLFREQDIV_16384
+  *         @arg @ref LL_RTC_TAMPER_SAMPLFREQDIV_8192
+  *         @arg @ref LL_RTC_TAMPER_SAMPLFREQDIV_4096
+  *         @arg @ref LL_RTC_TAMPER_SAMPLFREQDIV_2048
+  *         @arg @ref LL_RTC_TAMPER_SAMPLFREQDIV_1024
+  *         @arg @ref LL_RTC_TAMPER_SAMPLFREQDIV_512
+  *         @arg @ref LL_RTC_TAMPER_SAMPLFREQDIV_256
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_TAMPER_SetSamplingFreq(RTC_TypeDef *RTCx, uint32_t SamplingFreq)
+{
+  MODIFY_REG(RTCx->TAMPCR, RTC_TAMPCR_TAMPFREQ, SamplingFreq);
+}
+
+/**
+  * @brief  Get Tamper sampling frequency
+  * @rmtoll TAMPCR       TAMPFREQ      LL_RTC_TAMPER_GetSamplingFreq
+  * @param  RTCx RTC Instance
+  * @retval Returned value can be one of the following values:
+  *         @arg @ref LL_RTC_TAMPER_SAMPLFREQDIV_32768
+  *         @arg @ref LL_RTC_TAMPER_SAMPLFREQDIV_16384
+  *         @arg @ref LL_RTC_TAMPER_SAMPLFREQDIV_8192
+  *         @arg @ref LL_RTC_TAMPER_SAMPLFREQDIV_4096
+  *         @arg @ref LL_RTC_TAMPER_SAMPLFREQDIV_2048
+  *         @arg @ref LL_RTC_TAMPER_SAMPLFREQDIV_1024
+  *         @arg @ref LL_RTC_TAMPER_SAMPLFREQDIV_512
+  *         @arg @ref LL_RTC_TAMPER_SAMPLFREQDIV_256
+  */
+__STATIC_INLINE uint32_t LL_RTC_TAMPER_GetSamplingFreq(RTC_TypeDef *RTCx)
+{
+  return (uint32_t)(READ_BIT(RTCx->TAMPCR, RTC_TAMPCR_TAMPFREQ));
+}
+
+/**
+  * @brief  Enable Active level for Tamper input
+  * @rmtoll TAMPCR       TAMP1TRG      LL_RTC_TAMPER_EnableActiveLevel\n
+  *         TAMPCR       TAMP2TRG      LL_RTC_TAMPER_EnableActiveLevel\n
+  *         TAMPCR       TAMP3TRG      LL_RTC_TAMPER_EnableActiveLevel
+  * @param  RTCx RTC Instance
+  * @param  Tamper This parameter can be a combination of the following values:
+  *         @arg @ref LL_RTC_TAMPER_ACTIVELEVEL_TAMP1
+  *         @arg @ref LL_RTC_TAMPER_ACTIVELEVEL_TAMP2
+  *         @arg @ref LL_RTC_TAMPER_ACTIVELEVEL_TAMP3
+  *
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_TAMPER_EnableActiveLevel(RTC_TypeDef *RTCx, uint32_t Tamper)
+{
+  SET_BIT(RTCx->TAMPCR, Tamper);
+}
+
+/**
+  * @brief  Disable Active level for Tamper input
+  * @rmtoll TAMPCR       TAMP1TRG      LL_RTC_TAMPER_DisableActiveLevel\n
+  *         TAMPCR       TAMP2TRG      LL_RTC_TAMPER_DisableActiveLevel\n
+  *         TAMPCR       TAMP3TRG      LL_RTC_TAMPER_DisableActiveLevel
+  * @param  RTCx RTC Instance
+  * @param  Tamper This parameter can be a combination of the following values:
+  *         @arg @ref LL_RTC_TAMPER_ACTIVELEVEL_TAMP1
+  *         @arg @ref LL_RTC_TAMPER_ACTIVELEVEL_TAMP2
+  *         @arg @ref LL_RTC_TAMPER_ACTIVELEVEL_TAMP3
+  *
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_TAMPER_DisableActiveLevel(RTC_TypeDef *RTCx, uint32_t Tamper)
+{
+  CLEAR_BIT(RTCx->TAMPCR, Tamper);
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup RTC_LL_EF_Wakeup Wakeup
+  * @{
+  */
+
+/**
+  * @brief  Enable Wakeup timer
+  * @note   Bit is write-protected. @ref LL_RTC_DisableWriteProtection function should be called before.
+  * @rmtoll CR           WUTE          LL_RTC_WAKEUP_Enable
+  * @param  RTCx RTC Instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_WAKEUP_Enable(RTC_TypeDef *RTCx)
+{
+  SET_BIT(RTCx->CR, RTC_CR_WUTE);
+}
+
+/**
+  * @brief  Disable Wakeup timer
+  * @note   Bit is write-protected. @ref LL_RTC_DisableWriteProtection function should be called before.
+  * @rmtoll CR           WUTE          LL_RTC_WAKEUP_Disable
+  * @param  RTCx RTC Instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_WAKEUP_Disable(RTC_TypeDef *RTCx)
+{
+  CLEAR_BIT(RTCx->CR, RTC_CR_WUTE);
+}
+
+/**
+  * @brief  Check if Wakeup timer is enabled or not
+  * @rmtoll CR           WUTE          LL_RTC_WAKEUP_IsEnabled
+  * @param  RTCx RTC Instance
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_RTC_WAKEUP_IsEnabled(RTC_TypeDef *RTCx)
+{
+  return ((READ_BIT(RTCx->CR, RTC_CR_WUTE) == (RTC_CR_WUTE)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Select Wakeup clock
+  * @note   Bit is write-protected. @ref LL_RTC_DisableWriteProtection function should be called before.
+  * @note   Bit can be written only when RTC_CR WUTE bit = 0 and RTC_ISR WUTWF bit = 1
+  * @rmtoll CR           WUCKSEL       LL_RTC_WAKEUP_SetClock
+  * @param  RTCx RTC Instance
+  * @param  WakeupClock This parameter can be one of the following values:
+  *         @arg @ref LL_RTC_WAKEUPCLOCK_DIV_16
+  *         @arg @ref LL_RTC_WAKEUPCLOCK_DIV_8
+  *         @arg @ref LL_RTC_WAKEUPCLOCK_DIV_4
+  *         @arg @ref LL_RTC_WAKEUPCLOCK_DIV_2
+  *         @arg @ref LL_RTC_WAKEUPCLOCK_CKSPRE
+  *         @arg @ref LL_RTC_WAKEUPCLOCK_CKSPRE_WUT
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_WAKEUP_SetClock(RTC_TypeDef *RTCx, uint32_t WakeupClock)
+{
+  MODIFY_REG(RTCx->CR, RTC_CR_WUCKSEL, WakeupClock);
+}
+
+/**
+  * @brief  Get Wakeup clock
+  * @rmtoll CR           WUCKSEL       LL_RTC_WAKEUP_GetClock
+  * @param  RTCx RTC Instance
+  * @retval Returned value can be one of the following values:
+  *         @arg @ref LL_RTC_WAKEUPCLOCK_DIV_16
+  *         @arg @ref LL_RTC_WAKEUPCLOCK_DIV_8
+  *         @arg @ref LL_RTC_WAKEUPCLOCK_DIV_4
+  *         @arg @ref LL_RTC_WAKEUPCLOCK_DIV_2
+  *         @arg @ref LL_RTC_WAKEUPCLOCK_CKSPRE
+  *         @arg @ref LL_RTC_WAKEUPCLOCK_CKSPRE_WUT
+  */
+__STATIC_INLINE uint32_t LL_RTC_WAKEUP_GetClock(RTC_TypeDef *RTCx)
+{
+  return (uint32_t)(READ_BIT(RTCx->CR, RTC_CR_WUCKSEL));
+}
+
+/**
+  * @brief  Set Wakeup auto-reload value
+  * @note   Bit can be written only when WUTWF is set to 1 in RTC_ISR
+  * @rmtoll WUTR         WUT           LL_RTC_WAKEUP_SetAutoReload
+  * @param  RTCx RTC Instance
+  * @param  Value Value between Min_Data=0x00 and Max_Data=0xFFFF
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_WAKEUP_SetAutoReload(RTC_TypeDef *RTCx, uint32_t Value)
+{
+  MODIFY_REG(RTCx->WUTR, RTC_WUTR_WUT, Value);
+}
+
+/**
+  * @brief  Get Wakeup auto-reload value
+  * @rmtoll WUTR         WUT           LL_RTC_WAKEUP_GetAutoReload
+  * @param  RTCx RTC Instance
+  * @retval Value between Min_Data=0x00 and Max_Data=0xFFFF
+  */
+__STATIC_INLINE uint32_t LL_RTC_WAKEUP_GetAutoReload(RTC_TypeDef *RTCx)
+{
+  return (uint32_t)(READ_BIT(RTCx->WUTR, RTC_WUTR_WUT));
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup RTC_LL_EF_Backup_Registers Backup_Registers
+  * @{
+  */
+
+/**
+  * @brief  Writes a data in a specified RTC Backup data register.
+  * @rmtoll BKPxR        BKP           LL_RTC_BAK_SetRegister
+  * @param  RTCx RTC Instance
+  * @param  BackupRegister This parameter can be one of the following values:
+  *         @arg @ref LL_RTC_BKP_DR0
+  *         @arg @ref LL_RTC_BKP_DR1
+  *         @arg @ref LL_RTC_BKP_DR2
+  *         @arg @ref LL_RTC_BKP_DR3
+  *         @arg @ref LL_RTC_BKP_DR4
+  *         @arg @ref LL_RTC_BKP_DR5
+  *         @arg @ref LL_RTC_BKP_DR6
+  *         @arg @ref LL_RTC_BKP_DR7
+  *         @arg @ref LL_RTC_BKP_DR8
+  *         @arg @ref LL_RTC_BKP_DR9
+  *         @arg @ref LL_RTC_BKP_DR10
+  *         @arg @ref LL_RTC_BKP_DR11
+  *         @arg @ref LL_RTC_BKP_DR12
+  *         @arg @ref LL_RTC_BKP_DR13
+  *         @arg @ref LL_RTC_BKP_DR14
+  *         @arg @ref LL_RTC_BKP_DR15
+  *         @arg @ref LL_RTC_BKP_DR16
+  *         @arg @ref LL_RTC_BKP_DR17
+  *         @arg @ref LL_RTC_BKP_DR18
+  *         @arg @ref LL_RTC_BKP_DR19
+  *         @arg @ref LL_RTC_BKP_DR20
+  *         @arg @ref LL_RTC_BKP_DR21
+  *         @arg @ref LL_RTC_BKP_DR22
+  *         @arg @ref LL_RTC_BKP_DR23
+  *         @arg @ref LL_RTC_BKP_DR24
+  *         @arg @ref LL_RTC_BKP_DR25
+  *         @arg @ref LL_RTC_BKP_DR26
+  *         @arg @ref LL_RTC_BKP_DR27
+  *         @arg @ref LL_RTC_BKP_DR28
+  *         @arg @ref LL_RTC_BKP_DR29
+  *         @arg @ref LL_RTC_BKP_DR30
+  *         @arg @ref LL_RTC_BKP_DR31
+  * @param  Data Value between Min_Data=0x00 and Max_Data=0xFFFFFFFF
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_BAK_SetRegister(RTC_TypeDef *RTCx, uint32_t BackupRegister, uint32_t Data)
+{
+  uint32_t temp;
+
+  temp = (uint32_t)(&(RTCx->BKP0R));
+  temp += (BackupRegister * 4U);
+
+  /* Write the specified register */
+  *(__IO uint32_t *)temp = (uint32_t)Data;
+}
+
+/**
+  * @brief  Reads data from the specified RTC Backup data Register.
+  * @rmtoll BKPxR        BKP           LL_RTC_BAK_GetRegister
+  * @param  RTCx RTC Instance
+  * @param  BackupRegister This parameter can be one of the following values:
+  *         @arg @ref LL_RTC_BKP_DR0
+  *         @arg @ref LL_RTC_BKP_DR1
+  *         @arg @ref LL_RTC_BKP_DR2
+  *         @arg @ref LL_RTC_BKP_DR3
+  *         @arg @ref LL_RTC_BKP_DR4
+  *         @arg @ref LL_RTC_BKP_DR5
+  *         @arg @ref LL_RTC_BKP_DR6
+  *         @arg @ref LL_RTC_BKP_DR7
+  *         @arg @ref LL_RTC_BKP_DR8
+  *         @arg @ref LL_RTC_BKP_DR9
+  *         @arg @ref LL_RTC_BKP_DR10
+  *         @arg @ref LL_RTC_BKP_DR11
+  *         @arg @ref LL_RTC_BKP_DR12
+  *         @arg @ref LL_RTC_BKP_DR13
+  *         @arg @ref LL_RTC_BKP_DR14
+  *         @arg @ref LL_RTC_BKP_DR15
+  *         @arg @ref LL_RTC_BKP_DR16
+  *         @arg @ref LL_RTC_BKP_DR17
+  *         @arg @ref LL_RTC_BKP_DR18
+  *         @arg @ref LL_RTC_BKP_DR19
+  *         @arg @ref LL_RTC_BKP_DR20
+  *         @arg @ref LL_RTC_BKP_DR21
+  *         @arg @ref LL_RTC_BKP_DR22
+  *         @arg @ref LL_RTC_BKP_DR23
+  *         @arg @ref LL_RTC_BKP_DR24
+  *         @arg @ref LL_RTC_BKP_DR25
+  *         @arg @ref LL_RTC_BKP_DR26
+  *         @arg @ref LL_RTC_BKP_DR27
+  *         @arg @ref LL_RTC_BKP_DR28
+  *         @arg @ref LL_RTC_BKP_DR29
+  *         @arg @ref LL_RTC_BKP_DR30
+  *         @arg @ref LL_RTC_BKP_DR31
+  * @retval Value between Min_Data=0x00 and Max_Data=0xFFFFFFFF
+  */
+__STATIC_INLINE uint32_t LL_RTC_BAK_GetRegister(RTC_TypeDef *RTCx, uint32_t BackupRegister)
+{
+  uint32_t temp;
+
+  temp = (uint32_t)(&(RTCx->BKP0R));
+  temp += (BackupRegister * 4U);
+
+  /* Read the specified register */
+  return (*(__IO uint32_t *)temp);
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup RTC_LL_EF_Calibration Calibration
+  * @{
+  */
+
+/**
+  * @brief  Set Calibration output frequency (1 Hz or 512 Hz)
+  * @note Bits are write-protected. @ref LL_RTC_DisableWriteProtection function should be called before.
+  * @rmtoll CR           COE           LL_RTC_CAL_SetOutputFreq\n
+  *         CR           COSEL         LL_RTC_CAL_SetOutputFreq
+  * @param  RTCx RTC Instance
+  * @param  Frequency This parameter can be one of the following values:
+  *         @arg @ref LL_RTC_CALIB_OUTPUT_NONE
+  *         @arg @ref LL_RTC_CALIB_OUTPUT_1HZ
+  *         @arg @ref LL_RTC_CALIB_OUTPUT_512HZ
+  *
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_CAL_SetOutputFreq(RTC_TypeDef *RTCx, uint32_t Frequency)
+{
+  MODIFY_REG(RTCx->CR, RTC_CR_COE | RTC_CR_COSEL, Frequency);
+}
+
+/**
+  * @brief  Get Calibration output frequency (1 Hz or 512 Hz)
+  * @rmtoll CR           COE           LL_RTC_CAL_GetOutputFreq\n
+  *         CR           COSEL         LL_RTC_CAL_GetOutputFreq
+  * @param  RTCx RTC Instance
+  * @retval Returned value can be one of the following values:
+  *         @arg @ref LL_RTC_CALIB_OUTPUT_NONE
+  *         @arg @ref LL_RTC_CALIB_OUTPUT_1HZ
+  *         @arg @ref LL_RTC_CALIB_OUTPUT_512HZ
+  *
+  */
+__STATIC_INLINE uint32_t LL_RTC_CAL_GetOutputFreq(RTC_TypeDef *RTCx)
+{
+  return (uint32_t)(READ_BIT(RTCx->CR, RTC_CR_COE | RTC_CR_COSEL));
+}
+
+/**
+  * @brief  Insert or not One RTCCLK pulse every 2exp11 pulses (frequency increased by 488.5 ppm)
+  * @note   Bit is write-protected. @ref LL_RTC_DisableWriteProtection function should be called before.
+  * @note   Bit can be written only when RECALPF is set to 0 in RTC_ISR
+  * @rmtoll CALR         CALP          LL_RTC_CAL_SetPulse
+  * @param  RTCx RTC Instance
+  * @param  Pulse This parameter can be one of the following values:
+  *         @arg @ref LL_RTC_CALIB_INSERTPULSE_NONE
+  *         @arg @ref LL_RTC_CALIB_INSERTPULSE_SET
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_CAL_SetPulse(RTC_TypeDef *RTCx, uint32_t Pulse)
+{
+  MODIFY_REG(RTCx->CALR, RTC_CALR_CALP, Pulse);
+}
+
+/**
+  * @brief  Check if one RTCCLK has been inserted or not every 2exp11 pulses (frequency increased by 488.5 ppm)
+  * @rmtoll CALR         CALP          LL_RTC_CAL_IsPulseInserted
+  * @param  RTCx RTC Instance
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_RTC_CAL_IsPulseInserted(RTC_TypeDef *RTCx)
+{
+  return ((READ_BIT(RTCx->CALR, RTC_CALR_CALP) == (RTC_CALR_CALP)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Set smooth calibration cycle period
+  * @note   Bit is write-protected. @ref LL_RTC_DisableWriteProtection function should be called before.
+  * @note   Bit can be written only when RECALPF is set to 0 in RTC_ISR
+  * @rmtoll CALR         CALW8         LL_RTC_CAL_SetPeriod\n
+  *         CALR         CALW16        LL_RTC_CAL_SetPeriod
+  * @param  RTCx RTC Instance
+  * @param  Period This parameter can be one of the following values:
+  *         @arg @ref LL_RTC_CALIB_PERIOD_32SEC
+  *         @arg @ref LL_RTC_CALIB_PERIOD_16SEC
+  *         @arg @ref LL_RTC_CALIB_PERIOD_8SEC
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_CAL_SetPeriod(RTC_TypeDef *RTCx, uint32_t Period)
+{
+  MODIFY_REG(RTCx->CALR, RTC_CALR_CALW8 | RTC_CALR_CALW16, Period);
+}
+
+/**
+  * @brief  Get smooth calibration cycle period
+  * @rmtoll CALR         CALW8         LL_RTC_CAL_GetPeriod\n
+  *         CALR         CALW16        LL_RTC_CAL_GetPeriod
+  * @param  RTCx RTC Instance
+  * @retval Returned value can be one of the following values:
+  *         @arg @ref LL_RTC_CALIB_PERIOD_32SEC
+  *         @arg @ref LL_RTC_CALIB_PERIOD_16SEC
+  *         @arg @ref LL_RTC_CALIB_PERIOD_8SEC
+  */
+__STATIC_INLINE uint32_t LL_RTC_CAL_GetPeriod(RTC_TypeDef *RTCx)
+{
+  return (uint32_t)(READ_BIT(RTCx->CALR, RTC_CALR_CALW8 | RTC_CALR_CALW16));
+}
+
+/**
+  * @brief  Set smooth Calibration minus
+  * @note   Bit is write-protected. @ref LL_RTC_DisableWriteProtection function should be called before.
+  * @note   Bit can be written only when RECALPF is set to 0 in RTC_ISR
+  * @rmtoll CALR         CALM          LL_RTC_CAL_SetMinus
+  * @param  RTCx RTC Instance
+  * @param  CalibMinus Value between Min_Data=0x00 and Max_Data=0x1FF
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_CAL_SetMinus(RTC_TypeDef *RTCx, uint32_t CalibMinus)
+{
+  MODIFY_REG(RTCx->CALR, RTC_CALR_CALM, CalibMinus);
+}
+
+/**
+  * @brief  Get smooth Calibration minus
+  * @rmtoll CALR         CALM          LL_RTC_CAL_GetMinus
+  * @param  RTCx RTC Instance
+  * @retval Value between Min_Data=0x00 and Max_Data= 0x1FF
+  */
+__STATIC_INLINE uint32_t LL_RTC_CAL_GetMinus(RTC_TypeDef *RTCx)
+{
+  return (uint32_t)(READ_BIT(RTCx->CALR, RTC_CALR_CALM));
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup RTC_LL_EF_FLAG_Management FLAG_Management
+  * @{
+  */
+
+/**
+  * @brief  Get Internal Time-stamp flag
+  * @rmtoll ISR          ITSF          LL_RTC_IsActiveFlag_ITS
+  * @param  RTCx RTC Instance
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_RTC_IsActiveFlag_ITS(RTC_TypeDef *RTCx)
+{
+  return ((READ_BIT(RTCx->ISR, RTC_ISR_ITSF) == (RTC_ISR_ITSF)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Get Recalibration pending Flag
+  * @rmtoll ISR          RECALPF       LL_RTC_IsActiveFlag_RECALP
+  * @param  RTCx RTC Instance
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_RTC_IsActiveFlag_RECALP(RTC_TypeDef *RTCx)
+{
+  return ((READ_BIT(RTCx->ISR, RTC_ISR_RECALPF) == (RTC_ISR_RECALPF)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Get RTC_TAMP3 detection flag
+  * @rmtoll ISR          TAMP3F        LL_RTC_IsActiveFlag_TAMP3
+  * @param  RTCx RTC Instance
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_RTC_IsActiveFlag_TAMP3(RTC_TypeDef *RTCx)
+{
+  return ((READ_BIT(RTCx->ISR, RTC_ISR_TAMP3F) == (RTC_ISR_TAMP3F)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Get RTC_TAMP2 detection flag
+  * @rmtoll ISR          TAMP2F        LL_RTC_IsActiveFlag_TAMP2
+  * @param  RTCx RTC Instance
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_RTC_IsActiveFlag_TAMP2(RTC_TypeDef *RTCx)
+{
+  return ((READ_BIT(RTCx->ISR, RTC_ISR_TAMP2F) == (RTC_ISR_TAMP2F)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Get RTC_TAMP1 detection flag
+  * @rmtoll ISR          TAMP1F        LL_RTC_IsActiveFlag_TAMP1
+  * @param  RTCx RTC Instance
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_RTC_IsActiveFlag_TAMP1(RTC_TypeDef *RTCx)
+{
+  return ((READ_BIT(RTCx->ISR, RTC_ISR_TAMP1F) == (RTC_ISR_TAMP1F)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Get Time-stamp overflow flag
+  * @rmtoll ISR          TSOVF         LL_RTC_IsActiveFlag_TSOV
+  * @param  RTCx RTC Instance
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_RTC_IsActiveFlag_TSOV(RTC_TypeDef *RTCx)
+{
+  return ((READ_BIT(RTCx->ISR, RTC_ISR_TSOVF) == (RTC_ISR_TSOVF)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Get Time-stamp flag
+  * @rmtoll ISR          TSF           LL_RTC_IsActiveFlag_TS
+  * @param  RTCx RTC Instance
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_RTC_IsActiveFlag_TS(RTC_TypeDef *RTCx)
+{
+  return ((READ_BIT(RTCx->ISR, RTC_ISR_TSF) == (RTC_ISR_TSF)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Get Wakeup timer flag
+  * @rmtoll ISR          WUTF          LL_RTC_IsActiveFlag_WUT
+  * @param  RTCx RTC Instance
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_RTC_IsActiveFlag_WUT(RTC_TypeDef *RTCx)
+{
+  return ((READ_BIT(RTCx->ISR, RTC_ISR_WUTF) == (RTC_ISR_WUTF)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Get Alarm B flag
+  * @rmtoll ISR          ALRBF         LL_RTC_IsActiveFlag_ALRB
+  * @param  RTCx RTC Instance
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_RTC_IsActiveFlag_ALRB(RTC_TypeDef *RTCx)
+{
+  return ((READ_BIT(RTCx->ISR, RTC_ISR_ALRBF) == (RTC_ISR_ALRBF)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Get Alarm A flag
+  * @rmtoll ISR          ALRAF         LL_RTC_IsActiveFlag_ALRA
+  * @param  RTCx RTC Instance
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_RTC_IsActiveFlag_ALRA(RTC_TypeDef *RTCx)
+{
+  return ((READ_BIT(RTCx->ISR, RTC_ISR_ALRAF) == (RTC_ISR_ALRAF)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Clear Internal Time-stamp flag
+  * @rmtoll ISR          ITSF          LL_RTC_ClearFlag_ITS
+  * @param  RTCx RTC Instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_ClearFlag_ITS(RTC_TypeDef *RTCx)
+{
+  WRITE_REG(RTCx->ISR, (~((RTC_ISR_ITSF | RTC_ISR_INIT) & 0x0000FFFFU) | (RTCx->ISR & RTC_ISR_INIT)));
+}
+
+/**
+  * @brief  Clear RTC_TAMP3 detection flag
+  * @rmtoll ISR          TAMP3F        LL_RTC_ClearFlag_TAMP3
+  * @param  RTCx RTC Instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_ClearFlag_TAMP3(RTC_TypeDef *RTCx)
+{
+  WRITE_REG(RTCx->ISR, (~((RTC_ISR_TAMP3F | RTC_ISR_INIT) & 0x0000FFFFU) | (RTCx->ISR & RTC_ISR_INIT)));
+}
+
+/**
+  * @brief  Clear RTC_TAMP2 detection flag
+  * @rmtoll ISR          TAMP2F        LL_RTC_ClearFlag_TAMP2
+  * @param  RTCx RTC Instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_ClearFlag_TAMP2(RTC_TypeDef *RTCx)
+{
+  WRITE_REG(RTCx->ISR, (~((RTC_ISR_TAMP2F | RTC_ISR_INIT) & 0x0000FFFFU) | (RTCx->ISR & RTC_ISR_INIT)));
+}
+
+/**
+  * @brief  Clear RTC_TAMP1 detection flag
+  * @rmtoll ISR          TAMP1F        LL_RTC_ClearFlag_TAMP1
+  * @param  RTCx RTC Instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_ClearFlag_TAMP1(RTC_TypeDef *RTCx)
+{
+  WRITE_REG(RTCx->ISR, (~((RTC_ISR_TAMP1F | RTC_ISR_INIT) & 0x0000FFFFU) | (RTCx->ISR & RTC_ISR_INIT)));
+}
+
+/**
+  * @brief  Clear Time-stamp overflow flag
+  * @rmtoll ISR          TSOVF         LL_RTC_ClearFlag_TSOV
+  * @param  RTCx RTC Instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_ClearFlag_TSOV(RTC_TypeDef *RTCx)
+{
+  WRITE_REG(RTCx->ISR, (~((RTC_ISR_TSOVF | RTC_ISR_INIT) & 0x0000FFFFU) | (RTCx->ISR & RTC_ISR_INIT)));
+}
+
+/**
+  * @brief  Clear Time-stamp flag
+  * @rmtoll ISR          TSF           LL_RTC_ClearFlag_TS
+  * @param  RTCx RTC Instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_ClearFlag_TS(RTC_TypeDef *RTCx)
+{
+  WRITE_REG(RTCx->ISR, (~((RTC_ISR_TSF | RTC_ISR_INIT) & 0x0000FFFFU) | (RTCx->ISR & RTC_ISR_INIT)));
+}
+
+/**
+  * @brief  Clear Wakeup timer flag
+  * @rmtoll ISR          WUTF          LL_RTC_ClearFlag_WUT
+  * @param  RTCx RTC Instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_ClearFlag_WUT(RTC_TypeDef *RTCx)
+{
+  WRITE_REG(RTCx->ISR, (~((RTC_ISR_WUTF | RTC_ISR_INIT) & 0x0000FFFFU) | (RTCx->ISR & RTC_ISR_INIT)));
+}
+
+/**
+  * @brief  Clear Alarm B flag
+  * @rmtoll ISR          ALRBF         LL_RTC_ClearFlag_ALRB
+  * @param  RTCx RTC Instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_ClearFlag_ALRB(RTC_TypeDef *RTCx)
+{
+  WRITE_REG(RTCx->ISR, (~((RTC_ISR_ALRBF | RTC_ISR_INIT) & 0x0000FFFFU) | (RTCx->ISR & RTC_ISR_INIT)));
+}
+
+/**
+  * @brief  Clear Alarm A flag
+  * @rmtoll ISR          ALRAF         LL_RTC_ClearFlag_ALRA
+  * @param  RTCx RTC Instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_ClearFlag_ALRA(RTC_TypeDef *RTCx)
+{
+  WRITE_REG(RTCx->ISR, (~((RTC_ISR_ALRAF | RTC_ISR_INIT) & 0x0000FFFFU) | (RTCx->ISR & RTC_ISR_INIT)));
+}
+
+/**
+  * @brief  Get Initialization flag
+  * @rmtoll ISR          INITF         LL_RTC_IsActiveFlag_INIT
+  * @param  RTCx RTC Instance
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_RTC_IsActiveFlag_INIT(RTC_TypeDef *RTCx)
+{
+  return ((READ_BIT(RTCx->ISR, RTC_ISR_INITF) == (RTC_ISR_INITF)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Get Registers synchronization flag
+  * @rmtoll ISR          RSF           LL_RTC_IsActiveFlag_RS
+  * @param  RTCx RTC Instance
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_RTC_IsActiveFlag_RS(RTC_TypeDef *RTCx)
+{
+  return ((READ_BIT(RTCx->ISR, RTC_ISR_RSF) == (RTC_ISR_RSF)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Clear Registers synchronization flag
+  * @rmtoll ISR          RSF           LL_RTC_ClearFlag_RS
+  * @param  RTCx RTC Instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_ClearFlag_RS(RTC_TypeDef *RTCx)
+{
+  WRITE_REG(RTCx->ISR, (~((RTC_ISR_RSF | RTC_ISR_INIT) & 0x0000FFFFU) | (RTCx->ISR & RTC_ISR_INIT)));
+}
+
+/**
+  * @brief  Get Initialization status flag
+  * @rmtoll ISR          INITS         LL_RTC_IsActiveFlag_INITS
+  * @param  RTCx RTC Instance
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_RTC_IsActiveFlag_INITS(RTC_TypeDef *RTCx)
+{
+  return ((READ_BIT(RTCx->ISR, RTC_ISR_INITS) == (RTC_ISR_INITS)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Get Shift operation pending flag
+  * @rmtoll ISR          SHPF          LL_RTC_IsActiveFlag_SHP
+  * @param  RTCx RTC Instance
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_RTC_IsActiveFlag_SHP(RTC_TypeDef *RTCx)
+{
+  return ((READ_BIT(RTCx->ISR, RTC_ISR_SHPF) == (RTC_ISR_SHPF)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Get Wakeup timer write flag
+  * @rmtoll ISR          WUTWF         LL_RTC_IsActiveFlag_WUTW
+  * @param  RTCx RTC Instance
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_RTC_IsActiveFlag_WUTW(RTC_TypeDef *RTCx)
+{
+  return ((READ_BIT(RTCx->ISR, RTC_ISR_WUTWF) == (RTC_ISR_WUTWF)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Get Alarm B write flag
+  * @rmtoll ISR          ALRBWF        LL_RTC_IsActiveFlag_ALRBW
+  * @param  RTCx RTC Instance
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_RTC_IsActiveFlag_ALRBW(RTC_TypeDef *RTCx)
+{
+  return ((READ_BIT(RTCx->ISR, RTC_ISR_ALRBWF) == (RTC_ISR_ALRBWF)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Get Alarm A write flag
+  * @rmtoll ISR          ALRAWF        LL_RTC_IsActiveFlag_ALRAW
+  * @param  RTCx RTC Instance
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_RTC_IsActiveFlag_ALRAW(RTC_TypeDef *RTCx)
+{
+  return ((READ_BIT(RTCx->ISR, RTC_ISR_ALRAWF) == (RTC_ISR_ALRAWF)) ? 1UL : 0UL);
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup RTC_LL_EF_IT_Management IT_Management
+  * @{
+  */
+
+/**
+  * @brief  Enable Time-stamp interrupt
+  * @note   Bit is write-protected. @ref LL_RTC_DisableWriteProtection function should be called before.
+  * @rmtoll CR           TSIE          LL_RTC_EnableIT_TS
+  * @param  RTCx RTC Instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_EnableIT_TS(RTC_TypeDef *RTCx)
+{
+  SET_BIT(RTCx->CR, RTC_CR_TSIE);
+}
+
+/**
+  * @brief  Disable Time-stamp interrupt
+  * @note   Bit is write-protected. @ref LL_RTC_DisableWriteProtection function should be called before.
+  * @rmtoll CR           TSIE          LL_RTC_DisableIT_TS
+  * @param  RTCx RTC Instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_DisableIT_TS(RTC_TypeDef *RTCx)
+{
+  CLEAR_BIT(RTCx->CR, RTC_CR_TSIE);
+}
+
+/**
+  * @brief  Enable Wakeup timer interrupt
+  * @note   Bit is write-protected. @ref LL_RTC_DisableWriteProtection function should be called before.
+  * @rmtoll CR           WUTIE         LL_RTC_EnableIT_WUT
+  * @param  RTCx RTC Instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_EnableIT_WUT(RTC_TypeDef *RTCx)
+{
+  SET_BIT(RTCx->CR, RTC_CR_WUTIE);
+}
+
+/**
+  * @brief  Disable Wakeup timer interrupt
+  * @note   Bit is write-protected. @ref LL_RTC_DisableWriteProtection function should be called before.
+  * @rmtoll CR           WUTIE         LL_RTC_DisableIT_WUT
+  * @param  RTCx RTC Instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_DisableIT_WUT(RTC_TypeDef *RTCx)
+{
+  CLEAR_BIT(RTCx->CR, RTC_CR_WUTIE);
+}
+
+/**
+  * @brief  Enable Alarm B interrupt
+  * @note   Bit is write-protected. @ref LL_RTC_DisableWriteProtection function should be called before.
+  * @rmtoll CR           ALRBIE        LL_RTC_EnableIT_ALRB
+  * @param  RTCx RTC Instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_EnableIT_ALRB(RTC_TypeDef *RTCx)
+{
+  SET_BIT(RTCx->CR, RTC_CR_ALRBIE);
+}
+
+/**
+  * @brief  Disable Alarm B interrupt
+  * @note   Bit is write-protected. @ref LL_RTC_DisableWriteProtection function should be called before.
+  * @rmtoll CR           ALRBIE        LL_RTC_DisableIT_ALRB
+  * @param  RTCx RTC Instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_DisableIT_ALRB(RTC_TypeDef *RTCx)
+{
+  CLEAR_BIT(RTCx->CR, RTC_CR_ALRBIE);
+}
+
+/**
+  * @brief  Enable Alarm A interrupt
+  * @note   Bit is write-protected. @ref LL_RTC_DisableWriteProtection function should be called before.
+  * @rmtoll CR           ALRAIE        LL_RTC_EnableIT_ALRA
+  * @param  RTCx RTC Instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_EnableIT_ALRA(RTC_TypeDef *RTCx)
+{
+  SET_BIT(RTCx->CR, RTC_CR_ALRAIE);
+}
+
+/**
+  * @brief  Disable Alarm A interrupt
+  * @note   Bit is write-protected. @ref LL_RTC_DisableWriteProtection function should be called before.
+  * @rmtoll CR           ALRAIE        LL_RTC_DisableIT_ALRA
+  * @param  RTCx RTC Instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_DisableIT_ALRA(RTC_TypeDef *RTCx)
+{
+  CLEAR_BIT(RTCx->CR, RTC_CR_ALRAIE);
+}
+
+/**
+  * @brief  Enable Tamper 3 interrupt
+  * @rmtoll TAMPCR       TAMP3IE       LL_RTC_EnableIT_TAMP3
+  * @param  RTCx RTC Instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_EnableIT_TAMP3(RTC_TypeDef *RTCx)
+{
+  SET_BIT(RTCx->TAMPCR, RTC_TAMPCR_TAMP3IE);
+}
+
+/**
+  * @brief  Disable Tamper 3 interrupt
+  * @rmtoll TAMPCR       TAMP3IE       LL_RTC_DisableIT_TAMP3
+  * @param  RTCx RTC Instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_DisableIT_TAMP3(RTC_TypeDef *RTCx)
+{
+  CLEAR_BIT(RTCx->TAMPCR, RTC_TAMPCR_TAMP3IE);
+}
+
+/**
+  * @brief  Enable Tamper 2 interrupt
+  * @rmtoll TAMPCR       TAMP2IE       LL_RTC_EnableIT_TAMP2
+  * @param  RTCx RTC Instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_EnableIT_TAMP2(RTC_TypeDef *RTCx)
+{
+  SET_BIT(RTCx->TAMPCR, RTC_TAMPCR_TAMP2IE);
+}
+
+/**
+  * @brief  Disable Tamper 2 interrupt
+  * @rmtoll TAMPCR       TAMP2IE       LL_RTC_DisableIT_TAMP2
+  * @param  RTCx RTC Instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_DisableIT_TAMP2(RTC_TypeDef *RTCx)
+{
+  CLEAR_BIT(RTCx->TAMPCR, RTC_TAMPCR_TAMP2IE);
+}
+
+/**
+  * @brief  Enable Tamper 1 interrupt
+  * @rmtoll TAMPCR       TAMP1IE       LL_RTC_EnableIT_TAMP1
+  * @param  RTCx RTC Instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_EnableIT_TAMP1(RTC_TypeDef *RTCx)
+{
+  SET_BIT(RTCx->TAMPCR, RTC_TAMPCR_TAMP1IE);
+}
+
+/**
+  * @brief  Disable Tamper 1 interrupt
+  * @rmtoll TAMPCR       TAMP1IE       LL_RTC_DisableIT_TAMP1
+  * @param  RTCx RTC Instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_DisableIT_TAMP1(RTC_TypeDef *RTCx)
+{
+  CLEAR_BIT(RTCx->TAMPCR, RTC_TAMPCR_TAMP1IE);
+}
+
+/**
+  * @brief  Enable all Tamper Interrupt
+  * @rmtoll TAMPCR       TAMPIE        LL_RTC_EnableIT_TAMP
+  * @param  RTCx RTC Instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_EnableIT_TAMP(RTC_TypeDef *RTCx)
+{
+  SET_BIT(RTCx->TAMPCR, RTC_TAMPCR_TAMPIE);
+}
+
+/**
+  * @brief  Disable all Tamper Interrupt
+  * @rmtoll TAMPCR       TAMPIE        LL_RTC_DisableIT_TAMP
+  * @param  RTCx RTC Instance
+  * @retval None
+  */
+__STATIC_INLINE void LL_RTC_DisableIT_TAMP(RTC_TypeDef *RTCx)
+{
+  CLEAR_BIT(RTCx->TAMPCR, RTC_TAMPCR_TAMPIE);
+}
+
+/**
+  * @brief  Check if  Time-stamp interrupt is enabled or not
+  * @rmtoll CR           TSIE          LL_RTC_IsEnabledIT_TS
+  * @param  RTCx RTC Instance
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_RTC_IsEnabledIT_TS(RTC_TypeDef *RTCx)
+{
+  return ((READ_BIT(RTCx->CR, RTC_CR_TSIE) == (RTC_CR_TSIE)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Check if  Wakeup timer interrupt is enabled or not
+  * @rmtoll CR           WUTIE         LL_RTC_IsEnabledIT_WUT
+  * @param  RTCx RTC Instance
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_RTC_IsEnabledIT_WUT(RTC_TypeDef *RTCx)
+{
+  return ((READ_BIT(RTCx->CR, RTC_CR_WUTIE) == (RTC_CR_WUTIE)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Check if  Alarm B interrupt is enabled or not
+  * @rmtoll CR           ALRBIE        LL_RTC_IsEnabledIT_ALRB
+  * @param  RTCx RTC Instance
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_RTC_IsEnabledIT_ALRB(RTC_TypeDef *RTCx)
+{
+  return ((READ_BIT(RTCx->CR, RTC_CR_ALRBIE) == (RTC_CR_ALRBIE)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Check if  Alarm A interrupt is enabled or not
+  * @rmtoll CR           ALRAIE        LL_RTC_IsEnabledIT_ALRA
+  * @param  RTCx RTC Instance
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_RTC_IsEnabledIT_ALRA(RTC_TypeDef *RTCx)
+{
+  return ((READ_BIT(RTCx->CR, RTC_CR_ALRAIE) == (RTC_CR_ALRAIE)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Check if  Tamper 3 interrupt is enabled or not
+  * @rmtoll TAMPCR       TAMP3IE       LL_RTC_IsEnabledIT_TAMP3
+  * @param  RTCx RTC Instance
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_RTC_IsEnabledIT_TAMP3(RTC_TypeDef *RTCx)
+{
+  return ((READ_BIT(RTCx->TAMPCR,
+                    RTC_TAMPCR_TAMP3IE) == (RTC_TAMPCR_TAMP3IE)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Check if  Tamper 2 interrupt is enabled or not
+  * @rmtoll TAMPCR       TAMP2IE       LL_RTC_IsEnabledIT_TAMP2
+  * @param  RTCx RTC Instance
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_RTC_IsEnabledIT_TAMP2(RTC_TypeDef *RTCx)
+{
+  return ((READ_BIT(RTCx->TAMPCR,
+                    RTC_TAMPCR_TAMP2IE) == (RTC_TAMPCR_TAMP2IE)) ? 1UL : 0UL);
+
+}
+
+/**
+  * @brief  Check if  Tamper 1 interrupt is enabled or not
+  * @rmtoll TAMPCR       TAMP1IE       LL_RTC_IsEnabledIT_TAMP1
+  * @param  RTCx RTC Instance
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_RTC_IsEnabledIT_TAMP1(RTC_TypeDef *RTCx)
+{
+  return ((READ_BIT(RTCx->TAMPCR,
+                    RTC_TAMPCR_TAMP1IE) == (RTC_TAMPCR_TAMP1IE)) ? 1UL : 0UL);
+}
+
+/**
+  * @brief  Check if all the TAMPER interrupts are enabled or not
+  * @rmtoll TAMPCR       TAMPIE        LL_RTC_IsEnabledIT_TAMP
+  * @param  RTCx RTC Instance
+  * @retval State of bit (1 or 0).
+  */
+__STATIC_INLINE uint32_t LL_RTC_IsEnabledIT_TAMP(RTC_TypeDef *RTCx)
+{
+  return ((READ_BIT(RTCx->TAMPCR,
+                    RTC_TAMPCR_TAMPIE) == (RTC_TAMPCR_TAMPIE)) ? 1UL : 0UL);
+}
+
+/**
+  * @}
+  */
+
+#if defined(USE_FULL_LL_DRIVER)
+/** @defgroup RTC_LL_EF_Init Initialization and de-initialization functions
+  * @{
+  */
+
+ErrorStatus LL_RTC_DeInit(RTC_TypeDef *RTCx);
+ErrorStatus LL_RTC_Init(RTC_TypeDef *RTCx, LL_RTC_InitTypeDef *RTC_InitStruct);
+void        LL_RTC_StructInit(LL_RTC_InitTypeDef *RTC_InitStruct);
+ErrorStatus LL_RTC_TIME_Init(RTC_TypeDef *RTCx, uint32_t RTC_Format, LL_RTC_TimeTypeDef *RTC_TimeStruct);
+void        LL_RTC_TIME_StructInit(LL_RTC_TimeTypeDef *RTC_TimeStruct);
+ErrorStatus LL_RTC_DATE_Init(RTC_TypeDef *RTCx, uint32_t RTC_Format, LL_RTC_DateTypeDef *RTC_DateStruct);
+void        LL_RTC_DATE_StructInit(LL_RTC_DateTypeDef *RTC_DateStruct);
+ErrorStatus LL_RTC_ALMA_Init(RTC_TypeDef *RTCx, uint32_t RTC_Format, LL_RTC_AlarmTypeDef *RTC_AlarmStruct);
+ErrorStatus LL_RTC_ALMB_Init(RTC_TypeDef *RTCx, uint32_t RTC_Format, LL_RTC_AlarmTypeDef *RTC_AlarmStruct);
+void        LL_RTC_ALMA_StructInit(LL_RTC_AlarmTypeDef *RTC_AlarmStruct);
+void        LL_RTC_ALMB_StructInit(LL_RTC_AlarmTypeDef *RTC_AlarmStruct);
+ErrorStatus LL_RTC_EnterInitMode(RTC_TypeDef *RTCx);
+ErrorStatus LL_RTC_ExitInitMode(RTC_TypeDef *RTCx);
+ErrorStatus LL_RTC_WaitForSynchro(RTC_TypeDef *RTCx);
+
+/**
+  * @}
+  */
+#endif /* USE_FULL_LL_DRIVER */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#endif /* defined(RTC) */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* STM32F7xx_LL_RTC_H */

--- a/lib/STM32F7xx_HAL_Driver/Inc/stm32f7xx_ll_utils.h
+++ b/lib/STM32F7xx_HAL_Driver/Inc/stm32f7xx_ll_utils.h
@@ -250,7 +250,7 @@ __STATIC_INLINE uint32_t LL_GetPackageType(void)
   * @param  HCLKFrequency HCLK frequency in Hz (can be calculated thanks to RCC helper macro)
   * @note   When a RTOS is used, it is recommended to avoid changing the SysTick 
   *         configuration by calling this function, for a delay use rather osDelay RTOS service.
-  * @param  Ticks Number of ticks
+  * @param  Ticks Frequency of Ticks (Hz)
   * @retval None
   */
 __STATIC_INLINE void LL_InitTick(uint32_t HCLKFrequency, uint32_t Ticks)

--- a/lib/STM32F7xx_HAL_Driver/Src/stm32f7xx_hal.c
+++ b/lib/STM32F7xx_HAL_Driver/Src/stm32f7xx_hal.c
@@ -50,11 +50,11 @@
   * @{
   */
 /**
- * @brief STM32F7xx HAL Driver version number V1.3.0
+ * @brief STM32F7xx HAL Driver version number V1.3.1
    */
 #define __STM32F7xx_HAL_VERSION_MAIN   (0x01) /*!< [31:24] main version */
 #define __STM32F7xx_HAL_VERSION_SUB1   (0x03) /*!< [23:16] sub1 version */
-#define __STM32F7xx_HAL_VERSION_SUB2   (0x00) /*!< [15:8]  sub2 version */
+#define __STM32F7xx_HAL_VERSION_SUB2   (0x01) /*!< [15:8]  sub2 version */
 #define __STM32F7xx_HAL_VERSION_RC     (0x00) /*!< [7:0]  release candidate */ 
 #define __STM32F7xx_HAL_VERSION         ((__STM32F7xx_HAL_VERSION_MAIN << 24)\
                                         |(__STM32F7xx_HAL_VERSION_SUB1 << 16)\
@@ -346,7 +346,8 @@ HAL_StatusTypeDef HAL_SetTickFreq(HAL_TickFreqTypeDef Freq)
 
 /**
   * @brief Return tick frequency.
-  * @retval tick period in Hz
+  * @retval Tick frequency.
+  *         Value of @ref HAL_TickFreqTypeDef.
   */
 HAL_TickFreqTypeDef HAL_GetTickFreq(void)
 {

--- a/lib/STM32F7xx_HAL_Driver/Src/stm32f7xx_hal_adc_ex.c
+++ b/lib/STM32F7xx_HAL_Driver/Src/stm32f7xx_hal_adc_ex.c
@@ -754,6 +754,9 @@ HAL_StatusTypeDef HAL_ADCEx_MultiModeStop_DMA(ADC_HandleTypeDef* hadc)
   */
 uint32_t HAL_ADCEx_MultiModeGetValue(ADC_HandleTypeDef* hadc)
 {
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hadc);
+
   /* Return the multi mode conversion value */
   return ADC->CDR;
 }

--- a/lib/STM32F7xx_HAL_Driver/Src/stm32f7xx_hal_can.c
+++ b/lib/STM32F7xx_HAL_Driver/Src/stm32f7xx_hal_can.c
@@ -33,7 +33,7 @@
          (++) Enable the CAN interface clock using __HAL_RCC_CANx_CLK_ENABLE()
          (++) Configure CAN pins
              (+++) Enable the clock for the CAN GPIOs
-             (+++) Configure CAN pins as alternate function open-drain
+             (+++) Configure CAN pins as alternate function
          (++) In case of using interrupts (e.g. HAL_CAN_ActivateNotification())
              (+++) Configure the CAN interrupt priority using
                    HAL_NVIC_SetPriority()
@@ -235,6 +235,7 @@
   * @{
   */
 #define CAN_TIMEOUT_VALUE 10U
+#define CAN_WAKEUP_TIMEOUT_COUNTER 1000000U
 /**
   * @}
   */
@@ -248,8 +249,8 @@
   */
 
 /** @defgroup CAN_Exported_Functions_Group1 Initialization and de-initialization functions
- *  @brief    Initialization and Configuration functions
- *
+  * @brief    Initialization and Configuration functions
+  *
 @verbatim
   ==============================================================================
               ##### Initialization and de-initialization functions #####
@@ -328,7 +329,7 @@ HAL_StatusTypeDef HAL_CAN_Init(CAN_HandleTypeDef *hcan)
     /* Init the low level hardware: CLOCK, NVIC */
     HAL_CAN_MspInit(hcan);
   }
-#endif /* (USE_HAL_CAN_REGISTER_CALLBACKS) */
+#endif /* USE_HAL_CAN_REGISTER_CALLBACKS */
 
   /* Request initialisation */
   SET_BIT(hcan->Instance->MCR, CAN_MCR_INRQ);
@@ -482,7 +483,7 @@ HAL_StatusTypeDef HAL_CAN_DeInit(CAN_HandleTypeDef *hcan)
 #else
   /* DeInit the low level hardware: CLOCK, NVIC */
   HAL_CAN_MspDeInit(hcan);
-#endif /* (USE_HAL_CAN_REGISTER_CALLBACKS) */
+#endif /* USE_HAL_CAN_REGISTER_CALLBACKS */
 
   /* Reset the CAN peripheral */
   SET_BIT(hcan->Instance->MCR, CAN_MCR_RESET);
@@ -814,8 +815,8 @@ HAL_StatusTypeDef HAL_CAN_UnRegisterCallback(CAN_HandleTypeDef *hcan, HAL_CAN_Ca
   */
 
 /** @defgroup CAN_Exported_Functions_Group2 Configuration functions
- *  @brief    Configuration functions.
- *
+  * @brief    Configuration functions.
+  *
 @verbatim
   ==============================================================================
               ##### Configuration functions #####
@@ -887,7 +888,7 @@ HAL_StatusTypeDef HAL_CAN_ConfigFilter(CAN_HandleTypeDef *hcan, const CAN_Filter
 
     /* Check the parameters */
     assert_param(IS_CAN_FILTER_BANK_SINGLE(sFilterConfig->FilterBank));
-#endif
+#endif /* CAN3 */
 
     /* Initialisation mode for the filter */
     SET_BIT(can_ip->FMR, CAN_FMR_FINIT);
@@ -906,7 +907,7 @@ HAL_StatusTypeDef HAL_CAN_ConfigFilter(CAN_HandleTypeDef *hcan, const CAN_Filter
     CLEAR_BIT(can_ip->FMR, CAN_FMR_CAN2SB);
     SET_BIT(can_ip->FMR, sFilterConfig->SlaveStartFilterBank << CAN_FMR_CAN2SB_Pos);
 
-#endif
+#endif /* CAN3 */
     /* Convert filter number into bit position */
     filternbrbitpos = (uint32_t)1 << (sFilterConfig->FilterBank & 0x1FU);
 
@@ -998,8 +999,8 @@ HAL_StatusTypeDef HAL_CAN_ConfigFilter(CAN_HandleTypeDef *hcan, const CAN_Filter
   */
 
 /** @defgroup CAN_Exported_Functions_Group3 Control functions
- *  @brief    Control functions
- *
+  * @brief    Control functions
+  *
 @verbatim
   ==============================================================================
                       ##### Control functions #####
@@ -1171,7 +1172,6 @@ HAL_StatusTypeDef HAL_CAN_RequestSleep(CAN_HandleTypeDef *hcan)
 HAL_StatusTypeDef HAL_CAN_WakeUp(CAN_HandleTypeDef *hcan)
 {
   __IO uint32_t count = 0;
-  uint32_t timeout = 1000000U;
   HAL_CAN_StateTypeDef state = hcan->State;
 
   if ((state == HAL_CAN_STATE_READY) ||
@@ -1187,15 +1187,14 @@ HAL_StatusTypeDef HAL_CAN_WakeUp(CAN_HandleTypeDef *hcan)
       count++;
 
       /* Check if timeout is reached */
-      if (count > timeout)
+      if (count > CAN_WAKEUP_TIMEOUT_COUNTER)
       {
         /* Update error code */
         hcan->ErrorCode |= HAL_CAN_ERROR_TIMEOUT;
 
         return HAL_ERROR;
       }
-    }
-    while ((hcan->Instance->MSR & CAN_MSR_SLAK) != 0U);
+    } while ((hcan->Instance->MSR & CAN_MSR_SLAK) != 0U);
 
     /* Return function status */
     return HAL_OK;
@@ -1552,7 +1551,15 @@ HAL_StatusTypeDef HAL_CAN_GetRxMessage(CAN_HandleTypeDef *hcan, uint32_t RxFifo,
                         hcan->Instance->sFIFOMailBox[RxFifo].RIR) >> CAN_RI0R_EXID_Pos;
     }
     pHeader->RTR = (CAN_RI0R_RTR & hcan->Instance->sFIFOMailBox[RxFifo].RIR);
-    pHeader->DLC = (CAN_RDT0R_DLC & hcan->Instance->sFIFOMailBox[RxFifo].RDTR) >> CAN_RDT0R_DLC_Pos;
+    if (((CAN_RDT0R_DLC & hcan->Instance->sFIFOMailBox[RxFifo].RDTR) >> CAN_RDT0R_DLC_Pos) >= 8U)
+    {
+      /* Truncate DLC to 8 if received field is over range */
+      pHeader->DLC = 8U;
+    }
+    else
+    {
+      pHeader->DLC = (CAN_RDT0R_DLC & hcan->Instance->sFIFOMailBox[RxFifo].RDTR) >> CAN_RDT0R_DLC_Pos;
+    }
     pHeader->FilterMatchIndex = (CAN_RDT0R_FMI & hcan->Instance->sFIFOMailBox[RxFifo].RDTR) >> CAN_RDT0R_FMI_Pos;
     pHeader->Timestamp = (CAN_RDT0R_TIME & hcan->Instance->sFIFOMailBox[RxFifo].RDTR) >> CAN_RDT0R_TIME_Pos;
 
@@ -1628,8 +1635,8 @@ uint32_t HAL_CAN_GetRxFifoFillLevel(const CAN_HandleTypeDef *hcan, uint32_t RxFi
   */
 
 /** @defgroup CAN_Exported_Functions_Group4 Interrupts management
- *  @brief    Interrupts management
- *
+  * @brief    Interrupts management
+  *
 @verbatim
   ==============================================================================
                        ##### Interrupts management #####
@@ -2094,8 +2101,8 @@ void HAL_CAN_IRQHandler(CAN_HandleTypeDef *hcan)
   */
 
 /** @defgroup CAN_Exported_Functions_Group5 Callback functions
- *  @brief   CAN Callback functions
- *
+  * @brief   CAN Callback functions
+  *
 @verbatim
   ==============================================================================
                           ##### Callback functions #####
@@ -2344,8 +2351,8 @@ __weak void HAL_CAN_ErrorCallback(CAN_HandleTypeDef *hcan)
   */
 
 /** @defgroup CAN_Exported_Functions_Group6 Peripheral State and Error functions
- *  @brief   CAN Peripheral State functions
- *
+  * @brief   CAN Peripheral State functions
+  *
 @verbatim
   ==============================================================================
             ##### Peripheral State and Error functions #####

--- a/lib/STM32F7xx_HAL_Driver/Src/stm32f7xx_hal_cortex.c
+++ b/lib/STM32F7xx_HAL_Driver/Src/stm32f7xx_hal_cortex.c
@@ -291,8 +291,40 @@ void HAL_MPU_Enable(uint32_t MPU_Control)
 }
 
 /**
+  * @brief  Enables the MPU Region.
+  * @retval None
+  */
+void HAL_MPU_EnableRegion(uint32_t RegionNumber)
+{
+  /* Check the parameters */
+  assert_param(IS_MPU_REGION_NUMBER(RegionNumber));
+
+  /* Set the Region number */
+  MPU->RNR = RegionNumber;
+
+  /* Enable the Region */
+  SET_BIT(MPU->RASR, MPU_RASR_ENABLE_Msk);
+}
+
+/**
+  * @brief  Disables the MPU Region.
+  * @retval None
+  */
+void HAL_MPU_DisableRegion(uint32_t RegionNumber)
+{
+  /* Check the parameters */
+  assert_param(IS_MPU_REGION_NUMBER(RegionNumber));
+
+  /* Set the Region number */
+  MPU->RNR = RegionNumber;
+
+  /* Disable the Region */
+  CLEAR_BIT(MPU->RASR, MPU_RASR_ENABLE_Msk);
+}
+
+/**
   * @brief  Initializes and configures the Region and the memory to be protected.
-  * @param  MPU_Init Pointer to a MPU_Region_InitTypeDef structure that contains
+  * @param MPU_Init Pointer to a MPU_Region_InitTypeDef structure that contains
   *                the initialization and configuration information.
   * @retval None
   */
@@ -301,38 +333,32 @@ void HAL_MPU_ConfigRegion(MPU_Region_InitTypeDef *MPU_Init)
   /* Check the parameters */
   assert_param(IS_MPU_REGION_NUMBER(MPU_Init->Number));
   assert_param(IS_MPU_REGION_ENABLE(MPU_Init->Enable));
+  assert_param(IS_MPU_INSTRUCTION_ACCESS(MPU_Init->DisableExec));
+  assert_param(IS_MPU_REGION_PERMISSION_ATTRIBUTE(MPU_Init->AccessPermission));
+  assert_param(IS_MPU_TEX_LEVEL(MPU_Init->TypeExtField));
+  assert_param(IS_MPU_ACCESS_SHAREABLE(MPU_Init->IsShareable));
+  assert_param(IS_MPU_ACCESS_CACHEABLE(MPU_Init->IsCacheable));
+  assert_param(IS_MPU_ACCESS_BUFFERABLE(MPU_Init->IsBufferable));
+  assert_param(IS_MPU_SUB_REGION_DISABLE(MPU_Init->SubRegionDisable));
+  assert_param(IS_MPU_REGION_SIZE(MPU_Init->Size));
 
   /* Set the Region number */
   MPU->RNR = MPU_Init->Number;
 
-  if ((MPU_Init->Enable) != RESET)
-  {
-    /* Check the parameters */
-    assert_param(IS_MPU_INSTRUCTION_ACCESS(MPU_Init->DisableExec));
-    assert_param(IS_MPU_REGION_PERMISSION_ATTRIBUTE(MPU_Init->AccessPermission));
-    assert_param(IS_MPU_TEX_LEVEL(MPU_Init->TypeExtField));
-    assert_param(IS_MPU_ACCESS_SHAREABLE(MPU_Init->IsShareable));
-    assert_param(IS_MPU_ACCESS_CACHEABLE(MPU_Init->IsCacheable));
-    assert_param(IS_MPU_ACCESS_BUFFERABLE(MPU_Init->IsBufferable));
-    assert_param(IS_MPU_SUB_REGION_DISABLE(MPU_Init->SubRegionDisable));
-    assert_param(IS_MPU_REGION_SIZE(MPU_Init->Size));
-    
-    MPU->RBAR = MPU_Init->BaseAddress;
-    MPU->RASR = ((uint32_t)MPU_Init->DisableExec             << MPU_RASR_XN_Pos)   |
-                ((uint32_t)MPU_Init->AccessPermission        << MPU_RASR_AP_Pos)   |
-                ((uint32_t)MPU_Init->TypeExtField            << MPU_RASR_TEX_Pos)  |
-                ((uint32_t)MPU_Init->IsShareable             << MPU_RASR_S_Pos)    |
-                ((uint32_t)MPU_Init->IsCacheable             << MPU_RASR_C_Pos)    |
-                ((uint32_t)MPU_Init->IsBufferable            << MPU_RASR_B_Pos)    |
-                ((uint32_t)MPU_Init->SubRegionDisable        << MPU_RASR_SRD_Pos)  |
-                ((uint32_t)MPU_Init->Size                    << MPU_RASR_SIZE_Pos) |
-                ((uint32_t)MPU_Init->Enable                  << MPU_RASR_ENABLE_Pos);
-  }
-  else
-  {
-    MPU->RBAR = 0x00;
-    MPU->RASR = 0x00;
-  }
+  /* Disable the Region */
+  CLEAR_BIT(MPU->RASR, MPU_RASR_ENABLE_Msk);
+
+  /* Apply configuration */
+  MPU->RBAR = MPU_Init->BaseAddress;
+  MPU->RASR = ((uint32_t)MPU_Init->DisableExec             << MPU_RASR_XN_Pos)   |
+              ((uint32_t)MPU_Init->AccessPermission        << MPU_RASR_AP_Pos)   |
+              ((uint32_t)MPU_Init->TypeExtField            << MPU_RASR_TEX_Pos)  |
+              ((uint32_t)MPU_Init->IsShareable             << MPU_RASR_S_Pos)    |
+              ((uint32_t)MPU_Init->IsCacheable             << MPU_RASR_C_Pos)    |
+              ((uint32_t)MPU_Init->IsBufferable            << MPU_RASR_B_Pos)    |
+              ((uint32_t)MPU_Init->SubRegionDisable        << MPU_RASR_SRD_Pos)  |
+              ((uint32_t)MPU_Init->Size                    << MPU_RASR_SIZE_Pos) |
+              ((uint32_t)MPU_Init->Enable                  << MPU_RASR_ENABLE_Pos);
 }
 #endif /* __MPU_PRESENT */
 

--- a/lib/STM32F7xx_HAL_Driver/Src/stm32f7xx_hal_dma.c
+++ b/lib/STM32F7xx_HAL_Driver/Src/stm32f7xx_hal_dma.c
@@ -276,7 +276,7 @@ HAL_StatusTypeDef HAL_DMA_Init(DMA_HandleTypeDef *hdma)
         hdma->ErrorCode = HAL_DMA_ERROR_PARAM;
         
         /* Change the DMA state */
-        hdma->State = HAL_DMA_STATE_READY;
+        hdma->State = HAL_DMA_STATE_RESET;
         
         return HAL_ERROR; 
       }

--- a/lib/STM32F7xx_HAL_Driver/Src/stm32f7xx_hal_exti.c
+++ b/lib/STM32F7xx_HAL_Driver/Src/stm32f7xx_hal_exti.c
@@ -64,7 +64,7 @@
         (++) Provide exiting handle as parameter.
         (++) Provide pointer on EXTI_ConfigTypeDef structure as second parameter.
 
-    (#) Clear Exti configuration of a dedicated line using HAL_EXTI_GetConfigLine().
+    (#) Clear Exti configuration of a dedicated line using HAL_EXTI_ClearConfigLine().
         (++) Provide exiting handle as parameter.
 
     (#) Register callback to treat Exti interrupts using HAL_EXTI_RegisterCallback().
@@ -75,7 +75,7 @@
 
     (#) Get interrupt pending bit using HAL_EXTI_GetPending().
 
-    (#) Clear interrupt pending bit using HAL_EXTI_GetPending().
+    (#) Clear interrupt pending bit using HAL_EXTI_ClearPending().
 
     (#) Generate software interrupt using HAL_EXTI_GenerateSWI().
 
@@ -301,7 +301,7 @@ HAL_StatusTypeDef HAL_EXTI_GetConfigLine(EXTI_HandleTypeDef *hexti, EXTI_ConfigT
       assert_param(IS_EXTI_GPIO_PIN(linepos));
 
       regval = SYSCFG->EXTICR[linepos >> 2u];
-      pExtiConfig->GPIOSel = ((regval << (SYSCFG_EXTICR1_EXTI1_Pos * (3uL - (linepos & 0x03u)))) >> 24);
+      pExtiConfig->GPIOSel = (regval >> (SYSCFG_EXTICR1_EXTI1_Pos * (linepos & 0x03u))) & SYSCFG_EXTICR1_EXTI0;
     }
   }
 

--- a/lib/STM32F7xx_HAL_Driver/Src/stm32f7xx_hal_gpio.c
+++ b/lib/STM32F7xx_HAL_Driver/Src/stm32f7xx_hal_gpio.c
@@ -3,7 +3,7 @@
   * @file    stm32f7xx_hal_gpio.c
   * @author  MCD Application Team
   * @brief   GPIO HAL module driver.
-  *          This file provides firmware functions to manage the following 
+  *          This file provides firmware functions to manage the following
   *          functionalities of the General Purpose Input/Output (GPIO) peripheral:
   *           + Initialization and de-initialization functions
   *           + IO operation functions
@@ -23,86 +23,86 @@
   ==============================================================================
                     ##### GPIO Peripheral features #####
   ==============================================================================
-  [..] 
+  [..]
   Subject to the specific hardware characteristics of each I/O port listed in the datasheet, each
   port bit of the General Purpose IO (GPIO) Ports, can be individually configured by software
   in several modes:
-  (+) Input mode 
+  (+) Input mode
   (+) Analog mode
   (+) Output mode
   (+) Alternate function mode
   (+) External interrupt/event lines
 
-  [..]  
-  During and just after reset, the alternate functions and external interrupt  
+  [..]
+  During and just after reset, the alternate functions and external interrupt
   lines are not active and the I/O ports are configured in input floating mode.
-  
-  [..]   
-  All GPIO pins have weak internal pull-up and pull-down resistors, which can be 
+
+  [..]
+  All GPIO pins have weak internal pull-up and pull-down resistors, which can be
   activated or not.
 
   [..]
   In Output or Alternate mode, each IO can be configured on open-drain or push-pull
   type and the IO speed can be selected depending on the VDD value.
 
-  [..]  
-  All ports have external interrupt/event capability. To use external interrupt 
-  lines, the port must be configured in input mode. All available GPIO pins are 
-  connected to the 16 external interrupt/event lines from EXTI0 to EXTI15.
-  
   [..]
-  The external interrupt/event controller consists of up to 23 edge detectors 
-  (16 lines are connected to GPIO) for generating event/interrupt requests (each 
-  input line can be independently configured to select the type (interrupt or event) 
-  and the corresponding trigger event (rising or falling or both). Each line can 
-  also be masked independently. 
+  All ports have external interrupt/event capability. To use external interrupt
+  lines, the port must be configured in input mode. All available GPIO pins are
+  connected to the 16 external interrupt/event lines from EXTI0 to EXTI15.
+
+  [..]
+  The external interrupt/event controller consists of up to 23 edge detectors
+  (16 lines are connected to GPIO) for generating event/interrupt requests (each
+  input line can be independently configured to select the type (interrupt or event)
+  and the corresponding trigger event (rising or falling or both). Each line can
+  also be masked independently.
 
                      ##### How to use this driver #####
-  ==============================================================================  
+  ==============================================================================
   [..]
-    (#) Enable the GPIO AHB clock using the following function: __HAL_RCC_GPIOx_CLK_ENABLE(). 
+    (#) Enable the GPIO AHB clock using the following function: __HAL_RCC_GPIOx_CLK_ENABLE().
 
     (#) Configure the GPIO pin(s) using HAL_GPIO_Init().
         (++) Configure the IO mode using "Mode" member from GPIO_InitTypeDef structure
-        (++) Activate Pull-up, Pull-down resistor using "Pull" member from GPIO_InitTypeDef 
+        (++) Activate Pull-up, Pull-down resistor using "Pull" member from GPIO_InitTypeDef
              structure.
-        (++) In case of Output or alternate function mode selection: the speed is 
+        (++) In case of Output or alternate function mode selection: the speed is
              configured through "Speed" member from GPIO_InitTypeDef structure.
         (++) In alternate mode is selection, the alternate function connected to the IO
              is configured through "Alternate" member from GPIO_InitTypeDef structure.
-        (++) Analog mode is required when a pin is to be used as ADC channel 
+        (++) Analog mode is required when a pin is to be used as ADC channel
              or DAC output.
-        (++) In case of external interrupt/event selection the "Mode" member from 
-             GPIO_InitTypeDef structure select the type (interrupt or event) and 
+        (++) In case of external interrupt/event selection the "Mode" member from
+             GPIO_InitTypeDef structure select the type (interrupt or event) and
              the corresponding trigger event (rising or falling or both).
 
-    (#) In case of external interrupt/event mode selection, configure NVIC IRQ priority 
+    (#) In case of external interrupt/event mode selection, configure NVIC IRQ priority
         mapped to the EXTI line using HAL_NVIC_SetPriority() and enable it using
         HAL_NVIC_EnableIRQ().
-         
+
     (#) To get the level of a pin configured in input mode use HAL_GPIO_ReadPin().
-            
-    (#) To set/reset the level of a pin configured in output mode use 
+
+    (#) To set/reset the level of a pin configured in output mode use
         HAL_GPIO_WritePin()/HAL_GPIO_TogglePin().
-    
+
     (#) To lock pin configuration until next reset use HAL_GPIO_LockPin().
 
-                 
-    (#) During and just after reset, the alternate functions are not 
+
+    (#) During and just after reset, the alternate functions are not
         active and the GPIO pins are configured in input floating mode (except JTAG
         pins).
-  
-    (#) The LSE oscillator pins OSC32_IN and OSC32_OUT can be used as general purpose 
-        (PC14 and PC15, respectively) when the LSE oscillator is off. The LSE has 
+
+    (#) The LSE oscillator pins OSC32_IN and OSC32_OUT can be used as general purpose
+        (PC14 and PC15, respectively) when the LSE oscillator is off. The LSE has
         priority over the GPIO function.
-  
-    (#) The HSE oscillator pins OSC_IN/OSC_OUT can be used as 
-        general purpose PH0 and PH1, respectively, when the HSE oscillator is off. 
+
+    (#) The HSE oscillator pins OSC_IN/OSC_OUT can be used as
+        general purpose PH0 and PH1, respectively, when the HSE oscillator is off.
         The HSE has priority over the GPIO function.
-  
+
   @endverbatim
   ******************************************************************************
-  */ 
+  */
 
 /* Includes ------------------------------------------------------------------*/
 #include "stm32f7xx_hal.h"
@@ -147,7 +147,7 @@
   [..]
     This section provides functions allowing to initialize and de-initialize the GPIOs
     to be ready for use.
- 
+
 @endverbatim
   * @{
   */
@@ -172,23 +172,23 @@ void HAL_GPIO_Init(GPIO_TypeDef  *GPIOx, GPIO_InitTypeDef *GPIO_Init)
   assert_param(IS_GPIO_MODE(GPIO_Init->Mode));
 
   /* Configure the port pins */
-  for(position = 0; position < GPIO_NUMBER; position++)
+  for (position = 0; position < GPIO_NUMBER; position++)
   {
     /* Get the IO position */
     ioposition = ((uint32_t)0x01) << position;
     /* Get the current IO position */
     iocurrent = (uint32_t)(GPIO_Init->Pin) & ioposition;
 
-    if(iocurrent == ioposition)
+    if (iocurrent == ioposition)
     {
       /*--------------------- GPIO Mode Configuration ------------------------*/
       /* In case of Output or Alternate function mode selection */
-      if(((GPIO_Init->Mode & GPIO_MODE) == MODE_OUTPUT) || ((GPIO_Init->Mode & GPIO_MODE) == MODE_AF))
+      if (((GPIO_Init->Mode & GPIO_MODE) == MODE_OUTPUT) || ((GPIO_Init->Mode & GPIO_MODE) == MODE_AF))
       {
         /* Check the Speed parameter */
         assert_param(IS_GPIO_SPEED(GPIO_Init->Speed));
         /* Configure the IO Speed */
-        temp = GPIOx->OSPEEDR; 
+        temp = GPIOx->OSPEEDR;
         temp &= ~(GPIO_OSPEEDER_OSPEEDR0 << (position * 2));
         temp |= (GPIO_Init->Speed << (position * 2));
         GPIOx->OSPEEDR = temp;
@@ -199,8 +199,8 @@ void HAL_GPIO_Init(GPIO_TypeDef  *GPIOx, GPIO_InitTypeDef *GPIO_Init)
         temp |= (((GPIO_Init->Mode & OUTPUT_TYPE) >> OUTPUT_TYPE_Pos) << position);
         GPIOx->OTYPER = temp;
       }
-      
-      if((GPIO_Init->Mode & GPIO_MODE) != MODE_ANALOG)
+
+      if ((GPIO_Init->Mode & GPIO_MODE) != MODE_ANALOG)
       {
         /* Check the Pull parameter */
         assert_param(IS_GPIO_PULL(GPIO_Init->Pull));
@@ -213,7 +213,7 @@ void HAL_GPIO_Init(GPIO_TypeDef  *GPIOx, GPIO_InitTypeDef *GPIO_Init)
       }
 
       /* In case of Alternate function mode selection */
-      if((GPIO_Init->Mode & GPIO_MODE) == MODE_AF)
+      if ((GPIO_Init->Mode & GPIO_MODE) == MODE_AF)
       {
         /* Check the Alternate function parameter */
         assert_param(IS_GPIO_AF(GPIO_Init->Alternate));
@@ -224,7 +224,7 @@ void HAL_GPIO_Init(GPIO_TypeDef  *GPIOx, GPIO_InitTypeDef *GPIO_Init)
         temp |= ((uint32_t)(GPIO_Init->Alternate) << (((uint32_t)position & (uint32_t)0x07) * 4));
         GPIOx->AFR[position >> 3] = temp;
       }
-      
+
       /* Configure IO Direction mode (Input, Output, Alternate or Analog) */
       temp = GPIOx->MODER;
       temp &= ~(GPIO_MODER_MODER0 << (position * 2));
@@ -233,7 +233,7 @@ void HAL_GPIO_Init(GPIO_TypeDef  *GPIOx, GPIO_InitTypeDef *GPIO_Init)
 
       /*--------------------- EXTI Mode Configuration ------------------------*/
       /* Configure the External Interrupt or event for the current IO */
-      if((GPIO_Init->Mode & EXTI_MODE) != 0x00u)
+      if ((GPIO_Init->Mode & EXTI_MODE) != 0x00u)
       {
         /* Enable SYSCFG Clock */
         __HAL_RCC_SYSCFG_CLK_ENABLE();
@@ -246,7 +246,7 @@ void HAL_GPIO_Init(GPIO_TypeDef  *GPIOx, GPIO_InitTypeDef *GPIO_Init)
         /* Clear Rising Falling edge configuration */
         temp = EXTI->RTSR;
         temp &= ~((uint32_t)iocurrent);
-        if((GPIO_Init->Mode & TRIGGER_RISING) != 0x00u)
+        if ((GPIO_Init->Mode & TRIGGER_RISING) != 0x00u)
         {
           temp |= iocurrent;
         }
@@ -254,7 +254,7 @@ void HAL_GPIO_Init(GPIO_TypeDef  *GPIOx, GPIO_InitTypeDef *GPIO_Init)
 
         temp = EXTI->FTSR;
         temp &= ~((uint32_t)iocurrent);
-        if((GPIO_Init->Mode & TRIGGER_FALLING) != 0x00u)
+        if ((GPIO_Init->Mode & TRIGGER_FALLING) != 0x00u)
         {
           temp |= iocurrent;
         }
@@ -262,7 +262,7 @@ void HAL_GPIO_Init(GPIO_TypeDef  *GPIOx, GPIO_InitTypeDef *GPIO_Init)
 
         temp = EXTI->EMR;
         temp &= ~((uint32_t)iocurrent);
-        if((GPIO_Init->Mode & EXTI_EVT) != 0x00u)
+        if ((GPIO_Init->Mode & EXTI_EVT) != 0x00u)
         {
           temp |= iocurrent;
         }
@@ -271,7 +271,7 @@ void HAL_GPIO_Init(GPIO_TypeDef  *GPIOx, GPIO_InitTypeDef *GPIO_Init)
         /* Clear EXTI line configuration */
         temp = EXTI->IMR;
         temp &= ~((uint32_t)iocurrent);
-        if((GPIO_Init->Mode & EXTI_IT) != 0x00u)
+        if ((GPIO_Init->Mode & EXTI_IT) != 0x00u)
         {
           temp |= iocurrent;
         }
@@ -299,19 +299,19 @@ void HAL_GPIO_DeInit(GPIO_TypeDef  *GPIOx, uint32_t GPIO_Pin)
   assert_param(IS_GPIO_ALL_INSTANCE(GPIOx));
 
   /* Configure the port pins */
-  for(position = 0; position < GPIO_NUMBER; position++)
+  for (position = 0; position < GPIO_NUMBER; position++)
   {
     /* Get the IO position */
     ioposition = ((uint32_t)0x01) << position;
     /* Get the current IO position */
     iocurrent = (GPIO_Pin) & ioposition;
 
-    if(iocurrent == ioposition)
+    if (iocurrent == ioposition)
     {
       /*------------------------- EXTI Mode Configuration --------------------*/
       tmp = SYSCFG->EXTICR[position >> 2];
       tmp &= (((uint32_t)0x0F) << (4 * (position & 0x03)));
-      if(tmp == ((uint32_t)(GPIO_GET_INDEX(GPIOx)) << (4 * (position & 0x03))))
+      if (tmp == ((uint32_t)(GPIO_GET_INDEX(GPIOx)) << (4 * (position & 0x03))))
       {
         /* Clear EXTI line configuration */
         EXTI->IMR &= ~((uint32_t)iocurrent);
@@ -348,7 +348,7 @@ void HAL_GPIO_DeInit(GPIO_TypeDef  *GPIOx, uint32_t GPIO_Pin)
   * @}
   */
 
-/** @defgroup GPIO_Exported_Functions_Group2 IO operation functions 
+/** @defgroup GPIO_Exported_Functions_Group2 IO operation functions
  *  @brief   GPIO Read and Write
  *
 @verbatim
@@ -364,17 +364,17 @@ void HAL_GPIO_DeInit(GPIO_TypeDef  *GPIOx, uint32_t GPIO_Pin)
   * @brief  Reads the specified input port pin.
   * @param  GPIOx where x can be (A..K) to select the GPIO peripheral.
   * @param  GPIO_Pin specifies the port bit to read.
-  *         This parameter can be GPIO_PIN_x where x can be (0..15).
+  *         This parameter can be any combination of GPIO_PIN_x where x can be (0..15).
   * @retval The input port pin value.
   */
-GPIO_PinState HAL_GPIO_ReadPin(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin)
+GPIO_PinState HAL_GPIO_ReadPin(GPIO_TypeDef *GPIOx, uint16_t GPIO_Pin)
 {
   GPIO_PinState bitstatus;
 
   /* Check the parameters */
   assert_param(IS_GPIO_PIN(GPIO_Pin));
 
-  if((GPIOx->IDR & GPIO_Pin) != (uint32_t)GPIO_PIN_RESET)
+  if ((GPIOx->IDR & GPIO_Pin) != (uint32_t)GPIO_PIN_RESET)
   {
     bitstatus = GPIO_PIN_SET;
   }
@@ -394,20 +394,20 @@ GPIO_PinState HAL_GPIO_ReadPin(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin)
   *
   * @param  GPIOx where x can be (A..K) to select the GPIO peripheral.
   * @param  GPIO_Pin specifies the port bit to be written.
-  *          This parameter can be one of GPIO_PIN_x where x can be (0..15).
+  *         This parameter can be any combination of GPIO_PIN_x where x can be (0..15).
   * @param  PinState specifies the value to be written to the selected bit.
   *          This parameter can be one of the GPIO_PinState enum values:
   *            @arg GPIO_PIN_RESET: to clear the port pin
   *            @arg GPIO_PIN_SET: to set the port pin
   * @retval None
   */
-void HAL_GPIO_WritePin(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin, GPIO_PinState PinState)
+void HAL_GPIO_WritePin(GPIO_TypeDef *GPIOx, uint16_t GPIO_Pin, GPIO_PinState PinState)
 {
   /* Check the parameters */
   assert_param(IS_GPIO_PIN(GPIO_Pin));
   assert_param(IS_GPIO_PIN_ACTION(PinState));
 
-  if(PinState != GPIO_PIN_RESET)
+  if (PinState != GPIO_PIN_RESET)
   {
     GPIOx->BSRR = GPIO_Pin;
   }
@@ -421,9 +421,10 @@ void HAL_GPIO_WritePin(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin, GPIO_PinState Pin
   * @brief  Toggles the specified GPIO pins.
   * @param  GPIOx Where x can be (A..I) to select the GPIO peripheral.
   * @param  GPIO_Pin Specifies the pins to be toggled.
+  *         This parameter can be any combination of GPIO_PIN_x where x can be (0..15).
   * @retval None
   */
-void HAL_GPIO_TogglePin(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin)
+void HAL_GPIO_TogglePin(GPIO_TypeDef *GPIOx, uint16_t GPIO_Pin)
 {
   uint32_t odr;
 
@@ -448,7 +449,7 @@ void HAL_GPIO_TogglePin(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin)
   *         This parameter can be any combination of GPIO_PIN_x where x can be (0..15).
   * @retval None
   */
-HAL_StatusTypeDef HAL_GPIO_LockPin(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin)
+HAL_StatusTypeDef HAL_GPIO_LockPin(GPIO_TypeDef *GPIOx, uint16_t GPIO_Pin)
 {
   __IO uint32_t tmp = GPIO_LCKR_LCKK;
 
@@ -467,7 +468,7 @@ HAL_StatusTypeDef HAL_GPIO_LockPin(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin)
   tmp = GPIOx->LCKR;
 
   /* Read again in order to confirm lock is active */
-  if((GPIOx->LCKR & GPIO_LCKR_LCKK) != RESET)
+  if ((GPIOx->LCKR & GPIO_LCKR_LCKK) != RESET)
   {
     return HAL_OK;
   }
@@ -485,7 +486,7 @@ HAL_StatusTypeDef HAL_GPIO_LockPin(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin)
 void HAL_GPIO_EXTI_IRQHandler(uint16_t GPIO_Pin)
 {
   /* EXTI line interrupt detected */
-  if(__HAL_GPIO_EXTI_GET_IT(GPIO_Pin) != RESET)
+  if (__HAL_GPIO_EXTI_GET_IT(GPIO_Pin) != RESET)
   {
     __HAL_GPIO_EXTI_CLEAR_IT(GPIO_Pin);
     HAL_GPIO_EXTI_Callback(GPIO_Pin);
@@ -501,7 +502,7 @@ __weak void HAL_GPIO_EXTI_Callback(uint16_t GPIO_Pin)
 {
   /* Prevent unused argument(s) compilation warning */
   UNUSED(GPIO_Pin);
-  
+
   /* NOTE: This function Should not be modified, when the callback is needed,
            the HAL_GPIO_EXTI_Callback could be implemented in the user file
    */

--- a/lib/STM32F7xx_HAL_Driver/Src/stm32f7xx_hal_i2c.c
+++ b/lib/STM32F7xx_HAL_Driver/Src/stm32f7xx_hal_i2c.c
@@ -90,7 +90,7 @@
            add their own code by customization of function pointer HAL_I2C_SlaveRxCpltCallback()
       (+) In case of transfer Error, HAL_I2C_ErrorCallback() function is executed and users can
            add their own code by customization of function pointer HAL_I2C_ErrorCallback()
-      (+) Abort a master I2C process communication with Interrupt using HAL_I2C_Master_Abort_IT()
+      (+) Abort a master or memory I2C process communication with Interrupt using HAL_I2C_Master_Abort_IT()
       (+) End of abort process, HAL_I2C_AbortCpltCallback() is executed and users can
            add their own code by customization of function pointer HAL_I2C_AbortCpltCallback()
       (+) Discard a slave I2C process communication using __HAL_I2C_GENERATE_NACK() macro.
@@ -156,7 +156,7 @@
             HAL_I2C_Master_Seq_Receive_IT() or using HAL_I2C_Master_Seq_Receive_DMA()
       (+++) At reception end of current frame transfer, HAL_I2C_MasterRxCpltCallback() is executed and users can
            add their own code by customization of function pointer HAL_I2C_MasterRxCpltCallback()
-      (++) Abort a master IT or DMA I2C process communication with Interrupt using HAL_I2C_Master_Abort_IT()
+      (++) Abort a master or memory IT or DMA I2C process communication with Interrupt using HAL_I2C_Master_Abort_IT()
       (+++) End of abort process, HAL_I2C_AbortCpltCallback() is executed and users can
            add their own code by customization of function pointer HAL_I2C_AbortCpltCallback()
       (++) Enable/disable the Address listen mode in slave I2C mode using HAL_I2C_EnableListen_IT()
@@ -214,7 +214,7 @@
            add their own code by customization of function pointer HAL_I2C_SlaveRxCpltCallback()
       (+) In case of transfer Error, HAL_I2C_ErrorCallback() function is executed and users can
            add their own code by customization of function pointer HAL_I2C_ErrorCallback()
-      (+) Abort a master I2C process communication with Interrupt using HAL_I2C_Master_Abort_IT()
+      (+) Abort a master or memory I2C process communication with Interrupt using HAL_I2C_Master_Abort_IT()
       (+) End of abort process, HAL_I2C_AbortCpltCallback() is executed and users can
            add their own code by customization of function pointer HAL_I2C_AbortCpltCallback()
       (+) Discard a slave I2C process communication using __HAL_I2C_GENERATE_NACK() macro.
@@ -400,9 +400,15 @@
   * @}
   */
 
-/* Private macro -------------------------------------------------------------*/
+/* Private macros ------------------------------------------------------------*/
+/** @addtogroup I2C_Private_Macro
+  * @{
+  */
 /* Macro to get remaining data to transfer on DMA side */
 #define I2C_GET_DMA_REMAIN_DATA(__HANDLE__)     __HAL_DMA_GET_COUNTER(__HANDLE__)
+/**
+  * @}
+  */
 
 /* Private variables ---------------------------------------------------------*/
 /* Private function prototypes -----------------------------------------------*/
@@ -417,6 +423,7 @@ static void I2C_DMASlaveTransmitCplt(DMA_HandleTypeDef *hdma);
 static void I2C_DMASlaveReceiveCplt(DMA_HandleTypeDef *hdma);
 static void I2C_DMAError(DMA_HandleTypeDef *hdma);
 static void I2C_DMAAbort(DMA_HandleTypeDef *hdma);
+
 
 /* Private functions to handle IT transfer */
 static void I2C_ITAddrCplt(I2C_HandleTypeDef *hi2c, uint32_t ITFlags);
@@ -601,7 +608,12 @@ HAL_StatusTypeDef HAL_I2C_Init(I2C_HandleTypeDef *hi2c)
   /* Configure I2Cx: Addressing Master mode */
   if (hi2c->Init.AddressingMode == I2C_ADDRESSINGMODE_10BIT)
   {
-    hi2c->Instance->CR2 = (I2C_CR2_ADD10);
+    SET_BIT(hi2c->Instance->CR2, I2C_CR2_ADD10);
+  }
+  else
+  {
+    /* Clear the I2C ADD10 bit */
+    CLEAR_BIT(hi2c->Instance->CR2, I2C_CR2_ADD10);
   }
   /* Enable the AUTOEND by default, and enable NACK (should be disable only during Slave process */
   hi2c->Instance->CR2 |= (I2C_CR2_AUTOEND | I2C_CR2_NACK);
@@ -837,7 +849,7 @@ HAL_StatusTypeDef HAL_I2C_RegisterCallback(I2C_HandleTypeDef *hi2c, HAL_I2C_Call
 /**
   * @brief  Unregister an I2C Callback
   *         I2C callback is redirected to the weak predefined callback
-  * @note   The HAL_I2C_UnRegisterCallback() may be called before HAL_I2C_Init() in HAL_I2C_STATE_RESET 
+  * @note   The HAL_I2C_UnRegisterCallback() may be called before HAL_I2C_Init() in HAL_I2C_STATE_RESET
   *         to un-register callbacks for HAL_I2C_MSPINIT_CB_ID and HAL_I2C_MSPDEINIT_CB_ID.
   * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
   *                the configuration information for the specified I2C.
@@ -1108,6 +1120,7 @@ HAL_StatusTypeDef HAL_I2C_Master_Transmit(I2C_HandleTypeDef *hi2c, uint16_t DevA
                                           uint16_t Size, uint32_t Timeout)
 {
   uint32_t tickstart;
+  uint32_t xfermode;
 
   if (hi2c->State == HAL_I2C_STATE_READY)
   {
@@ -1131,18 +1144,39 @@ HAL_StatusTypeDef HAL_I2C_Master_Transmit(I2C_HandleTypeDef *hi2c, uint16_t DevA
     hi2c->XferCount = Size;
     hi2c->XferISR   = NULL;
 
-    /* Send Slave Address */
-    /* Set NBYTES to write and reload if hi2c->XferCount > MAX_NBYTE_SIZE and generate RESTART */
     if (hi2c->XferCount > MAX_NBYTE_SIZE)
     {
       hi2c->XferSize = MAX_NBYTE_SIZE;
-      I2C_TransferConfig(hi2c, DevAddress, (uint8_t)hi2c->XferSize, I2C_RELOAD_MODE,
-                         I2C_GENERATE_START_WRITE);
+      xfermode = I2C_RELOAD_MODE;
     }
     else
     {
       hi2c->XferSize = hi2c->XferCount;
-      I2C_TransferConfig(hi2c, DevAddress, (uint8_t)hi2c->XferSize, I2C_AUTOEND_MODE,
+      xfermode = I2C_AUTOEND_MODE;
+    }
+
+    if (hi2c->XferSize > 0U)
+    {
+      /* Preload TX register */
+      /* Write data to TXDR */
+      hi2c->Instance->TXDR = *hi2c->pBuffPtr;
+
+      /* Increment Buffer pointer */
+      hi2c->pBuffPtr++;
+
+      hi2c->XferCount--;
+      hi2c->XferSize--;
+
+      /* Send Slave Address */
+      /* Set NBYTES to write and reload if hi2c->XferCount > MAX_NBYTE_SIZE and generate RESTART */
+      I2C_TransferConfig(hi2c, DevAddress, (uint8_t)(hi2c->XferSize + 1U), xfermode,
+                         I2C_GENERATE_START_WRITE);
+    }
+    else
+    {
+      /* Send Slave Address */
+      /* Set NBYTES to write and reload if hi2c->XferCount > MAX_NBYTE_SIZE and generate RESTART */
+      I2C_TransferConfig(hi2c, DevAddress, (uint8_t)hi2c->XferSize, xfermode,
                          I2C_GENERATE_START_WRITE);
     }
 
@@ -1254,7 +1288,7 @@ HAL_StatusTypeDef HAL_I2C_Master_Receive(I2C_HandleTypeDef *hi2c, uint16_t DevAd
     /* Set NBYTES to write and reload if hi2c->XferCount > MAX_NBYTE_SIZE and generate RESTART */
     if (hi2c->XferCount > MAX_NBYTE_SIZE)
     {
-      hi2c->XferSize = MAX_NBYTE_SIZE;
+      hi2c->XferSize = 1U;
       I2C_TransferConfig(hi2c, DevAddress, (uint8_t)hi2c->XferSize, I2C_RELOAD_MODE,
                          I2C_GENERATE_START_READ);
     }
@@ -1345,6 +1379,8 @@ HAL_StatusTypeDef HAL_I2C_Slave_Transmit(I2C_HandleTypeDef *hi2c, uint8_t *pData
                                          uint32_t Timeout)
 {
   uint32_t tickstart;
+  uint16_t tmpXferCount;
+  HAL_StatusTypeDef error;
 
   if (hi2c->State == HAL_I2C_STATE_READY)
   {
@@ -1371,11 +1407,28 @@ HAL_StatusTypeDef HAL_I2C_Slave_Transmit(I2C_HandleTypeDef *hi2c, uint8_t *pData
     /* Enable Address Acknowledge */
     hi2c->Instance->CR2 &= ~I2C_CR2_NACK;
 
+    /* Preload TX data if no stretch enable */
+    if (hi2c->Init.NoStretchMode == I2C_NOSTRETCH_ENABLE)
+    {
+      /* Preload TX register */
+      /* Write data to TXDR */
+      hi2c->Instance->TXDR = *hi2c->pBuffPtr;
+
+      /* Increment Buffer pointer */
+      hi2c->pBuffPtr++;
+
+      hi2c->XferCount--;
+    }
+
     /* Wait until ADDR flag is set */
     if (I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_ADDR, RESET, Timeout, tickstart) != HAL_OK)
     {
       /* Disable Address Acknowledge */
       hi2c->Instance->CR2 |= I2C_CR2_NACK;
+
+      /* Flush TX register */
+      I2C_Flush_TXDR(hi2c);
+
       return HAL_ERROR;
     }
 
@@ -1390,6 +1443,10 @@ HAL_StatusTypeDef HAL_I2C_Slave_Transmit(I2C_HandleTypeDef *hi2c, uint8_t *pData
       {
         /* Disable Address Acknowledge */
         hi2c->Instance->CR2 |= I2C_CR2_NACK;
+
+        /* Flush TX register */
+        I2C_Flush_TXDR(hi2c);
+
         return HAL_ERROR;
       }
 
@@ -1402,6 +1459,10 @@ HAL_StatusTypeDef HAL_I2C_Slave_Transmit(I2C_HandleTypeDef *hi2c, uint8_t *pData
     {
       /* Disable Address Acknowledge */
       hi2c->Instance->CR2 |= I2C_CR2_NACK;
+
+      /* Flush TX register */
+      I2C_Flush_TXDR(hi2c);
+
       return HAL_ERROR;
     }
 
@@ -1425,30 +1486,47 @@ HAL_StatusTypeDef HAL_I2C_Slave_Transmit(I2C_HandleTypeDef *hi2c, uint8_t *pData
     }
 
     /* Wait until AF flag is set */
-    if (I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_AF, RESET, Timeout, tickstart) != HAL_OK)
+    error = I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_AF, RESET, Timeout, tickstart);
+
+    if (error != HAL_OK)
     {
-      /* Disable Address Acknowledge */
-      hi2c->Instance->CR2 |= I2C_CR2_NACK;
-      return HAL_ERROR;
+      /* Check that I2C transfer finished */
+      /* if yes, normal use case, a NACK is sent by the MASTER when Transfer is finished */
+      /* Mean XferCount == 0 */
+
+      tmpXferCount = hi2c->XferCount;
+      if ((hi2c->ErrorCode == HAL_I2C_ERROR_AF) && (tmpXferCount == 0U))
+      {
+        /* Reset ErrorCode to NONE */
+        hi2c->ErrorCode = HAL_I2C_ERROR_NONE;
+      }
+      else
+      {
+        /* Disable Address Acknowledge */
+        hi2c->Instance->CR2 |= I2C_CR2_NACK;
+        return HAL_ERROR;
+      }
     }
-
-    /* Flush TX register */
-    I2C_Flush_TXDR(hi2c);
-
-    /* Clear AF flag */
-    __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_AF);
-
-    /* Wait until STOP flag is set */
-    if (I2C_WaitOnSTOPFlagUntilTimeout(hi2c, Timeout, tickstart) != HAL_OK)
+    else
     {
-      /* Disable Address Acknowledge */
-      hi2c->Instance->CR2 |= I2C_CR2_NACK;
+      /* Flush TX register */
+      I2C_Flush_TXDR(hi2c);
 
-      return HAL_ERROR;
+      /* Clear AF flag */
+      __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_AF);
+
+      /* Wait until STOP flag is set */
+      if (I2C_WaitOnSTOPFlagUntilTimeout(hi2c, Timeout, tickstart) != HAL_OK)
+      {
+        /* Disable Address Acknowledge */
+        hi2c->Instance->CR2 |= I2C_CR2_NACK;
+
+        return HAL_ERROR;
+      }
+
+      /* Clear STOP flag */
+      __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
     }
-
-    /* Clear STOP flag */
-    __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
 
     /* Wait until BUSY flag is reset */
     if (I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_BUSY, SET, Timeout, tickstart) != HAL_OK)
@@ -1652,7 +1730,26 @@ HAL_StatusTypeDef HAL_I2C_Master_Transmit_IT(I2C_HandleTypeDef *hi2c, uint16_t D
 
     /* Send Slave Address */
     /* Set NBYTES to write and reload if hi2c->XferCount > MAX_NBYTE_SIZE */
-    I2C_TransferConfig(hi2c, DevAddress, (uint8_t)hi2c->XferSize, xfermode, I2C_GENERATE_START_WRITE);
+    if (hi2c->XferSize > 0U)
+    {
+      /* Preload TX register */
+      /* Write data to TXDR */
+      hi2c->Instance->TXDR = *hi2c->pBuffPtr;
+
+      /* Increment Buffer pointer */
+      hi2c->pBuffPtr++;
+
+      hi2c->XferCount--;
+      hi2c->XferSize--;
+
+      I2C_TransferConfig(hi2c, DevAddress, (uint8_t)(hi2c->XferSize + 1U), xfermode,
+                         I2C_GENERATE_START_WRITE);
+    }
+    else
+    {
+      I2C_TransferConfig(hi2c, DevAddress, (uint8_t)hi2c->XferSize, xfermode,
+                         I2C_GENERATE_START_WRITE);
+    }
 
     /* Process Unlocked */
     __HAL_UNLOCK(hi2c);
@@ -1712,7 +1809,7 @@ HAL_StatusTypeDef HAL_I2C_Master_Receive_IT(I2C_HandleTypeDef *hi2c, uint16_t De
 
     if (hi2c->XferCount > MAX_NBYTE_SIZE)
     {
-      hi2c->XferSize = MAX_NBYTE_SIZE;
+      hi2c->XferSize = 1U;
       xfermode = I2C_RELOAD_MODE;
     }
     else
@@ -1774,6 +1871,20 @@ HAL_StatusTypeDef HAL_I2C_Slave_Transmit_IT(I2C_HandleTypeDef *hi2c, uint8_t *pD
     hi2c->XferSize    = hi2c->XferCount;
     hi2c->XferOptions = I2C_NO_OPTION_FRAME;
     hi2c->XferISR     = I2C_Slave_ISR_IT;
+
+    /* Preload TX data if no stretch enable */
+    if (hi2c->Init.NoStretchMode == I2C_NOSTRETCH_ENABLE)
+    {
+      /* Preload TX register */
+      /* Write data to TXDR */
+      hi2c->Instance->TXDR = *hi2c->pBuffPtr;
+
+      /* Increment Buffer pointer */
+      hi2c->pBuffPtr++;
+
+      hi2c->XferCount--;
+      hi2c->XferSize--;
+    }
 
     /* Process Unlocked */
     __HAL_UNLOCK(hi2c);
@@ -1861,6 +1972,7 @@ HAL_StatusTypeDef HAL_I2C_Master_Transmit_DMA(I2C_HandleTypeDef *hi2c, uint16_t 
 {
   uint32_t xfermode;
   HAL_StatusTypeDef dmaxferstatus;
+  uint32_t sizetoxfer = 0U;
 
   if (hi2c->State == HAL_I2C_STATE_READY)
   {
@@ -1895,6 +2007,20 @@ HAL_StatusTypeDef HAL_I2C_Master_Transmit_DMA(I2C_HandleTypeDef *hi2c, uint16_t 
 
     if (hi2c->XferSize > 0U)
     {
+      /* Preload TX register */
+      /* Write data to TXDR */
+      hi2c->Instance->TXDR = *hi2c->pBuffPtr;
+
+      /* Increment Buffer pointer */
+      hi2c->pBuffPtr++;
+
+      sizetoxfer = hi2c->XferSize;
+      hi2c->XferCount--;
+      hi2c->XferSize--;
+    }
+
+    if (hi2c->XferSize > 0U)
+    {
       if (hi2c->hdmatx != NULL)
       {
         /* Set the I2C DMA transfer complete callback */
@@ -1908,8 +2034,8 @@ HAL_StatusTypeDef HAL_I2C_Master_Transmit_DMA(I2C_HandleTypeDef *hi2c, uint16_t 
         hi2c->hdmatx->XferAbortCallback = NULL;
 
         /* Enable the DMA stream */
-        dmaxferstatus = HAL_DMA_Start_IT(hi2c->hdmatx, (uint32_t)pData, (uint32_t)&hi2c->Instance->TXDR,
-                                         hi2c->XferSize);
+        dmaxferstatus = HAL_DMA_Start_IT(hi2c->hdmatx, (uint32_t)hi2c->pBuffPtr,
+                                         (uint32_t)&hi2c->Instance->TXDR, hi2c->XferSize);
       }
       else
       {
@@ -1930,7 +2056,8 @@ HAL_StatusTypeDef HAL_I2C_Master_Transmit_DMA(I2C_HandleTypeDef *hi2c, uint16_t 
       {
         /* Send Slave Address */
         /* Set NBYTES to write and reload if hi2c->XferCount > MAX_NBYTE_SIZE and generate RESTART */
-        I2C_TransferConfig(hi2c, DevAddress, (uint8_t)hi2c->XferSize, xfermode, I2C_GENERATE_START_WRITE);
+        I2C_TransferConfig(hi2c, DevAddress, (uint8_t)(hi2c->XferSize + 1U),
+                           xfermode, I2C_GENERATE_START_WRITE);
 
         /* Update XferCount value */
         hi2c->XferCount -= hi2c->XferSize;
@@ -1969,7 +2096,7 @@ HAL_StatusTypeDef HAL_I2C_Master_Transmit_DMA(I2C_HandleTypeDef *hi2c, uint16_t 
 
       /* Send Slave Address */
       /* Set NBYTES to write and generate START condition */
-      I2C_TransferConfig(hi2c, DevAddress, (uint8_t)hi2c->XferSize, I2C_AUTOEND_MODE,
+      I2C_TransferConfig(hi2c, DevAddress, (uint8_t)sizetoxfer, I2C_AUTOEND_MODE,
                          I2C_GENERATE_START_WRITE);
 
       /* Process Unlocked */
@@ -2031,7 +2158,7 @@ HAL_StatusTypeDef HAL_I2C_Master_Receive_DMA(I2C_HandleTypeDef *hi2c, uint16_t D
 
     if (hi2c->XferCount > MAX_NBYTE_SIZE)
     {
-      hi2c->XferSize = MAX_NBYTE_SIZE;
+      hi2c->XferSize = 1U;
       xfermode = I2C_RELOAD_MODE;
     }
     else
@@ -2125,11 +2252,11 @@ HAL_StatusTypeDef HAL_I2C_Master_Receive_DMA(I2C_HandleTypeDef *hi2c, uint16_t D
       /* Note : The I2C interrupts must be enabled after unlocking current process
                 to avoid the risk of I2C interrupt handle execution before current
                 process unlock */
-      /* Enable ERR, TC, STOP, NACK, TXI interrupt */
+      /* Enable ERR, TC, STOP, NACK, RXI interrupt */
       /* possible to enable all of these */
       /* I2C_IT_ERRI | I2C_IT_TCI | I2C_IT_STOPI | I2C_IT_NACKI |
         I2C_IT_ADDRI | I2C_IT_RXI | I2C_IT_TXI */
-      I2C_Enable_IRQ(hi2c, I2C_XFER_TX_IT);
+      I2C_Enable_IRQ(hi2c, I2C_XFER_RX_IT);
     }
 
     return HAL_OK;
@@ -2173,38 +2300,87 @@ HAL_StatusTypeDef HAL_I2C_Slave_Transmit_DMA(I2C_HandleTypeDef *hi2c, uint8_t *p
     hi2c->XferOptions = I2C_NO_OPTION_FRAME;
     hi2c->XferISR     = I2C_Slave_ISR_DMA;
 
-    if (hi2c->hdmatx != NULL)
+    /* Preload TX data if no stretch enable */
+    if (hi2c->Init.NoStretchMode == I2C_NOSTRETCH_ENABLE)
     {
-      /* Set the I2C DMA transfer complete callback */
-      hi2c->hdmatx->XferCpltCallback = I2C_DMASlaveTransmitCplt;
+      /* Preload TX register */
+      /* Write data to TXDR */
+      hi2c->Instance->TXDR = *hi2c->pBuffPtr;
 
-      /* Set the DMA error callback */
-      hi2c->hdmatx->XferErrorCallback = I2C_DMAError;
+      /* Increment Buffer pointer */
+      hi2c->pBuffPtr++;
 
-      /* Set the unused DMA callbacks to NULL */
-      hi2c->hdmatx->XferHalfCpltCallback = NULL;
-      hi2c->hdmatx->XferAbortCallback = NULL;
+      hi2c->XferCount--;
+      hi2c->XferSize--;
+    }
 
-      /* Enable the DMA stream */
-      dmaxferstatus = HAL_DMA_Start_IT(hi2c->hdmatx, (uint32_t)pData, (uint32_t)&hi2c->Instance->TXDR,
-                                       hi2c->XferSize);
+    if (hi2c->XferCount != 0U)
+    {
+      if (hi2c->hdmatx != NULL)
+      {
+        /* Set the I2C DMA transfer complete callback */
+        hi2c->hdmatx->XferCpltCallback = I2C_DMASlaveTransmitCplt;
+
+        /* Set the DMA error callback */
+        hi2c->hdmatx->XferErrorCallback = I2C_DMAError;
+
+        /* Set the unused DMA callbacks to NULL */
+        hi2c->hdmatx->XferHalfCpltCallback = NULL;
+        hi2c->hdmatx->XferAbortCallback = NULL;
+
+        /* Enable the DMA stream */
+        dmaxferstatus = HAL_DMA_Start_IT(hi2c->hdmatx,
+                                         (uint32_t)hi2c->pBuffPtr, (uint32_t)&hi2c->Instance->TXDR,
+                                         hi2c->XferSize);
+      }
+      else
+      {
+        /* Update I2C state */
+        hi2c->State     = HAL_I2C_STATE_LISTEN;
+        hi2c->Mode      = HAL_I2C_MODE_NONE;
+
+        /* Update I2C error code */
+        hi2c->ErrorCode |= HAL_I2C_ERROR_DMA_PARAM;
+
+        /* Process Unlocked */
+        __HAL_UNLOCK(hi2c);
+
+        return HAL_ERROR;
+      }
+
+      if (dmaxferstatus == HAL_OK)
+      {
+        /* Enable Address Acknowledge */
+        hi2c->Instance->CR2 &= ~I2C_CR2_NACK;
+
+        /* Process Unlocked */
+        __HAL_UNLOCK(hi2c);
+
+        /* Note : The I2C interrupts must be enabled after unlocking current process
+                  to avoid the risk of I2C interrupt handle execution before current
+                  process unlock */
+        /* Enable ERR, STOP, NACK, ADDR interrupts */
+        I2C_Enable_IRQ(hi2c, I2C_XFER_LISTEN_IT);
+
+        /* Enable DMA Request */
+        hi2c->Instance->CR1 |= I2C_CR1_TXDMAEN;
+      }
+      else
+      {
+        /* Update I2C state */
+        hi2c->State     = HAL_I2C_STATE_LISTEN;
+        hi2c->Mode      = HAL_I2C_MODE_NONE;
+
+        /* Update I2C error code */
+        hi2c->ErrorCode |= HAL_I2C_ERROR_DMA;
+
+        /* Process Unlocked */
+        __HAL_UNLOCK(hi2c);
+
+        return HAL_ERROR;
+      }
     }
     else
-    {
-      /* Update I2C state */
-      hi2c->State     = HAL_I2C_STATE_LISTEN;
-      hi2c->Mode      = HAL_I2C_MODE_NONE;
-
-      /* Update I2C error code */
-      hi2c->ErrorCode |= HAL_I2C_ERROR_DMA_PARAM;
-
-      /* Process Unlocked */
-      __HAL_UNLOCK(hi2c);
-
-      return HAL_ERROR;
-    }
-
-    if (dmaxferstatus == HAL_OK)
     {
       /* Enable Address Acknowledge */
       hi2c->Instance->CR2 &= ~I2C_CR2_NACK;
@@ -2213,27 +2389,10 @@ HAL_StatusTypeDef HAL_I2C_Slave_Transmit_DMA(I2C_HandleTypeDef *hi2c, uint8_t *p
       __HAL_UNLOCK(hi2c);
 
       /* Note : The I2C interrupts must be enabled after unlocking current process
-                to avoid the risk of I2C interrupt handle execution before current
-                process unlock */
+      to avoid the risk of I2C interrupt handle execution before current
+      process unlock */
       /* Enable ERR, STOP, NACK, ADDR interrupts */
       I2C_Enable_IRQ(hi2c, I2C_XFER_LISTEN_IT);
-
-      /* Enable DMA Request */
-      hi2c->Instance->CR1 |= I2C_CR1_TXDMAEN;
-    }
-    else
-    {
-      /* Update I2C state */
-      hi2c->State     = HAL_I2C_STATE_LISTEN;
-      hi2c->Mode      = HAL_I2C_MODE_NONE;
-
-      /* Update I2C error code */
-      hi2c->ErrorCode |= HAL_I2C_ERROR_DMA;
-
-      /* Process Unlocked */
-      __HAL_UNLOCK(hi2c);
-
-      return HAL_ERROR;
     }
 
     return HAL_OK;
@@ -2347,6 +2506,7 @@ HAL_StatusTypeDef HAL_I2C_Slave_Receive_DMA(I2C_HandleTypeDef *hi2c, uint8_t *pD
     return HAL_BUSY;
   }
 }
+
 /**
   * @brief  Write an amount of data in blocking mode to a specific memory address
   * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
@@ -2545,7 +2705,7 @@ HAL_StatusTypeDef HAL_I2C_Mem_Read(I2C_HandleTypeDef *hi2c, uint16_t DevAddress,
     /* Set NBYTES to write and reload if hi2c->XferCount > MAX_NBYTE_SIZE and generate RESTART */
     if (hi2c->XferCount > MAX_NBYTE_SIZE)
     {
-      hi2c->XferSize = MAX_NBYTE_SIZE;
+      hi2c->XferSize = 1U;
       I2C_TransferConfig(hi2c, DevAddress, (uint8_t)hi2c->XferSize, I2C_RELOAD_MODE,
                          I2C_GENERATE_START_READ);
     }
@@ -2583,7 +2743,7 @@ HAL_StatusTypeDef HAL_I2C_Mem_Read(I2C_HandleTypeDef *hi2c, uint16_t DevAddress,
 
         if (hi2c->XferCount > MAX_NBYTE_SIZE)
         {
-          hi2c->XferSize = MAX_NBYTE_SIZE;
+          hi2c->XferSize = 1U;
           I2C_TransferConfig(hi2c, DevAddress, (uint8_t) hi2c->XferSize, I2C_RELOAD_MODE,
                              I2C_NO_STARTSTOP);
         }
@@ -2661,6 +2821,7 @@ HAL_StatusTypeDef HAL_I2C_Mem_Write_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddr
     hi2c->ErrorCode   = HAL_I2C_ERROR_NONE;
 
     /* Prepare transfer parameters */
+    hi2c->XferSize    = 0U;
     hi2c->pBuffPtr    = pData;
     hi2c->XferCount   = Size;
     hi2c->XferOptions = I2C_NO_OPTION_FRAME;
@@ -2782,11 +2943,11 @@ HAL_StatusTypeDef HAL_I2C_Mem_Read_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddre
               to avoid the risk of I2C interrupt handle execution before current
               process unlock */
 
-    /* Enable ERR, TC, STOP, NACK, RXI interrupt */
+    /* Enable ERR, TC, STOP, NACK, TXI interrupt */
     /* possible to enable all of these */
     /* I2C_IT_ERRI | I2C_IT_TCI | I2C_IT_STOPI | I2C_IT_NACKI |
       I2C_IT_ADDRI | I2C_IT_RXI | I2C_IT_TXI */
-    I2C_Enable_IRQ(hi2c, (I2C_XFER_TX_IT | I2C_XFER_RX_IT));
+    I2C_Enable_IRQ(hi2c, I2C_XFER_TX_IT);
 
     return HAL_OK;
   }
@@ -2795,6 +2956,7 @@ HAL_StatusTypeDef HAL_I2C_Mem_Read_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddre
     return HAL_BUSY;
   }
 }
+
 /**
   * @brief  Write an amount of data in non-blocking mode with DMA to a specific memory address
   * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
@@ -3191,22 +3353,6 @@ HAL_StatusTypeDef HAL_I2C_IsDeviceReady(I2C_HandleTypeDef *hi2c, uint16_t DevAdd
         __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
       }
 
-      /* Check if the maximum allowed number of trials has been reached */
-      if (I2C_Trials == Trials)
-      {
-        /* Generate Stop */
-        hi2c->Instance->CR2 |= I2C_CR2_STOP;
-
-        /* Wait until STOPF flag is reset */
-        if (I2C_WaitOnFlagUntilTimeout(hi2c, I2C_FLAG_STOPF, RESET, Timeout, tickstart) != HAL_OK)
-        {
-          return HAL_ERROR;
-        }
-
-        /* Clear STOP Flag */
-        __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
-      }
-
       /* Increment Trials */
       I2C_Trials++;
     } while (I2C_Trials < Trials);
@@ -3245,6 +3391,7 @@ HAL_StatusTypeDef HAL_I2C_Master_Seq_Transmit_IT(I2C_HandleTypeDef *hi2c, uint16
 {
   uint32_t xfermode;
   uint32_t xferrequest = I2C_GENERATE_START_WRITE;
+  uint32_t sizetoxfer = 0U;
 
   /* Check the parameters */
   assert_param(IS_I2C_TRANSFER_OPTIONS_REQUEST(XferOptions));
@@ -3276,6 +3423,21 @@ HAL_StatusTypeDef HAL_I2C_Master_Seq_Transmit_IT(I2C_HandleTypeDef *hi2c, uint16
       xfermode = hi2c->XferOptions;
     }
 
+    if ((hi2c->XferSize > 0U) && ((XferOptions == I2C_FIRST_FRAME) || \
+                                  (XferOptions == I2C_FIRST_AND_LAST_FRAME)))
+    {
+      /* Preload TX register */
+      /* Write data to TXDR */
+      hi2c->Instance->TXDR = *hi2c->pBuffPtr;
+
+      /* Increment Buffer pointer */
+      hi2c->pBuffPtr++;
+
+      sizetoxfer = hi2c->XferSize;
+      hi2c->XferCount--;
+      hi2c->XferSize--;
+    }
+
     /* If transfer direction not change and there is no request to start another frame,
        do not generate Restart Condition */
     /* Mean Previous state is same as current state */
@@ -3297,7 +3459,14 @@ HAL_StatusTypeDef HAL_I2C_Master_Seq_Transmit_IT(I2C_HandleTypeDef *hi2c, uint16
     }
 
     /* Send Slave Address and set NBYTES to write */
-    I2C_TransferConfig(hi2c, DevAddress, (uint8_t)hi2c->XferSize, xfermode, xferrequest);
+    if ((XferOptions == I2C_FIRST_FRAME) || (XferOptions == I2C_FIRST_AND_LAST_FRAME))
+    {
+      I2C_TransferConfig(hi2c, DevAddress, (uint8_t)sizetoxfer, xfermode, xferrequest);
+    }
+    else
+    {
+      I2C_TransferConfig(hi2c, DevAddress, (uint8_t)hi2c->XferSize, xfermode, xferrequest);
+    }
 
     /* Process Unlocked */
     __HAL_UNLOCK(hi2c);
@@ -3337,6 +3506,7 @@ HAL_StatusTypeDef HAL_I2C_Master_Seq_Transmit_DMA(I2C_HandleTypeDef *hi2c, uint1
   uint32_t xfermode;
   uint32_t xferrequest = I2C_GENERATE_START_WRITE;
   HAL_StatusTypeDef dmaxferstatus;
+  uint32_t sizetoxfer = 0U;
 
   /* Check the parameters */
   assert_param(IS_I2C_TRANSFER_OPTIONS_REQUEST(XferOptions));
@@ -3366,6 +3536,21 @@ HAL_StatusTypeDef HAL_I2C_Master_Seq_Transmit_DMA(I2C_HandleTypeDef *hi2c, uint1
     {
       hi2c->XferSize = hi2c->XferCount;
       xfermode = hi2c->XferOptions;
+    }
+
+    if ((hi2c->XferSize > 0U) && ((XferOptions == I2C_FIRST_FRAME) || \
+                                  (XferOptions == I2C_FIRST_AND_LAST_FRAME)))
+    {
+      /* Preload TX register */
+      /* Write data to TXDR */
+      hi2c->Instance->TXDR = *hi2c->pBuffPtr;
+
+      /* Increment Buffer pointer */
+      hi2c->pBuffPtr++;
+
+      sizetoxfer = hi2c->XferSize;
+      hi2c->XferCount--;
+      hi2c->XferSize--;
     }
 
     /* If transfer direction not change and there is no request to start another frame,
@@ -3403,8 +3588,8 @@ HAL_StatusTypeDef HAL_I2C_Master_Seq_Transmit_DMA(I2C_HandleTypeDef *hi2c, uint1
         hi2c->hdmatx->XferAbortCallback = NULL;
 
         /* Enable the DMA stream */
-        dmaxferstatus = HAL_DMA_Start_IT(hi2c->hdmatx, (uint32_t)pData, (uint32_t)&hi2c->Instance->TXDR,
-                                         hi2c->XferSize);
+        dmaxferstatus = HAL_DMA_Start_IT(hi2c->hdmatx, (uint32_t)hi2c->pBuffPtr,
+                                         (uint32_t)&hi2c->Instance->TXDR, hi2c->XferSize);
       }
       else
       {
@@ -3424,7 +3609,14 @@ HAL_StatusTypeDef HAL_I2C_Master_Seq_Transmit_DMA(I2C_HandleTypeDef *hi2c, uint1
       if (dmaxferstatus == HAL_OK)
       {
         /* Send Slave Address and set NBYTES to write */
-        I2C_TransferConfig(hi2c, DevAddress, (uint8_t)hi2c->XferSize, xfermode, xferrequest);
+        if ((XferOptions == I2C_FIRST_FRAME) || (XferOptions == I2C_FIRST_AND_LAST_FRAME))
+        {
+          I2C_TransferConfig(hi2c, DevAddress, (uint8_t)sizetoxfer, xfermode, xferrequest);
+        }
+        else
+        {
+          I2C_TransferConfig(hi2c, DevAddress, (uint8_t)hi2c->XferSize, xfermode, xferrequest);
+        }
 
         /* Update XferCount value */
         hi2c->XferCount -= hi2c->XferSize;
@@ -3463,8 +3655,14 @@ HAL_StatusTypeDef HAL_I2C_Master_Seq_Transmit_DMA(I2C_HandleTypeDef *hi2c, uint1
 
       /* Send Slave Address */
       /* Set NBYTES to write and generate START condition */
-      I2C_TransferConfig(hi2c, DevAddress, (uint8_t)hi2c->XferSize, I2C_AUTOEND_MODE,
-                         I2C_GENERATE_START_WRITE);
+      if ((XferOptions == I2C_FIRST_FRAME) || (XferOptions == I2C_FIRST_AND_LAST_FRAME))
+      {
+        I2C_TransferConfig(hi2c, DevAddress, (uint8_t)sizetoxfer, xfermode, xferrequest);
+      }
+      else
+      {
+        I2C_TransferConfig(hi2c, DevAddress, (uint8_t)hi2c->XferSize, xfermode, xferrequest);
+      }
 
       /* Process Unlocked */
       __HAL_UNLOCK(hi2c);
@@ -3727,11 +3925,11 @@ HAL_StatusTypeDef HAL_I2C_Master_Seq_Receive_DMA(I2C_HandleTypeDef *hi2c, uint16
       /* Note : The I2C interrupts must be enabled after unlocking current process
                 to avoid the risk of I2C interrupt handle execution before current
                 process unlock */
-      /* Enable ERR, TC, STOP, NACK, TXI interrupt */
+      /* Enable ERR, TC, STOP, NACK, RXI interrupt */
       /* possible to enable all of these */
       /* I2C_IT_ERRI | I2C_IT_TCI | I2C_IT_STOPI | I2C_IT_NACKI |
         I2C_IT_ADDRI | I2C_IT_RXI | I2C_IT_TXI */
-      I2C_Enable_IRQ(hi2c, I2C_XFER_TX_IT);
+      I2C_Enable_IRQ(hi2c, I2C_XFER_RX_IT);
     }
 
     return HAL_OK;
@@ -3891,7 +4089,7 @@ HAL_StatusTypeDef HAL_I2C_Slave_Seq_Transmit_DMA(I2C_HandleTypeDef *hi2c, uint8_
           hi2c->Instance->CR1 &= ~I2C_CR1_RXDMAEN;
 
           /* Set the I2C DMA Abort callback :
-           will lead to call HAL_I2C_ErrorCallback() at end of DMA abort procedure */
+          will lead to call HAL_I2C_ErrorCallback() at end of DMA abort procedure */
           hi2c->hdmarx->XferAbortCallback = I2C_DMAAbort;
 
           /* Abort DMA RX */
@@ -3913,7 +4111,7 @@ HAL_StatusTypeDef HAL_I2C_Slave_Seq_Transmit_DMA(I2C_HandleTypeDef *hi2c, uint8_
         if (hi2c->hdmatx != NULL)
         {
           /* Set the I2C DMA Abort callback :
-           will lead to call HAL_I2C_ErrorCallback() at end of DMA abort procedure */
+          will lead to call HAL_I2C_ErrorCallback() at end of DMA abort procedure */
           hi2c->hdmatx->XferAbortCallback = I2C_DMAAbort;
 
           /* Abort DMA TX */
@@ -4366,7 +4564,7 @@ HAL_StatusTypeDef HAL_I2C_DisableListen_IT(I2C_HandleTypeDef *hi2c)
 }
 
 /**
-  * @brief  Abort a master I2C IT or DMA process communication with Interrupt.
+  * @brief  Abort a master or memory I2C IT or DMA process communication with Interrupt.
   * @param  hi2c Pointer to a I2C_HandleTypeDef structure that contains
   *                the configuration information for the specified I2C.
   * @param  DevAddress Target device address: The device 7 bits address value
@@ -4375,7 +4573,9 @@ HAL_StatusTypeDef HAL_I2C_DisableListen_IT(I2C_HandleTypeDef *hi2c)
   */
 HAL_StatusTypeDef HAL_I2C_Master_Abort_IT(I2C_HandleTypeDef *hi2c, uint16_t DevAddress)
 {
-  if (hi2c->Mode == HAL_I2C_MODE_MASTER)
+  HAL_I2C_ModeTypeDef tmp_mode = hi2c->Mode;
+
+  if ((tmp_mode == HAL_I2C_MODE_MASTER) || (tmp_mode == HAL_I2C_MODE_MEM))
   {
     /* Process Locked */
     __HAL_LOCK(hi2c);
@@ -4435,7 +4635,7 @@ HAL_StatusTypeDef HAL_I2C_Master_Abort_IT(I2C_HandleTypeDef *hi2c, uint16_t DevA
   *                the configuration information for the specified I2C.
   * @retval None
   */
-void HAL_I2C_EV_IRQHandler(I2C_HandleTypeDef *hi2c)
+void HAL_I2C_EV_IRQHandler(I2C_HandleTypeDef *hi2c) /* Derogation MISRAC2012-Rule-8.13 */
 {
   /* Get current IT Flags and IT sources value */
   uint32_t itflags   = READ_REG(hi2c->Instance->ISR);
@@ -4688,7 +4888,7 @@ __weak void HAL_I2C_AbortCpltCallback(I2C_HandleTypeDef *hi2c)
   *                the configuration information for the specified I2C.
   * @retval HAL state
   */
-HAL_I2C_StateTypeDef HAL_I2C_GetState(I2C_HandleTypeDef *hi2c)
+HAL_I2C_StateTypeDef HAL_I2C_GetState(const I2C_HandleTypeDef *hi2c)
 {
   /* Return I2C handle state */
   return hi2c->State;
@@ -4700,7 +4900,7 @@ HAL_I2C_StateTypeDef HAL_I2C_GetState(I2C_HandleTypeDef *hi2c)
   *         the configuration information for I2C module
   * @retval HAL mode
   */
-HAL_I2C_ModeTypeDef HAL_I2C_GetMode(I2C_HandleTypeDef *hi2c)
+HAL_I2C_ModeTypeDef HAL_I2C_GetMode(const I2C_HandleTypeDef *hi2c)
 {
   return hi2c->Mode;
 }
@@ -4711,7 +4911,7 @@ HAL_I2C_ModeTypeDef HAL_I2C_GetMode(I2C_HandleTypeDef *hi2c)
   *              the configuration information for the specified I2C.
   * @retval I2C Error Code
   */
-uint32_t HAL_I2C_GetError(I2C_HandleTypeDef *hi2c)
+uint32_t HAL_I2C_GetError(const I2C_HandleTypeDef *hi2c)
 {
   return hi2c->ErrorCode;
 }
@@ -4774,17 +4974,22 @@ static HAL_StatusTypeDef I2C_Master_ISR_IT(struct __I2C_HandleTypeDef *hi2c, uin
     hi2c->XferSize--;
     hi2c->XferCount--;
   }
-  else if ((I2C_CHECK_FLAG(tmpITFlags, I2C_FLAG_TXIS) != RESET) && \
-           (I2C_CHECK_IT_SOURCE(ITSources, I2C_IT_TXI) != RESET))
+  else if ((I2C_CHECK_FLAG(tmpITFlags, I2C_FLAG_TC) == RESET) && \
+           ((I2C_CHECK_FLAG(tmpITFlags, I2C_FLAG_TXIS) != RESET) && \
+            (I2C_CHECK_IT_SOURCE(ITSources, I2C_IT_TXI) != RESET)))
   {
     /* Write data to TXDR */
-    hi2c->Instance->TXDR = *hi2c->pBuffPtr;
+    if (hi2c->XferCount != 0U)
+    {
+      /* Write data to TXDR */
+      hi2c->Instance->TXDR = *hi2c->pBuffPtr;
 
-    /* Increment Buffer pointer */
-    hi2c->pBuffPtr++;
+      /* Increment Buffer pointer */
+      hi2c->pBuffPtr++;
 
-    hi2c->XferSize--;
-    hi2c->XferCount--;
+      hi2c->XferSize--;
+      hi2c->XferCount--;
+    }
   }
   else if ((I2C_CHECK_FLAG(tmpITFlags, I2C_FLAG_TCR) != RESET) && \
            (I2C_CHECK_IT_SOURCE(ITSources, I2C_IT_TCI) != RESET))
@@ -4795,7 +5000,15 @@ static HAL_StatusTypeDef I2C_Master_ISR_IT(struct __I2C_HandleTypeDef *hi2c, uin
 
       if (hi2c->XferCount > MAX_NBYTE_SIZE)
       {
-        hi2c->XferSize = MAX_NBYTE_SIZE;
+        /* Errata workaround 170323 */
+        if (I2C_GET_DIR(hi2c) == I2C_DIRECTION_RECEIVE)
+        {
+          hi2c->XferSize = 1U;
+        }
+        else
+        {
+          hi2c->XferSize = MAX_NBYTE_SIZE;
+        }
         I2C_TransferConfig(hi2c, devaddress, (uint8_t)hi2c->XferSize, I2C_RELOAD_MODE, I2C_NO_STARTSTOP);
       }
       else
@@ -4883,7 +5096,7 @@ static HAL_StatusTypeDef I2C_Master_ISR_IT(struct __I2C_HandleTypeDef *hi2c, uin
   * @retval HAL status
   */
 static HAL_StatusTypeDef I2C_Mem_ISR_IT(struct __I2C_HandleTypeDef *hi2c, uint32_t ITFlags,
-                                           uint32_t ITSources)
+                                        uint32_t ITSources)
 {
   uint32_t direction = I2C_GENERATE_START_WRITE;
   uint32_t tmpITFlags = ITFlags;
@@ -4950,7 +5163,15 @@ static HAL_StatusTypeDef I2C_Mem_ISR_IT(struct __I2C_HandleTypeDef *hi2c, uint32
     {
       if (hi2c->XferCount > MAX_NBYTE_SIZE)
       {
-        hi2c->XferSize = MAX_NBYTE_SIZE;
+        /* Errata workaround 170323 */
+        if (I2C_GET_DIR(hi2c) == I2C_DIRECTION_RECEIVE)
+        {
+          hi2c->XferSize = 1U;
+        }
+        else
+        {
+          hi2c->XferSize = MAX_NBYTE_SIZE;
+        }
         I2C_TransferConfig(hi2c, (uint16_t)hi2c->Devaddress, (uint8_t)hi2c->XferSize,
                            I2C_RELOAD_MODE, I2C_NO_STARTSTOP);
       }
@@ -4971,6 +5192,12 @@ static HAL_StatusTypeDef I2C_Mem_ISR_IT(struct __I2C_HandleTypeDef *hi2c, uint32
   else if ((I2C_CHECK_FLAG(tmpITFlags, I2C_FLAG_TC) != RESET) && \
            (I2C_CHECK_IT_SOURCE(ITSources, I2C_IT_TCI) != RESET))
   {
+    /* Disable Interrupt related to address step */
+    I2C_Disable_IRQ(hi2c, I2C_XFER_TX_IT);
+
+    /* Enable ERR, TC, STOP, NACK and RXI interrupts */
+    I2C_Enable_IRQ(hi2c, I2C_XFER_RX_IT);
+
     if (hi2c->State == HAL_I2C_STATE_BUSY_RX)
     {
       direction = I2C_GENERATE_START_READ;
@@ -4978,7 +5205,15 @@ static HAL_StatusTypeDef I2C_Mem_ISR_IT(struct __I2C_HandleTypeDef *hi2c, uint32
 
     if (hi2c->XferCount > MAX_NBYTE_SIZE)
     {
-      hi2c->XferSize = MAX_NBYTE_SIZE;
+      /* Errata workaround 170323 */
+      if (I2C_GET_DIR(hi2c) == I2C_DIRECTION_RECEIVE)
+      {
+        hi2c->XferSize = 1U;
+      }
+      else
+      {
+        hi2c->XferSize = MAX_NBYTE_SIZE;
+      }
 
       /* Set NBYTES to write and reload if hi2c->XferCount > MAX_NBYTE_SIZE and generate RESTART */
       I2C_TransferConfig(hi2c, (uint16_t)hi2c->Devaddress, (uint8_t)hi2c->XferSize,
@@ -5035,9 +5270,8 @@ static HAL_StatusTypeDef I2C_Slave_ISR_IT(struct __I2C_HandleTypeDef *hi2c, uint
     /* Call I2C Slave complete process */
     I2C_ITSlaveCplt(hi2c, tmpITFlags);
   }
-
-  if ((I2C_CHECK_FLAG(tmpITFlags, I2C_FLAG_AF) != RESET) && \
-      (I2C_CHECK_IT_SOURCE(ITSources, I2C_IT_NACKI) != RESET))
+  else if ((I2C_CHECK_FLAG(tmpITFlags, I2C_FLAG_AF) != RESET) && \
+           (I2C_CHECK_IT_SOURCE(ITSources, I2C_IT_NACKI) != RESET))
   {
     /* Check that I2C transfer finished */
     /* if yes, normal use case, a NACK is sent by the MASTER when Transfer is finished */
@@ -5200,7 +5434,15 @@ static HAL_StatusTypeDef I2C_Master_ISR_DMA(struct __I2C_HandleTypeDef *hi2c, ui
       /* Prepare the new XferSize to transfer */
       if (hi2c->XferCount > MAX_NBYTE_SIZE)
       {
-        hi2c->XferSize = MAX_NBYTE_SIZE;
+        /* Errata workaround 170323 */
+        if (I2C_GET_DIR(hi2c) == I2C_DIRECTION_RECEIVE)
+        {
+          hi2c->XferSize = 1U;
+        }
+        else
+        {
+          hi2c->XferSize = MAX_NBYTE_SIZE;
+        }
         xfermode = I2C_RELOAD_MODE;
       }
       else
@@ -5301,7 +5543,7 @@ static HAL_StatusTypeDef I2C_Master_ISR_DMA(struct __I2C_HandleTypeDef *hi2c, ui
   * @retval HAL status
   */
 static HAL_StatusTypeDef I2C_Mem_ISR_DMA(struct __I2C_HandleTypeDef *hi2c, uint32_t ITFlags,
-                                            uint32_t ITSources)
+                                         uint32_t ITSources)
 {
   uint32_t direction = I2C_GENERATE_START_WRITE;
 
@@ -5337,6 +5579,9 @@ static HAL_StatusTypeDef I2C_Mem_ISR_DMA(struct __I2C_HandleTypeDef *hi2c, uint3
   else if ((I2C_CHECK_FLAG(ITFlags, I2C_FLAG_TCR) != RESET) && \
            (I2C_CHECK_IT_SOURCE(ITSources, I2C_IT_TCI) != RESET))
   {
+    /* Disable Interrupt related to address step */
+    I2C_Disable_IRQ(hi2c, I2C_XFER_TX_IT);
+
     /* Enable only Error interrupt */
     I2C_Enable_IRQ(hi2c, I2C_XFER_ERROR_IT);
 
@@ -5345,7 +5590,15 @@ static HAL_StatusTypeDef I2C_Mem_ISR_DMA(struct __I2C_HandleTypeDef *hi2c, uint3
       /* Prepare the new XferSize to transfer */
       if (hi2c->XferCount > MAX_NBYTE_SIZE)
       {
-        hi2c->XferSize = MAX_NBYTE_SIZE;
+        /* Errata workaround 170323 */
+        if (I2C_GET_DIR(hi2c) == I2C_DIRECTION_RECEIVE)
+        {
+          hi2c->XferSize = 1U;
+        }
+        else
+        {
+          hi2c->XferSize = MAX_NBYTE_SIZE;
+        }
         I2C_TransferConfig(hi2c, (uint16_t)hi2c->Devaddress, (uint8_t)hi2c->XferSize,
                            I2C_RELOAD_MODE, I2C_NO_STARTSTOP);
       }
@@ -5379,6 +5632,12 @@ static HAL_StatusTypeDef I2C_Mem_ISR_DMA(struct __I2C_HandleTypeDef *hi2c, uint3
   else if ((I2C_CHECK_FLAG(ITFlags, I2C_FLAG_TC) != RESET) && \
            (I2C_CHECK_IT_SOURCE(ITSources, I2C_IT_TCI) != RESET))
   {
+    /* Disable Interrupt related to address step */
+    I2C_Disable_IRQ(hi2c, I2C_XFER_TX_IT);
+
+    /* Enable only Error and NACK interrupt for data transfer */
+    I2C_Enable_IRQ(hi2c, I2C_XFER_ERROR_IT);
+
     if (hi2c->State == HAL_I2C_STATE_BUSY_RX)
     {
       direction = I2C_GENERATE_START_READ;
@@ -5386,7 +5645,15 @@ static HAL_StatusTypeDef I2C_Mem_ISR_DMA(struct __I2C_HandleTypeDef *hi2c, uint3
 
     if (hi2c->XferCount > MAX_NBYTE_SIZE)
     {
-      hi2c->XferSize = MAX_NBYTE_SIZE;
+      /* Errata workaround 170323 */
+      if (I2C_GET_DIR(hi2c) == I2C_DIRECTION_RECEIVE)
+      {
+        hi2c->XferSize = 1U;
+      }
+      else
+      {
+        hi2c->XferSize = MAX_NBYTE_SIZE;
+      }
 
       /* Set NBYTES to write and reload if hi2c->XferCount > MAX_NBYTE_SIZE and generate RESTART */
       I2C_TransferConfig(hi2c, (uint16_t)hi2c->Devaddress, (uint8_t)hi2c->XferSize,
@@ -5456,9 +5723,8 @@ static HAL_StatusTypeDef I2C_Slave_ISR_DMA(struct __I2C_HandleTypeDef *hi2c, uin
     /* Call I2C Slave complete process */
     I2C_ITSlaveCplt(hi2c, ITFlags);
   }
-
-  if ((I2C_CHECK_FLAG(ITFlags, I2C_FLAG_AF) != RESET) && \
-      (I2C_CHECK_IT_SOURCE(ITSources, I2C_IT_NACKI) != RESET))
+  else if ((I2C_CHECK_FLAG(ITFlags, I2C_FLAG_AF) != RESET) && \
+           (I2C_CHECK_IT_SOURCE(ITSources, I2C_IT_NACKI) != RESET))
   {
     /* Check that I2C transfer finished */
     /* if yes, normal use case, a NACK is sent by the MASTER when Transfer is finished */
@@ -6057,6 +6323,7 @@ static void I2C_ITSlaveCplt(I2C_HandleTypeDef *hi2c, uint32_t ITFlags)
 {
   uint32_t tmpcr1value = READ_REG(hi2c->Instance->CR1);
   uint32_t tmpITFlags = ITFlags;
+  uint32_t tmpoptions = hi2c->XferOptions;
   HAL_I2C_StateTypeDef tmpstate = hi2c->State;
 
   /* Clear STOP Flag */
@@ -6072,6 +6339,11 @@ static void I2C_ITSlaveCplt(I2C_HandleTypeDef *hi2c, uint32_t ITFlags)
   {
     I2C_Disable_IRQ(hi2c, I2C_XFER_LISTEN_IT | I2C_XFER_RX_IT);
     hi2c->PreviousState = I2C_STATE_SLAVE_BUSY_RX;
+  }
+  else if (tmpstate == HAL_I2C_STATE_LISTEN)
+  {
+    I2C_Disable_IRQ(hi2c, I2C_XFER_LISTEN_IT | I2C_XFER_TX_IT | I2C_XFER_RX_IT);
+    hi2c->PreviousState = I2C_STATE_NONE;
   }
   else
   {
@@ -6137,6 +6409,57 @@ static void I2C_ITSlaveCplt(I2C_HandleTypeDef *hi2c, uint32_t ITFlags)
   {
     /* Set ErrorCode corresponding to a Non-Acknowledge */
     hi2c->ErrorCode |= HAL_I2C_ERROR_AF;
+  }
+
+  if ((I2C_CHECK_FLAG(tmpITFlags, I2C_FLAG_AF) != RESET) && \
+      (I2C_CHECK_IT_SOURCE(tmpcr1value, I2C_IT_NACKI) != RESET))
+  {
+    /* Check that I2C transfer finished */
+    /* if yes, normal use case, a NACK is sent by the MASTER when Transfer is finished */
+    /* Mean XferCount == 0*/
+    /* So clear Flag NACKF only */
+    if (hi2c->XferCount == 0U)
+    {
+      if ((hi2c->State == HAL_I2C_STATE_LISTEN) && (tmpoptions == I2C_FIRST_AND_LAST_FRAME))
+        /* Same action must be done for (tmpoptions == I2C_LAST_FRAME) which removed for
+           Warning[Pa134]: left and right operands are identical */
+      {
+        /* Call I2C Listen complete process */
+        I2C_ITListenCplt(hi2c, tmpITFlags);
+      }
+      else if ((hi2c->State == HAL_I2C_STATE_BUSY_TX_LISTEN) && (tmpoptions != I2C_NO_OPTION_FRAME))
+      {
+        /* Clear NACK Flag */
+        __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_AF);
+
+        /* Flush TX register */
+        I2C_Flush_TXDR(hi2c);
+
+        /* Last Byte is Transmitted */
+        /* Call I2C Slave Sequential complete process */
+        I2C_ITSlaveSeqCplt(hi2c);
+      }
+      else
+      {
+        /* Clear NACK Flag */
+        __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_AF);
+      }
+    }
+    else
+    {
+      /* if no, error use case, a Non-Acknowledge of last Data is generated by the MASTER*/
+      /* Clear NACK Flag */
+      __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_AF);
+
+      /* Set ErrorCode corresponding to a Non-Acknowledge */
+      hi2c->ErrorCode |= HAL_I2C_ERROR_AF;
+
+      if ((tmpoptions == I2C_FIRST_FRAME) || (tmpoptions == I2C_NEXT_FRAME))
+      {
+        /* Call the corresponding callback to inform upper layer of End of Transfer */
+        I2C_ITError(hi2c, hi2c->ErrorCode);
+      }
+    }
   }
 
   hi2c->Mode = HAL_I2C_MODE_NONE;
@@ -6266,6 +6589,7 @@ static void I2C_ITListenCplt(I2C_HandleTypeDef *hi2c, uint32_t ITFlags)
 static void I2C_ITError(I2C_HandleTypeDef *hi2c, uint32_t ErrorCode)
 {
   HAL_I2C_StateTypeDef tmpstate = hi2c->State;
+
   uint32_t tmppreviousstate;
 
   /* Reset handle parameters */
@@ -6293,18 +6617,36 @@ static void I2C_ITError(I2C_HandleTypeDef *hi2c, uint32_t ErrorCode)
     /* Disable all interrupts */
     I2C_Disable_IRQ(hi2c, I2C_XFER_LISTEN_IT | I2C_XFER_RX_IT | I2C_XFER_TX_IT);
 
+    /* Flush TX register */
+    I2C_Flush_TXDR(hi2c);
+
     /* If state is an abort treatment on going, don't change state */
     /* This change will be do later */
     if (hi2c->State != HAL_I2C_STATE_ABORT)
     {
       /* Set HAL_I2C_STATE_READY */
       hi2c->State         = HAL_I2C_STATE_READY;
+
+      /* Check if a STOPF is detected */
+      if (__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_STOPF) == SET)
+      {
+        if (__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_AF) == SET)
+        {
+          __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_AF);
+          hi2c->ErrorCode |= HAL_I2C_ERROR_AF;
+        }
+
+        /* Clear STOP Flag */
+        __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
+      }
+
     }
     hi2c->XferISR       = NULL;
   }
 
   /* Abort DMA TX transfer if any */
   tmppreviousstate = hi2c->PreviousState;
+
   if ((hi2c->hdmatx != NULL) && ((tmppreviousstate == I2C_STATE_MASTER_BUSY_TX) || \
                                  (tmppreviousstate == I2C_STATE_SLAVE_BUSY_TX)))
   {
@@ -6479,6 +6821,7 @@ static void I2C_DMAMasterTransmitCplt(DMA_HandleTypeDef *hdma)
   }
 }
 
+
 /**
   * @brief  DMA I2C slave transmit process complete callback.
   * @param  hdma DMA handle
@@ -6506,6 +6849,7 @@ static void I2C_DMASlaveTransmitCplt(DMA_HandleTypeDef *hdma)
     /* So STOP condition should be manage through Interrupt treatment */
   }
 }
+
 
 /**
   * @brief DMA I2C master receive process complete callback.
@@ -6535,7 +6879,15 @@ static void I2C_DMAMasterReceiveCplt(DMA_HandleTypeDef *hdma)
     /* Set the XferSize to transfer */
     if (hi2c->XferCount > MAX_NBYTE_SIZE)
     {
-      hi2c->XferSize = MAX_NBYTE_SIZE;
+      /* Errata workaround 170323 */
+      if (I2C_GET_DIR(hi2c) == I2C_DIRECTION_RECEIVE)
+      {
+        hi2c->XferSize = 1U;
+      }
+      else
+      {
+        hi2c->XferSize = MAX_NBYTE_SIZE;
+      }
     }
     else
     {
@@ -6556,6 +6908,7 @@ static void I2C_DMAMasterReceiveCplt(DMA_HandleTypeDef *hdma)
     }
   }
 }
+
 
 /**
   * @brief  DMA I2C slave receive process complete callback.
@@ -6584,6 +6937,7 @@ static void I2C_DMASlaveReceiveCplt(DMA_HandleTypeDef *hdma)
     /* So STOP condition should be manage through Interrupt treatment */
   }
 }
+
 
 /**
   * @brief  DMA I2C communication error callback.
@@ -6623,6 +6977,7 @@ static void I2C_DMAError(DMA_HandleTypeDef *hdma)
   }
 }
 
+
 /**
   * @brief DMA I2C communication abort callback
   *        (To be called at end of DMA Abort procedure).
@@ -6647,6 +7002,7 @@ static void I2C_DMAAbort(DMA_HandleTypeDef *hdma)
   I2C_TreatErrorCallback(hi2c);
 }
 
+
 /**
   * @brief  This function handles I2C Communication Timeout. It waits
   *                until a flag is no longer in the specified status.
@@ -6663,18 +7019,27 @@ static HAL_StatusTypeDef I2C_WaitOnFlagUntilTimeout(I2C_HandleTypeDef *hi2c, uin
 {
   while (__HAL_I2C_GET_FLAG(hi2c, Flag) == Status)
   {
+    /* Check if an error is detected */
+    if (I2C_IsErrorOccurred(hi2c, Timeout, Tickstart) != HAL_OK)
+    {
+      return HAL_ERROR;
+    }
+
     /* Check for the Timeout */
     if (Timeout != HAL_MAX_DELAY)
     {
       if (((HAL_GetTick() - Tickstart) > Timeout) || (Timeout == 0U))
       {
-        hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
-        hi2c->State = HAL_I2C_STATE_READY;
-        hi2c->Mode = HAL_I2C_MODE_NONE;
+        if ((__HAL_I2C_GET_FLAG(hi2c, Flag) == Status))
+        {
+          hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+          hi2c->State = HAL_I2C_STATE_READY;
+          hi2c->Mode = HAL_I2C_MODE_NONE;
 
-        /* Process Unlocked */
-        __HAL_UNLOCK(hi2c);
-        return HAL_ERROR;
+          /* Process Unlocked */
+          __HAL_UNLOCK(hi2c);
+          return HAL_ERROR;
+        }
       }
     }
   }
@@ -6705,14 +7070,17 @@ static HAL_StatusTypeDef I2C_WaitOnTXISFlagUntilTimeout(I2C_HandleTypeDef *hi2c,
     {
       if (((HAL_GetTick() - Tickstart) > Timeout) || (Timeout == 0U))
       {
-        hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
-        hi2c->State = HAL_I2C_STATE_READY;
-        hi2c->Mode = HAL_I2C_MODE_NONE;
+        if ((__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_TXIS) == RESET))
+        {
+          hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+          hi2c->State = HAL_I2C_STATE_READY;
+          hi2c->Mode = HAL_I2C_MODE_NONE;
 
-        /* Process Unlocked */
-        __HAL_UNLOCK(hi2c);
+          /* Process Unlocked */
+          __HAL_UNLOCK(hi2c);
 
-        return HAL_ERROR;
+          return HAL_ERROR;
+        }
       }
     }
   }
@@ -6741,14 +7109,17 @@ static HAL_StatusTypeDef I2C_WaitOnSTOPFlagUntilTimeout(I2C_HandleTypeDef *hi2c,
     /* Check for the Timeout */
     if (((HAL_GetTick() - Tickstart) > Timeout) || (Timeout == 0U))
     {
-      hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
-      hi2c->State = HAL_I2C_STATE_READY;
-      hi2c->Mode = HAL_I2C_MODE_NONE;
+      if ((__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_STOPF) == RESET))
+      {
+        hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+        hi2c->State = HAL_I2C_STATE_READY;
+        hi2c->Mode = HAL_I2C_MODE_NONE;
 
-      /* Process Unlocked */
-      __HAL_UNLOCK(hi2c);
+        /* Process Unlocked */
+        __HAL_UNLOCK(hi2c);
 
-      return HAL_ERROR;
+        return HAL_ERROR;
+      }
     }
   }
   return HAL_OK;
@@ -6765,16 +7136,18 @@ static HAL_StatusTypeDef I2C_WaitOnSTOPFlagUntilTimeout(I2C_HandleTypeDef *hi2c,
 static HAL_StatusTypeDef I2C_WaitOnRXNEFlagUntilTimeout(I2C_HandleTypeDef *hi2c, uint32_t Timeout,
                                                         uint32_t Tickstart)
 {
-  while (__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_RXNE) == RESET)
+  HAL_StatusTypeDef status = HAL_OK;
+
+  while ((__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_RXNE) == RESET) && (status == HAL_OK))
   {
     /* Check if an error is detected */
     if (I2C_IsErrorOccurred(hi2c, Timeout, Tickstart) != HAL_OK)
     {
-      return HAL_ERROR;
+      status = HAL_ERROR;
     }
 
     /* Check if a STOPF is detected */
-    if (__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_STOPF) == SET)
+    if ((__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_STOPF) == SET) && (status == HAL_OK))
     {
       /* Check if an RXNE is pending */
       /* Store Last receive data if any */
@@ -6782,19 +7155,14 @@ static HAL_StatusTypeDef I2C_WaitOnRXNEFlagUntilTimeout(I2C_HandleTypeDef *hi2c,
       {
         /* Return HAL_OK */
         /* The Reading of data from RXDR will be done in caller function */
-        return HAL_OK;
+        status = HAL_OK;
       }
-      else
+
+      /* Check a no-acknowledge have been detected */
+      if (__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_AF) == SET)
       {
-        if (__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_AF) == SET)
-        {
-          __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_AF);
-          hi2c->ErrorCode = HAL_I2C_ERROR_AF;
-        }
-        else
-        {
-          hi2c->ErrorCode = HAL_I2C_ERROR_NONE;
-        }
+        __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_AF);
+        hi2c->ErrorCode = HAL_I2C_ERROR_AF;
 
         /* Clear STOP Flag */
         __HAL_I2C_CLEAR_FLAG(hi2c, I2C_FLAG_STOPF);
@@ -6808,23 +7176,30 @@ static HAL_StatusTypeDef I2C_WaitOnRXNEFlagUntilTimeout(I2C_HandleTypeDef *hi2c,
         /* Process Unlocked */
         __HAL_UNLOCK(hi2c);
 
-        return HAL_ERROR;
+        status = HAL_ERROR;
+      }
+      else
+      {
+        hi2c->ErrorCode = HAL_I2C_ERROR_NONE;
       }
     }
 
     /* Check for the Timeout */
-    if (((HAL_GetTick() - Tickstart) > Timeout) || (Timeout == 0U))
+    if ((((HAL_GetTick() - Tickstart) > Timeout) || (Timeout == 0U)) && (status == HAL_OK))
     {
-      hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
-      hi2c->State = HAL_I2C_STATE_READY;
+      if ((__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_RXNE) == RESET))
+      {
+        hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
+        hi2c->State = HAL_I2C_STATE_READY;
 
-      /* Process Unlocked */
-      __HAL_UNLOCK(hi2c);
+        /* Process Unlocked */
+        __HAL_UNLOCK(hi2c);
 
-      return HAL_ERROR;
+        status = HAL_ERROR;
+      }
     }
   }
-  return HAL_OK;
+  return status;
 }
 
 /**
@@ -6878,7 +7253,7 @@ static HAL_StatusTypeDef I2C_IsErrorOccurred(I2C_HandleTypeDef *hi2c, uint32_t T
             /* Check for the Timeout */
             if ((HAL_GetTick() - tickstart) > I2C_TIMEOUT_STOPF)
             {
-              error_code |=HAL_I2C_ERROR_TIMEOUT;
+              error_code |= HAL_I2C_ERROR_TIMEOUT;
 
               status = HAL_ERROR;
 
@@ -7007,13 +7382,59 @@ static void I2C_Enable_IRQ(I2C_HandleTypeDef *hi2c, uint16_t InterruptRequest)
 {
   uint32_t tmpisr = 0U;
 
-  if ((hi2c->XferISR == I2C_Master_ISR_DMA) || \
-      (hi2c->XferISR == I2C_Slave_ISR_DMA))
+  if ((hi2c->XferISR != I2C_Master_ISR_DMA) && \
+      (hi2c->XferISR != I2C_Slave_ISR_DMA) && \
+      (hi2c->XferISR != I2C_Mem_ISR_DMA))
   {
     if ((InterruptRequest & I2C_XFER_LISTEN_IT) == I2C_XFER_LISTEN_IT)
     {
       /* Enable ERR, STOP, NACK and ADDR interrupts */
       tmpisr |= I2C_IT_ADDRI | I2C_IT_STOPI | I2C_IT_NACKI | I2C_IT_ERRI;
+    }
+
+    if ((InterruptRequest & I2C_XFER_TX_IT) == I2C_XFER_TX_IT)
+    {
+      /* Enable ERR, TC, STOP, NACK and TXI interrupts */
+      tmpisr |= I2C_IT_ERRI | I2C_IT_TCI | I2C_IT_STOPI | I2C_IT_NACKI | I2C_IT_TXI;
+    }
+
+    if ((InterruptRequest & I2C_XFER_RX_IT) == I2C_XFER_RX_IT)
+    {
+      /* Enable ERR, TC, STOP, NACK and RXI interrupts */
+      tmpisr |= I2C_IT_ERRI | I2C_IT_TCI | I2C_IT_STOPI | I2C_IT_NACKI | I2C_IT_RXI;
+    }
+
+    if (InterruptRequest == I2C_XFER_ERROR_IT)
+    {
+      /* Enable ERR and NACK interrupts */
+      tmpisr |= I2C_IT_ERRI | I2C_IT_NACKI;
+    }
+
+    if (InterruptRequest == I2C_XFER_CPLT_IT)
+    {
+      /* Enable STOP interrupts */
+      tmpisr |= I2C_IT_STOPI;
+    }
+  }
+
+  else
+  {
+    if ((InterruptRequest & I2C_XFER_LISTEN_IT) == I2C_XFER_LISTEN_IT)
+    {
+      /* Enable ERR, STOP, NACK and ADDR interrupts */
+      tmpisr |= I2C_IT_ADDRI | I2C_IT_STOPI | I2C_IT_NACKI | I2C_IT_ERRI;
+    }
+
+    if ((InterruptRequest & I2C_XFER_TX_IT) == I2C_XFER_TX_IT)
+    {
+      /* Enable ERR, TC, STOP, NACK and TXI interrupts */
+      tmpisr |= I2C_IT_ERRI | I2C_IT_TCI | I2C_IT_STOPI | I2C_IT_NACKI | I2C_IT_TXI;
+    }
+
+    if ((InterruptRequest & I2C_XFER_RX_IT) == I2C_XFER_RX_IT)
+    {
+      /* Enable ERR, TC, STOP, NACK and RXI interrupts */
+      tmpisr |= I2C_IT_ERRI | I2C_IT_TCI | I2C_IT_STOPI | I2C_IT_NACKI | I2C_IT_RXI;
     }
 
     if (InterruptRequest == I2C_XFER_ERROR_IT)
@@ -7032,38 +7453,6 @@ static void I2C_Enable_IRQ(I2C_HandleTypeDef *hi2c, uint16_t InterruptRequest)
     {
       /* Enable TC interrupts */
       tmpisr |= I2C_IT_TCI;
-    }
-  }
-  else
-  {
-    if ((InterruptRequest & I2C_XFER_LISTEN_IT) == I2C_XFER_LISTEN_IT)
-    {
-      /* Enable ERR, STOP, NACK, and ADDR interrupts */
-      tmpisr |= I2C_IT_ADDRI | I2C_IT_STOPI | I2C_IT_NACKI | I2C_IT_ERRI;
-    }
-
-    if ((InterruptRequest & I2C_XFER_TX_IT) == I2C_XFER_TX_IT)
-    {
-      /* Enable ERR, TC, STOP, NACK and RXI interrupts */
-      tmpisr |= I2C_IT_ERRI | I2C_IT_TCI | I2C_IT_STOPI | I2C_IT_NACKI | I2C_IT_TXI;
-    }
-
-    if ((InterruptRequest & I2C_XFER_RX_IT) == I2C_XFER_RX_IT)
-    {
-      /* Enable ERR, TC, STOP, NACK and TXI interrupts */
-      tmpisr |= I2C_IT_ERRI | I2C_IT_TCI | I2C_IT_STOPI | I2C_IT_NACKI | I2C_IT_RXI;
-    }
-
-    if (InterruptRequest == I2C_XFER_ERROR_IT)
-    {
-      /* Enable ERR and NACK interrupts */
-      tmpisr |= I2C_IT_ERRI | I2C_IT_NACKI;
-    }
-
-    if (InterruptRequest == I2C_XFER_CPLT_IT)
-    {
-      /* Enable STOP interrupts */
-      tmpisr |= I2C_IT_STOPI;
     }
   }
 

--- a/lib/STM32F7xx_HAL_Driver/Src/stm32f7xx_hal_pwr.c
+++ b/lib/STM32F7xx_HAL_Driver/Src/stm32f7xx_hal_pwr.c
@@ -389,6 +389,9 @@ void HAL_PWR_EnterSLEEPMode(uint32_t Regulator, uint8_t SLEEPEntry)
   assert_param(IS_PWR_REGULATOR(Regulator));
   assert_param(IS_PWR_SLEEP_ENTRY(SLEEPEntry));
 
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(Regulator);
+
   /* Clear SLEEPDEEP bit of Cortex System Control Register */
   CLEAR_BIT(SCB->SCR, ((uint32_t)SCB_SCR_SLEEPDEEP_Msk));
 

--- a/lib/STM32F7xx_HAL_Driver/Src/stm32f7xx_hal_rtc.c
+++ b/lib/STM32F7xx_HAL_Driver/Src/stm32f7xx_hal_rtc.c
@@ -1,0 +1,1920 @@
+/**
+  ******************************************************************************
+  * @file    stm32f7xx_hal_rtc.c
+  * @author  MCD Application Team
+  * @brief   RTC HAL module driver.
+  *          This file provides firmware functions to manage the following
+  *          functionalities of the Real-Time Clock (RTC) peripheral:
+  *           + Initialization and de-initialization functions
+  *           + RTC Calendar (Time and Date) configuration functions
+  *           + RTC Alarms (Alarm A and Alarm B) configuration functions
+  *           + Peripheral Control functions
+  *           + Peripheral State functions
+  *
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2017 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
+  @verbatim
+  ==============================================================================
+               ##### RTC and Backup Domain Operating Condition #####
+  ==============================================================================
+  [..] The real-time clock (RTC), the RTC backup registers, and the backup
+       SRAM (BKP SRAM) can be powered from the VBAT voltage when the main
+       VDD supply is powered off.
+       To retain the content of the RTC backup registers, BKP SRAM, and supply
+       the RTC when VDD is turned off, VBAT pin can be connected to an optional
+       standby voltage supplied by a battery or by another source.
+
+  [..] To allow the RTC operating even when the main digital supply (VDD) is turned
+       off, the VBAT pin powers the following blocks:
+    (#) The RTC
+    (#) The LSE oscillator
+    (#) The BKP SRAM when the low power backup regulator is enabled
+    (#) PC13 to PC15 I/Os, plus PI8 and PC1 I/Os (when available)
+
+  [..] When the backup domain is supplied by VDD (analog switch connected to VDD),
+       the following pins are available:
+    (#) PC14 and PC15 can be used as either GPIO or LSE pins
+    (#) PC13 can be used as a GPIO or as the RTC_AF1 pin
+    (#) PI8 can be used as a GPIO or as the RTC_AF2 pin
+    (#) PC1 can be used as a GPIO or as the RTC_AF3 pin
+
+  [..] When the backup domain is supplied by VBAT (analog switch connected to VBAT
+       because VDD is not present), the following pins are available:
+    (#) PC14 and PC15 can be used as LSE pins only
+    (#) PC13 can be used as the RTC_AF1 pin
+    (#) PI8 can be used as the RTC_AF2 pin
+    (#) PC1 can be used as the RTC_AF3 pin
+
+                   ##### Backup Domain Reset #####
+  ==================================================================
+  [..] The backup domain reset sets all RTC registers and the RCC_BDCR register
+       to their reset values.
+       The BKP SRAM is not affected by this reset. The only way to reset the BKP
+       SRAM is through the Flash interface by requesting a protection level
+       change from 1 to 0.
+  [..] A backup domain reset is generated when one of the following events occurs:
+    (#) Software reset, triggered by setting the BDRST bit in the
+        RCC Backup domain control register (RCC_BDCR).
+    (#) VDD or VBAT power on, if both supplies have previously been powered off.
+    (#) Tamper detection event resets all data backup registers.
+
+                   ##### Backup Domain Access #####
+  ==================================================================
+  [..] After reset, the backup domain (RTC registers, RTC backup data registers
+       and BKP SRAM) is protected against possible unwanted write accesses.
+  [..] To enable access to the RTC Domain and RTC registers, proceed as follows:
+    (+) Enable the Power Controller (PWR) APB1 interface clock using the
+        __HAL_RCC_PWR_CLK_ENABLE() macro.
+    (+) Enable access to RTC domain using the HAL_PWR_EnableBkUpAccess() function.
+    (+) Select the RTC clock source using the __HAL_RCC_RTC_CONFIG() macro.
+    (+) Enable RTC Clock using the __HAL_RCC_RTC_ENABLE() macro.
+
+  ==============================================================================
+                        ##### How to use this driver #####
+  ==============================================================================
+  [..]
+    (+) Enable the RTC domain access (see description in the section above).
+    (+) Configure the RTC Prescaler (Asynchronous and Synchronous) and RTC hour
+        format using the HAL_RTC_Init() function.
+
+  *** Time and Date configuration ***
+  ===================================
+  [..]
+    (+) To configure the RTC Calendar (Time and Date) use the HAL_RTC_SetTime()
+        and HAL_RTC_SetDate() functions.
+    (+) To read the RTC Calendar, use the HAL_RTC_GetTime() and HAL_RTC_GetDate()
+        functions.
+    (+) To manage the RTC summer or winter time change, use the following
+        functions:
+        (++) HAL_RTC_DST_Add1Hour() or HAL_RTC_DST_Sub1Hour to add or subtract
+             1 hour from the calendar time.
+        (++) HAL_RTC_DST_SetStoreOperation() or HAL_RTC_DST_ClearStoreOperation
+             to memorize whether the time change has been performed or not.
+
+  *** Alarm configuration ***
+  ===========================
+  [..]
+    (+) To configure the RTC Alarm use the HAL_RTC_SetAlarm() function.
+        You can also configure the RTC Alarm with interrupt mode using the
+        HAL_RTC_SetAlarm_IT() function.
+    (+) To read the RTC Alarm, use the HAL_RTC_GetAlarm() function.
+
+                  ##### RTC and low power modes #####
+  ==================================================================
+  [..] The MCU can be woken up from a low power mode by an RTC alternate
+       function.
+  [..] The RTC alternate functions are the RTC alarms (Alarm A and Alarm B),
+       RTC wakeup, RTC tamper event detection and RTC timestamp event detection.
+       These RTC alternate functions can wake up the system from the Stop and
+       Standby low power modes.
+  [..] The system can also wake up from low power modes without depending
+       on an external interrupt (Auto-wakeup mode), by using the RTC alarm
+       or the RTC wakeup events.
+  [..] The RTC provides a programmable time base for waking up from the
+       Stop or Standby mode at regular intervals.
+       Wakeup from STOP and STANDBY modes is possible only when the RTC clock
+       source is LSE or LSI.
+
+  *** Callback registration ***
+  =============================================
+  [..]
+  The compilation define  USE_HAL_RTC_REGISTER_CALLBACKS when set to 1
+  allows the user to configure dynamically the driver callbacks.
+  Use Function HAL_RTC_RegisterCallback() to register an interrupt callback.
+  [..]
+  Function HAL_RTC_RegisterCallback() allows to register following callbacks:
+    (+) AlarmAEventCallback          : RTC Alarm A Event callback.
+    (+) AlarmBEventCallback          : RTC Alarm B Event callback.
+    (+) TimeStampEventCallback       : RTC Timestamp Event callback.
+    (+) WakeUpTimerEventCallback     : RTC WakeUpTimer Event callback.
+    (+) Tamper1EventCallback         : RTC Tamper 1 Event callback.
+    (+) Tamper2EventCallback         : RTC Tamper 2 Event callback.
+    (+) Tamper3EventCallback         : RTC Tamper 3 Event callback.
+    (+) MspInitCallback              : RTC MspInit callback.
+    (+) MspDeInitCallback            : RTC MspDeInit callback.
+  [..]
+  This function takes as parameters the HAL peripheral handle, the Callback ID
+  and a pointer to the user callback function.
+  [..]
+  Use function HAL_RTC_UnRegisterCallback() to reset a callback to the default
+  weak function.
+  HAL_RTC_UnRegisterCallback() takes as parameters the HAL peripheral handle,
+  and the Callback ID.
+  This function allows to reset following callbacks:
+    (+) AlarmAEventCallback          : RTC Alarm A Event callback.
+    (+) AlarmBEventCallback          : RTC Alarm B Event callback.
+    (+) TimeStampEventCallback       : RTC Timestamp Event callback.
+    (+) WakeUpTimerEventCallback     : RTC WakeUpTimer Event callback.
+    (+) Tamper1EventCallback         : RTC Tamper 1 Event callback.
+    (+) Tamper2EventCallback         : RTC Tamper 2 Event callback.
+    (+) Tamper3EventCallback         : RTC Tamper 3 Event callback.
+    (+) MspInitCallback              : RTC MspInit callback.
+    (+) MspDeInitCallback            : RTC MspDeInit callback.
+  [..]
+  By default, after the HAL_RTC_Init() and when the state is HAL_RTC_STATE_RESET,
+  all callbacks are set to the corresponding weak functions:
+  examples AlarmAEventCallback(), WakeUpTimerEventCallback().
+  Exception done for MspInit() and MspDeInit() callbacks that are reset to the
+  legacy weak function in the HAL_RTC_Init()/HAL_RTC_DeInit() only
+  when these callbacks are null (not registered beforehand).
+  If not, MspInit() or MspDeInit() are not null, HAL_RTC_Init()/HAL_RTC_DeInit()
+  keep and use the user MspInit()/MspDeInit() callbacks (registered beforehand).
+  [..]
+  Callbacks can be registered/unregistered in HAL_RTC_STATE_READY state only.
+  Exception done MspInit()/MspDeInit() that can be registered/unregistered
+  in HAL_RTC_STATE_READY or HAL_RTC_STATE_RESET state.
+  Thus registered (user) MspInit()/MspDeInit() callbacks can be used during the
+  Init/DeInit.
+  In that case first register the MspInit()/MspDeInit() user callbacks
+  using HAL_RTC_RegisterCallback() before calling HAL_RTC_DeInit()
+  or HAL_RTC_Init() functions.
+  [..]
+  When The compilation define USE_HAL_RTC_REGISTER_CALLBACKS is set to 0 or
+  not defined, the callback registration feature is not available and all
+  callbacks are set to the corresponding weak functions.
+
+  @endverbatim
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f7xx_hal.h"
+
+/** @addtogroup STM32F7xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup RTC RTC
+  * @brief    RTC HAL module driver
+  * @{
+  */
+
+#ifdef HAL_RTC_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* Exported functions --------------------------------------------------------*/
+
+/** @defgroup RTC_Exported_Functions RTC Exported Functions
+  * @{
+  */
+
+/** @defgroup RTC_Exported_Functions_Group1 Initialization and de-initialization functions
+  * @brief    Initialization and Configuration functions
+  *
+@verbatim
+ ===============================================================================
+              ##### Initialization and de-initialization functions #####
+ ===============================================================================
+   [..] This section provides functions allowing to initialize and configure the
+         RTC Prescaler (Synchronous and Asynchronous), RTC Hour format, disable
+         RTC registers Write protection, enter and exit the RTC initialization mode,
+         RTC registers synchronization check and reference clock detection enable.
+         (#) The RTC Prescaler is programmed to generate the RTC 1Hz time base.
+             It is split into 2 programmable prescalers to minimize power consumption.
+             (++) A 7-bit asynchronous prescaler and a 15-bit synchronous prescaler.
+             (++) When both prescalers are used, it is recommended to configure the
+                 asynchronous prescaler to a high value to minimize power consumption.
+         (#) All RTC registers are Write protected. Writing to the RTC registers
+             is enabled by writing a key into the Write Protection register, RTC_WPR.
+         (#) To configure the RTC Calendar, user application should enter
+             initialization mode. In this mode, the calendar counter is stopped
+             and its value can be updated. When the initialization sequence is
+             complete, the calendar restarts counting after 4 RTCCLK cycles.
+         (#) To read the calendar through the shadow registers after Calendar
+             initialization, calendar update or after wakeup from low power modes
+             the software must first clear the RSF flag. The software must then
+             wait until it is set again before reading the calendar, which means
+             that the calendar registers have been correctly copied into the
+             RTC_TR and RTC_DR shadow registers. The HAL_RTC_WaitForSynchro() function
+             implements the above software sequence (RSF clear and RSF check).
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Initializes the RTC peripheral
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTC_Init(RTC_HandleTypeDef *hrtc)
+{
+  HAL_StatusTypeDef status = HAL_ERROR;
+
+  /* Check RTC handler validity */
+  if (hrtc == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Check the parameters */
+  assert_param(IS_RTC_ALL_INSTANCE(hrtc->Instance));
+  assert_param(IS_RTC_HOUR_FORMAT(hrtc->Init.HourFormat));
+  assert_param(IS_RTC_ASYNCH_PREDIV(hrtc->Init.AsynchPrediv));
+  assert_param(IS_RTC_SYNCH_PREDIV(hrtc->Init.SynchPrediv));
+  assert_param(IS_RTC_OUTPUT(hrtc->Init.OutPut));
+  assert_param(IS_RTC_OUTPUT_POL(hrtc->Init.OutPutPolarity));
+  assert_param(IS_RTC_OUTPUT_TYPE(hrtc->Init.OutPutType));
+
+#if (USE_HAL_RTC_REGISTER_CALLBACKS == 1)
+  if (hrtc->State == HAL_RTC_STATE_RESET)
+  {
+    /* Allocate lock resource and initialize it */
+    hrtc->Lock = HAL_UNLOCKED;
+
+    hrtc->AlarmAEventCallback          =  HAL_RTC_AlarmAEventCallback;        /* Legacy weak AlarmAEventCallback      */
+    hrtc->AlarmBEventCallback          =  HAL_RTCEx_AlarmBEventCallback;      /* Legacy weak AlarmBEventCallback      */
+    hrtc->TimeStampEventCallback       =  HAL_RTCEx_TimeStampEventCallback;   /* Legacy weak TimeStampEventCallback   */
+    hrtc->WakeUpTimerEventCallback     =  HAL_RTCEx_WakeUpTimerEventCallback; /* Legacy weak WakeUpTimerEventCallback */
+    hrtc->Tamper1EventCallback         =  HAL_RTCEx_Tamper1EventCallback;     /* Legacy weak Tamper1EventCallback     */
+    hrtc->Tamper2EventCallback         =  HAL_RTCEx_Tamper2EventCallback;     /* Legacy weak Tamper2EventCallback     */
+    hrtc->Tamper3EventCallback         =  HAL_RTCEx_Tamper3EventCallback;     /* Legacy weak Tamper3EventCallback     */
+
+    if (hrtc->MspInitCallback == NULL)
+    {
+      hrtc->MspInitCallback = HAL_RTC_MspInit;
+    }
+    /* Init the low level hardware */
+    hrtc->MspInitCallback(hrtc);
+
+    if (hrtc->MspDeInitCallback == NULL)
+    {
+      hrtc->MspDeInitCallback = HAL_RTC_MspDeInit;
+    }
+  }
+#else /* USE_HAL_RTC_REGISTER_CALLBACKS */
+  if (hrtc->State == HAL_RTC_STATE_RESET)
+  {
+    /* Allocate lock resource and initialize it */
+    hrtc->Lock = HAL_UNLOCKED;
+
+    /* Initialize RTC MSP */
+    HAL_RTC_MspInit(hrtc);
+  }
+#endif /* USE_HAL_RTC_REGISTER_CALLBACKS */
+
+  /* Set RTC state */
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Check whether the calendar needs to be initialized */
+  if (__HAL_RTC_IS_CALENDAR_INITIALIZED(hrtc) == 0U)
+  {
+    /* Disable the write protection for RTC registers */
+    __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+    /* Enter Initialization mode */
+    status = RTC_EnterInitMode(hrtc);
+
+    if (status == HAL_OK)
+    {
+      /* Clear RTC_CR FMT, OSEL and POL Bits */
+      hrtc->Instance->CR &= ((uint32_t)~(RTC_CR_FMT | RTC_CR_OSEL | RTC_CR_POL));
+      /* Set RTC_CR register */
+      hrtc->Instance->CR |= (uint32_t)(hrtc->Init.HourFormat | hrtc->Init.OutPut | hrtc->Init.OutPutPolarity);
+
+      /* Configure the RTC PRER */
+      hrtc->Instance->PRER = (uint32_t)(hrtc->Init.SynchPrediv);
+      hrtc->Instance->PRER |= (uint32_t)(hrtc->Init.AsynchPrediv << RTC_PRER_PREDIV_A_Pos);
+
+      /* Exit Initialization mode */
+      status = RTC_ExitInitMode(hrtc);
+    }
+
+    if (status == HAL_OK)
+    {
+      hrtc->Instance->OR &= (uint32_t)~RTC_OUTPUT_TYPE_PUSHPULL;
+      hrtc->Instance->OR |= (uint32_t)(hrtc->Init.OutPutType);
+    }
+
+    /* Enable the write protection for RTC registers */
+    __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+  }
+  else
+  {
+    /* The calendar is already initialized */
+    status = HAL_OK;
+  }
+
+  if (status == HAL_OK)
+  {
+    hrtc->State = HAL_RTC_STATE_READY;
+  }
+
+  return status;
+}
+
+/**
+  * @brief  DeInitializes the RTC peripheral
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @note   This function does not reset the RTC Backup Data registers.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTC_DeInit(RTC_HandleTypeDef *hrtc)
+{
+  HAL_StatusTypeDef status = HAL_ERROR;
+
+  /* Check the parameters */
+  assert_param(IS_RTC_ALL_INSTANCE(hrtc->Instance));
+
+  /* Set RTC state */
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  /* Enter Initialization mode */
+  status = RTC_EnterInitMode(hrtc);
+
+  if (status == HAL_OK)
+  {
+    /* Reset RTC registers */
+    hrtc->Instance->TR = 0x00000000U;
+    hrtc->Instance->DR = (RTC_DR_WDU_0 | RTC_DR_MU_0 | RTC_DR_DU_0);
+    hrtc->Instance->CR  &= 0x00000000U;
+    hrtc->Instance->WUTR = RTC_WUTR_WUT;
+    hrtc->Instance->PRER = (uint32_t)(RTC_PRER_PREDIV_A | 0x000000FFU);
+    hrtc->Instance->ALRMAR   = 0x00000000U;
+    hrtc->Instance->ALRMBR   = 0x00000000U;
+    hrtc->Instance->CALR     = 0x00000000U;
+    hrtc->Instance->SHIFTR   = 0x00000000U;
+    hrtc->Instance->ALRMASSR = 0x00000000U;
+    hrtc->Instance->ALRMBSSR = 0x00000000U;
+
+    /* Exit Initialization mode */
+    status = RTC_ExitInitMode(hrtc);
+  }
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  if (status == HAL_OK)
+  {
+    /* Reset Tamper and alternate functions configuration register */
+    hrtc->Instance->TAMPCR = 0x00000000U;
+
+    /* Reset Option register */
+    hrtc->Instance->OR = 0x00000000U;
+
+#if (USE_HAL_RTC_REGISTER_CALLBACKS == 1)
+    if (hrtc->MspDeInitCallback == NULL)
+    {
+      hrtc->MspDeInitCallback = HAL_RTC_MspDeInit;
+    }
+
+    /* DeInit the low level hardware: CLOCK, NVIC.*/
+    hrtc->MspDeInitCallback(hrtc);
+#else /* USE_HAL_RTC_REGISTER_CALLBACKS */
+    /* De-Initialize RTC MSP */
+    HAL_RTC_MspDeInit(hrtc);
+#endif /* USE_HAL_RTC_REGISTER_CALLBACKS */
+
+    hrtc->State = HAL_RTC_STATE_RESET;
+  }
+
+  /* Release Lock */
+  __HAL_UNLOCK(hrtc);
+
+  return status;
+}
+
+#if (USE_HAL_RTC_REGISTER_CALLBACKS == 1)
+/**
+  * @brief  Registers a User RTC Callback
+  *         To be used instead of the weak predefined callback
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  CallbackID ID of the callback to be registered
+  *         This parameter can be one of the following values:
+  *          @arg @ref HAL_RTC_ALARM_A_EVENT_CB_ID          Alarm A Event Callback ID
+  *          @arg @ref HAL_RTC_ALARM_B_EVENT_CB_ID          Alarm B Event Callback ID
+  *          @arg @ref HAL_RTC_TIMESTAMP_EVENT_CB_ID        Timestamp Event Callback ID
+  *          @arg @ref HAL_RTC_WAKEUPTIMER_EVENT_CB_ID      Wakeup Timer Event Callback ID
+  *          @arg @ref HAL_RTC_TAMPER1_EVENT_CB_ID          Tamper 1 Callback ID
+  *          @arg @ref HAL_RTC_TAMPER2_EVENT_CB_ID          Tamper 2 Callback ID
+  *          @arg @ref HAL_RTC_TAMPER3_EVENT_CB_ID          Tamper 3 Callback ID
+  *          @arg @ref HAL_RTC_MSPINIT_CB_ID                Msp Init callback ID
+  *          @arg @ref HAL_RTC_MSPDEINIT_CB_ID              Msp DeInit callback ID
+  * @param  pCallback pointer to the Callback function
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTC_RegisterCallback(RTC_HandleTypeDef *hrtc, HAL_RTC_CallbackIDTypeDef CallbackID, pRTC_CallbackTypeDef pCallback)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+
+  if (pCallback == NULL)
+  {
+    return HAL_ERROR;
+  }
+
+  /* Process locked */
+  __HAL_LOCK(hrtc);
+
+  if (HAL_RTC_STATE_READY == hrtc->State)
+  {
+    switch (CallbackID)
+    {
+      case HAL_RTC_ALARM_A_EVENT_CB_ID :
+        hrtc->AlarmAEventCallback = pCallback;
+        break;
+
+      case HAL_RTC_ALARM_B_EVENT_CB_ID :
+        hrtc->AlarmBEventCallback = pCallback;
+        break;
+
+      case HAL_RTC_TIMESTAMP_EVENT_CB_ID :
+        hrtc->TimeStampEventCallback = pCallback;
+        break;
+
+      case HAL_RTC_WAKEUPTIMER_EVENT_CB_ID :
+        hrtc->WakeUpTimerEventCallback = pCallback;
+        break;
+
+      case HAL_RTC_TAMPER1_EVENT_CB_ID :
+        hrtc->Tamper1EventCallback = pCallback;
+        break;
+
+      case HAL_RTC_TAMPER2_EVENT_CB_ID :
+        hrtc->Tamper2EventCallback = pCallback;
+        break;
+
+      case HAL_RTC_TAMPER3_EVENT_CB_ID :
+        hrtc->Tamper3EventCallback = pCallback;
+        break;
+
+      case HAL_RTC_MSPINIT_CB_ID :
+        hrtc->MspInitCallback = pCallback;
+        break;
+
+      case HAL_RTC_MSPDEINIT_CB_ID :
+        hrtc->MspDeInitCallback = pCallback;
+        break;
+
+      default :
+        /* Return error status */
+        status =  HAL_ERROR;
+        break;
+    }
+  }
+  else if (HAL_RTC_STATE_RESET == hrtc->State)
+  {
+    switch (CallbackID)
+    {
+      case HAL_RTC_MSPINIT_CB_ID :
+        hrtc->MspInitCallback = pCallback;
+        break;
+
+      case HAL_RTC_MSPDEINIT_CB_ID :
+        hrtc->MspDeInitCallback = pCallback;
+        break;
+
+      default :
+        /* Return error status */
+        status =  HAL_ERROR;
+        break;
+    }
+  }
+  else
+  {
+    /* Return error status */
+    status =  HAL_ERROR;
+  }
+
+  /* Release Lock */
+  __HAL_UNLOCK(hrtc);
+
+  return status;
+}
+
+/**
+  * @brief  Unregisters an RTC Callback
+  *         RTC callback is redirected to the weak predefined callback
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  CallbackID ID of the callback to be unregistered
+  *         This parameter can be one of the following values:
+  *          @arg @ref HAL_RTC_ALARM_A_EVENT_CB_ID          Alarm A Event Callback ID
+  *          @arg @ref HAL_RTC_ALARM_B_EVENT_CB_ID          Alarm B Event Callback ID
+  *          @arg @ref HAL_RTC_TIMESTAMP_EVENT_CB_ID        Timestamp Event Callback ID
+  *          @arg @ref HAL_RTC_WAKEUPTIMER_EVENT_CB_ID      Wakeup Timer Event Callback ID
+  *          @arg @ref HAL_RTC_TAMPER1_EVENT_CB_ID          Tamper 1 Callback ID
+  *          @arg @ref HAL_RTC_TAMPER2_EVENT_CB_ID          Tamper 2 Callback ID
+  *          @arg @ref HAL_RTC_TAMPER3_EVENT_CB_ID          Tamper 3 Callback ID
+  *          @arg @ref HAL_RTC_MSPINIT_CB_ID Msp Init callback ID
+  *          @arg @ref HAL_RTC_MSPDEINIT_CB_ID Msp DeInit callback ID
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTC_UnRegisterCallback(RTC_HandleTypeDef *hrtc, HAL_RTC_CallbackIDTypeDef CallbackID)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+
+  /* Process locked */
+  __HAL_LOCK(hrtc);
+
+  if (HAL_RTC_STATE_READY == hrtc->State)
+  {
+    switch (CallbackID)
+    {
+      case HAL_RTC_ALARM_A_EVENT_CB_ID :
+        hrtc->AlarmAEventCallback = HAL_RTC_AlarmAEventCallback;             /* Legacy weak AlarmAEventCallback    */
+        break;
+
+      case HAL_RTC_ALARM_B_EVENT_CB_ID :
+        hrtc->AlarmBEventCallback = HAL_RTCEx_AlarmBEventCallback;           /* Legacy weak AlarmBEventCallback */
+        break;
+
+      case HAL_RTC_TIMESTAMP_EVENT_CB_ID :
+        hrtc->TimeStampEventCallback = HAL_RTCEx_TimeStampEventCallback;     /* Legacy weak TimeStampEventCallback    */
+        break;
+
+      case HAL_RTC_WAKEUPTIMER_EVENT_CB_ID :
+        hrtc->WakeUpTimerEventCallback = HAL_RTCEx_WakeUpTimerEventCallback; /* Legacy weak WakeUpTimerEventCallback */
+        break;
+
+      case HAL_RTC_TAMPER1_EVENT_CB_ID :
+        hrtc->Tamper1EventCallback = HAL_RTCEx_Tamper1EventCallback;         /* Legacy weak Tamper1EventCallback   */
+        break;
+
+      case HAL_RTC_TAMPER2_EVENT_CB_ID :
+        hrtc->Tamper2EventCallback = HAL_RTCEx_Tamper2EventCallback;         /* Legacy weak Tamper2EventCallback         */
+        break;
+
+      case HAL_RTC_TAMPER3_EVENT_CB_ID :
+        hrtc->Tamper3EventCallback = HAL_RTCEx_Tamper3EventCallback;         /* Legacy weak Tamper3EventCallback         */
+        break;
+
+      case HAL_RTC_MSPINIT_CB_ID :
+        hrtc->MspInitCallback = HAL_RTC_MspInit;
+        break;
+
+      case HAL_RTC_MSPDEINIT_CB_ID :
+        hrtc->MspDeInitCallback = HAL_RTC_MspDeInit;
+        break;
+
+      default :
+        /* Return error status */
+        status =  HAL_ERROR;
+        break;
+    }
+  }
+  else if (HAL_RTC_STATE_RESET == hrtc->State)
+  {
+    switch (CallbackID)
+    {
+      case HAL_RTC_MSPINIT_CB_ID :
+        hrtc->MspInitCallback = HAL_RTC_MspInit;
+        break;
+
+      case HAL_RTC_MSPDEINIT_CB_ID :
+        hrtc->MspDeInitCallback = HAL_RTC_MspDeInit;
+        break;
+
+      default :
+        /* Return error status */
+        status =  HAL_ERROR;
+        break;
+    }
+  }
+  else
+  {
+    /* Return error status */
+    status =  HAL_ERROR;
+  }
+
+  /* Release Lock */
+  __HAL_UNLOCK(hrtc);
+
+  return status;
+}
+#endif /* USE_HAL_RTC_REGISTER_CALLBACKS */
+
+/**
+  * @brief  Initializes the RTC MSP.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @retval None
+  */
+__weak void HAL_RTC_MspInit(RTC_HandleTypeDef *hrtc)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hrtc);
+
+  /* NOTE: This function should not be modified, when the callback is needed,
+           the HAL_RTC_MspInit could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  DeInitializes the RTC MSP.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @retval None
+  */
+__weak void HAL_RTC_MspDeInit(RTC_HandleTypeDef *hrtc)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hrtc);
+
+  /* NOTE: This function should not be modified, when the callback is needed,
+           the HAL_RTC_MspDeInit could be implemented in the user file
+   */
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup RTC_Exported_Functions_Group2 RTC Time and Date functions
+  * @brief    RTC Time and Date functions
+  *
+@verbatim
+ ===============================================================================
+                 ##### RTC Time and Date functions #####
+ ===============================================================================
+
+ [..] This section provides functions allowing to configure Time and Date features
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Sets RTC current time.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  sTime Pointer to Time structure
+  * @note   DayLightSaving and StoreOperation interfaces are deprecated.
+  *         To manage Daylight Saving Time, please use HAL_RTC_DST_xxx functions.
+  * @param  Format Specifies the format of the entered parameters.
+  *          This parameter can be one of the following values:
+  *            @arg RTC_FORMAT_BIN: Binary data format
+  *            @arg RTC_FORMAT_BCD: BCD data format
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTC_SetTime(RTC_HandleTypeDef *hrtc, RTC_TimeTypeDef *sTime, uint32_t Format)
+{
+  uint32_t tmpreg = 0U;
+  HAL_StatusTypeDef status;
+
+  /* Check the parameters */
+  assert_param(IS_RTC_FORMAT(Format));
+  assert_param(IS_RTC_DAYLIGHT_SAVING(sTime->DayLightSaving));
+  assert_param(IS_RTC_STORE_OPERATION(sTime->StoreOperation));
+
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  if (Format == RTC_FORMAT_BIN)
+  {
+    if ((hrtc->Instance->CR & RTC_CR_FMT) != 0U)
+    {
+      assert_param(IS_RTC_HOUR12(sTime->Hours));
+      assert_param(IS_RTC_HOURFORMAT12(sTime->TimeFormat));
+    }
+    else
+    {
+      sTime->TimeFormat = 0x00U;
+      assert_param(IS_RTC_HOUR24(sTime->Hours));
+    }
+    assert_param(IS_RTC_MINUTES(sTime->Minutes));
+    assert_param(IS_RTC_SECONDS(sTime->Seconds));
+
+    tmpreg = (uint32_t)(( (uint32_t)RTC_ByteToBcd2(sTime->Hours)   << RTC_TR_HU_Pos)  | \
+                        ( (uint32_t)RTC_ByteToBcd2(sTime->Minutes) << RTC_TR_MNU_Pos) | \
+                        ( (uint32_t)RTC_ByteToBcd2(sTime->Seconds))                   | \
+                        (((uint32_t)sTime->TimeFormat)             << RTC_TR_PM_Pos));
+  }
+  else
+  {
+    if ((hrtc->Instance->CR & RTC_CR_FMT) != 0U)
+    {
+      assert_param(IS_RTC_HOUR12(RTC_Bcd2ToByte(sTime->Hours)));
+      assert_param(IS_RTC_HOURFORMAT12(sTime->TimeFormat));
+    }
+    else
+    {
+      sTime->TimeFormat = 0x00U;
+      assert_param(IS_RTC_HOUR24(RTC_Bcd2ToByte(sTime->Hours)));
+    }
+    assert_param(IS_RTC_MINUTES(RTC_Bcd2ToByte(sTime->Minutes)));
+    assert_param(IS_RTC_SECONDS(RTC_Bcd2ToByte(sTime->Seconds)));
+    tmpreg = (((uint32_t)(sTime->Hours)      << RTC_TR_HU_Pos)  | \
+              ((uint32_t)(sTime->Minutes)    << RTC_TR_MNU_Pos) | \
+              ((uint32_t) sTime->Seconds)                       | \
+              ((uint32_t)(sTime->TimeFormat) << RTC_TR_PM_Pos));
+  }
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  /* Enter Initialization mode */
+  status = RTC_EnterInitMode(hrtc);
+
+  if (status == HAL_OK)
+  {
+    /* Set the RTC_TR register */
+    hrtc->Instance->TR = (uint32_t)(tmpreg & RTC_TR_RESERVED_MASK);
+
+    /* Clear the bits to be configured (Deprecated. Use HAL_RTC_DST_xxx functions instead) */
+    hrtc->Instance->CR &= (uint32_t)~RTC_CR_BKP;
+
+    /* Configure the RTC_CR register (Deprecated. Use HAL_RTC_DST_xxx functions instead) */
+    hrtc->Instance->CR |= (uint32_t)(sTime->DayLightSaving | sTime->StoreOperation);
+
+    /* Exit Initialization mode */
+    status = RTC_ExitInitMode(hrtc);
+  }
+
+  if (status == HAL_OK)
+  {
+    hrtc->State = HAL_RTC_STATE_READY;
+  }
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return status;
+}
+
+/**
+  * @brief  Gets RTC current time.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  sTime Pointer to Time structure
+  * @param  Format Specifies the format of the entered parameters.
+  *          This parameter can be one of the following values:
+  *            @arg RTC_FORMAT_BIN: Binary data format
+  *            @arg RTC_FORMAT_BCD: BCD data format
+  * @note  You can use SubSeconds and SecondFraction (sTime structure fields
+  *        returned) to convert SubSeconds value in second fraction ratio with
+  *        time unit following generic formula:
+  *        Second fraction ratio * time_unit =
+  *           [(SecondFraction - SubSeconds) / (SecondFraction + 1)] * time_unit
+  *        This conversion can be performed only if no shift operation is pending
+  *        (ie. SHFP=0) when PREDIV_S >= SS
+  * @note  You must call HAL_RTC_GetDate() after HAL_RTC_GetTime() to unlock the
+  *        values in the higher-order calendar shadow registers to ensure
+  *        consistency between the time and date values.
+  *        Reading RTC current time locks the values in calendar shadow registers
+  *        until current date is read to ensure consistency between the time and
+  *        date values.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTC_GetTime(RTC_HandleTypeDef *hrtc, RTC_TimeTypeDef *sTime, uint32_t Format)
+{
+  uint32_t tmpreg = 0U;
+
+  /* Check the parameters */
+  assert_param(IS_RTC_FORMAT(Format));
+
+  /* Get subseconds value from the corresponding register */
+  sTime->SubSeconds = (uint32_t)(hrtc->Instance->SSR);
+
+  /* Get SecondFraction structure field from the corresponding register field*/
+  sTime->SecondFraction = (uint32_t)(hrtc->Instance->PRER & RTC_PRER_PREDIV_S);
+
+  /* Get the TR register */
+  tmpreg = (uint32_t)(hrtc->Instance->TR & RTC_TR_RESERVED_MASK);
+
+  /* Fill the structure fields with the read parameters */
+  sTime->Hours      = (uint8_t)((tmpreg & (RTC_TR_HT  | RTC_TR_HU))  >> RTC_TR_HU_Pos);
+  sTime->Minutes    = (uint8_t)((tmpreg & (RTC_TR_MNT | RTC_TR_MNU)) >> RTC_TR_MNU_Pos);
+  sTime->Seconds    = (uint8_t)( tmpreg & (RTC_TR_ST  | RTC_TR_SU));
+  sTime->TimeFormat = (uint8_t)((tmpreg & (RTC_TR_PM))               >> RTC_TR_PM_Pos);
+
+  /* Check the input parameters format */
+  if (Format == RTC_FORMAT_BIN)
+  {
+    /* Convert the time structure parameters to Binary format */
+    sTime->Hours = (uint8_t)RTC_Bcd2ToByte(sTime->Hours);
+    sTime->Minutes = (uint8_t)RTC_Bcd2ToByte(sTime->Minutes);
+    sTime->Seconds = (uint8_t)RTC_Bcd2ToByte(sTime->Seconds);
+  }
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Sets RTC current date.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  sDate Pointer to date structure
+  * @param  Format specifies the format of the entered parameters.
+  *          This parameter can be one of the following values:
+  *            @arg RTC_FORMAT_BIN: Binary data format
+  *            @arg RTC_FORMAT_BCD: BCD data format
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTC_SetDate(RTC_HandleTypeDef *hrtc, RTC_DateTypeDef *sDate, uint32_t Format)
+{
+  uint32_t datetmpreg = 0U;
+  HAL_StatusTypeDef status;
+
+  /* Check the parameters */
+  assert_param(IS_RTC_FORMAT(Format));
+
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  if ((Format == RTC_FORMAT_BIN) && ((sDate->Month & 0x10U) == 0x10U))
+  {
+    sDate->Month = (uint8_t)((sDate->Month & (uint8_t)~(0x10U)) + (uint8_t)0x0AU);
+  }
+
+  assert_param(IS_RTC_WEEKDAY(sDate->WeekDay));
+
+  if (Format == RTC_FORMAT_BIN)
+  {
+    assert_param(IS_RTC_YEAR(sDate->Year));
+    assert_param(IS_RTC_MONTH(sDate->Month));
+    assert_param(IS_RTC_DATE(sDate->Date));
+
+    datetmpreg = (((uint32_t)RTC_ByteToBcd2(sDate->Year)  << RTC_DR_YU_Pos) | \
+                  ((uint32_t)RTC_ByteToBcd2(sDate->Month) << RTC_DR_MU_Pos) | \
+                  ((uint32_t)RTC_ByteToBcd2(sDate->Date))                   | \
+                  ((uint32_t)sDate->WeekDay               << RTC_DR_WDU_Pos));
+  }
+  else
+  {
+    assert_param(IS_RTC_YEAR(RTC_Bcd2ToByte(sDate->Year)));
+    assert_param(IS_RTC_MONTH(RTC_Bcd2ToByte(sDate->Month)));
+    assert_param(IS_RTC_DATE(RTC_Bcd2ToByte(sDate->Date)));
+
+    datetmpreg = ((((uint32_t)sDate->Year)    << RTC_DR_YU_Pos) | \
+                  (((uint32_t)sDate->Month)   << RTC_DR_MU_Pos) | \
+                  ((uint32_t) sDate->Date)                      | \
+                  (((uint32_t)sDate->WeekDay) << RTC_DR_WDU_Pos));
+  }
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  /* Enter Initialization mode */
+  status = RTC_EnterInitMode(hrtc);
+
+  if (status == HAL_OK)
+  {
+    /* Set the RTC_DR register */
+    hrtc->Instance->DR = (uint32_t)(datetmpreg & RTC_DR_RESERVED_MASK);
+
+    /* Exit Initialization mode */
+    status = RTC_ExitInitMode(hrtc);
+  }
+
+  if (status == HAL_OK)
+  {
+    hrtc->State = HAL_RTC_STATE_READY;
+  }
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return status;
+}
+
+/**
+  * @brief  Gets RTC current date.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  sDate Pointer to Date structure
+  * @param  Format Specifies the format of the entered parameters.
+  *          This parameter can be one of the following values:
+  *            @arg RTC_FORMAT_BIN:  Binary data format
+  *            @arg RTC_FORMAT_BCD:  BCD data format
+  * @note  You must call HAL_RTC_GetDate() after HAL_RTC_GetTime() to unlock the
+  *        values in the higher-order calendar shadow registers to ensure
+  *        consistency between the time and date values.
+  *        Reading RTC current time locks the values in calendar shadow registers
+  *        until current date is read to ensure consistency between the time and
+  *        date values.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTC_GetDate(RTC_HandleTypeDef *hrtc, RTC_DateTypeDef *sDate, uint32_t Format)
+{
+  uint32_t datetmpreg = 0U;
+
+  /* Check the parameters */
+  assert_param(IS_RTC_FORMAT(Format));
+
+  /* Get the DR register */
+  datetmpreg = (uint32_t)(hrtc->Instance->DR & RTC_DR_RESERVED_MASK);
+
+  /* Fill the structure fields with the read parameters */
+  sDate->Year    = (uint8_t)((datetmpreg & (RTC_DR_YT | RTC_DR_YU)) >> RTC_DR_YU_Pos);
+  sDate->Month   = (uint8_t)((datetmpreg & (RTC_DR_MT | RTC_DR_MU)) >> RTC_DR_MU_Pos);
+  sDate->Date    = (uint8_t) (datetmpreg & (RTC_DR_DT | RTC_DR_DU));
+  sDate->WeekDay = (uint8_t)((datetmpreg & (RTC_DR_WDU))            >> RTC_DR_WDU_Pos);
+
+  /* Check the input parameters format */
+  if (Format == RTC_FORMAT_BIN)
+  {
+    /* Convert the date structure parameters to Binary format */
+    sDate->Year  = (uint8_t)RTC_Bcd2ToByte(sDate->Year);
+    sDate->Month = (uint8_t)RTC_Bcd2ToByte(sDate->Month);
+    sDate->Date  = (uint8_t)RTC_Bcd2ToByte(sDate->Date);
+  }
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup RTC_Exported_Functions_Group3 RTC Alarm functions
+  * @brief    RTC Alarm functions
+  *
+@verbatim
+ ===============================================================================
+                 ##### RTC Alarm functions #####
+ ===============================================================================
+
+ [..] This section provides functions allowing to configure Alarm feature
+
+@endverbatim
+  * @{
+  */
+/**
+  * @brief  Sets the specified RTC Alarm.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  sAlarm Pointer to Alarm structure
+  * @param  Format Specifies the format of the entered parameters.
+  *          This parameter can be one of the following values:
+  *             @arg RTC_FORMAT_BIN: Binary data format
+  *             @arg RTC_FORMAT_BCD: BCD data format
+  * @note   The Alarm register can only be written when the corresponding Alarm
+  *         is disabled (Use the HAL_RTC_DeactivateAlarm()).
+  * @note   The HAL_RTC_SetTime() must be called before enabling the Alarm feature.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTC_SetAlarm(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef *sAlarm, uint32_t Format)
+{
+  uint32_t tickstart = 0U;
+  uint32_t tmpreg = 0U;
+  uint32_t subsecondtmpreg = 0U;
+
+  /* Check the parameters */
+  assert_param(IS_RTC_FORMAT(Format));
+  assert_param(IS_RTC_ALARM(sAlarm->Alarm));
+  assert_param(IS_RTC_ALARM_MASK(sAlarm->AlarmMask));
+  assert_param(IS_RTC_ALARM_DATE_WEEKDAY_SEL(sAlarm->AlarmDateWeekDaySel));
+  assert_param(IS_RTC_ALARM_SUB_SECOND_VALUE(sAlarm->AlarmTime.SubSeconds));
+  assert_param(IS_RTC_ALARM_SUB_SECOND_MASK(sAlarm->AlarmSubSecondMask));
+
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  /* Change RTC state to BUSY */
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Check the data format (binary or BCD) and store the Alarm time and date
+     configuration accordingly */
+  if (Format == RTC_FORMAT_BIN)
+  {
+    if ((hrtc->Instance->CR & RTC_CR_FMT) != 0U)
+    {
+      assert_param(IS_RTC_HOUR12(sAlarm->AlarmTime.Hours));
+      assert_param(IS_RTC_HOURFORMAT12(sAlarm->AlarmTime.TimeFormat));
+    }
+    else
+    {
+      sAlarm->AlarmTime.TimeFormat = 0x00U;
+      assert_param(IS_RTC_HOUR24(sAlarm->AlarmTime.Hours));
+    }
+    assert_param(IS_RTC_MINUTES(sAlarm->AlarmTime.Minutes));
+    assert_param(IS_RTC_SECONDS(sAlarm->AlarmTime.Seconds));
+
+    if (sAlarm->AlarmDateWeekDaySel == RTC_ALARMDATEWEEKDAYSEL_DATE)
+    {
+      assert_param(IS_RTC_ALARM_DATE_WEEKDAY_DATE(sAlarm->AlarmDateWeekDay));
+    }
+    else
+    {
+      assert_param(IS_RTC_ALARM_DATE_WEEKDAY_WEEKDAY(sAlarm->AlarmDateWeekDay));
+    }
+
+    tmpreg = (((uint32_t)RTC_ByteToBcd2(sAlarm->AlarmTime.Hours)   << RTC_ALRMAR_HU_Pos)  | \
+              ((uint32_t)RTC_ByteToBcd2(sAlarm->AlarmTime.Minutes) << RTC_ALRMAR_MNU_Pos) | \
+              ((uint32_t)RTC_ByteToBcd2(sAlarm->AlarmTime.Seconds))                       | \
+              ((uint32_t)(sAlarm->AlarmTime.TimeFormat)            << RTC_TR_PM_Pos)      | \
+              ((uint32_t)RTC_ByteToBcd2(sAlarm->AlarmDateWeekDay)  << RTC_ALRMAR_DU_Pos)  | \
+              ((uint32_t)sAlarm->AlarmDateWeekDaySel)                                     | \
+              ((uint32_t)sAlarm->AlarmMask));
+  }
+  else
+  {
+    if ((hrtc->Instance->CR & RTC_CR_FMT) != 0U)
+    {
+      assert_param(IS_RTC_HOUR12(RTC_Bcd2ToByte(sAlarm->AlarmTime.Hours)));
+      assert_param(IS_RTC_HOURFORMAT12(sAlarm->AlarmTime.TimeFormat));
+    }
+    else
+    {
+      sAlarm->AlarmTime.TimeFormat = 0x00U;
+      assert_param(IS_RTC_HOUR24(RTC_Bcd2ToByte(sAlarm->AlarmTime.Hours)));
+    }
+
+    assert_param(IS_RTC_MINUTES(RTC_Bcd2ToByte(sAlarm->AlarmTime.Minutes)));
+    assert_param(IS_RTC_SECONDS(RTC_Bcd2ToByte(sAlarm->AlarmTime.Seconds)));
+
+    if (sAlarm->AlarmDateWeekDaySel == RTC_ALARMDATEWEEKDAYSEL_DATE)
+    {
+      assert_param(IS_RTC_ALARM_DATE_WEEKDAY_DATE(RTC_Bcd2ToByte(sAlarm->AlarmDateWeekDay)));
+    }
+    else
+    {
+      assert_param(IS_RTC_ALARM_DATE_WEEKDAY_WEEKDAY(RTC_Bcd2ToByte(sAlarm->AlarmDateWeekDay)));
+    }
+
+    tmpreg = (((uint32_t)(sAlarm->AlarmTime.Hours)      << RTC_ALRMAR_HU_Pos)  | \
+              ((uint32_t)(sAlarm->AlarmTime.Minutes)    << RTC_ALRMAR_MNU_Pos) | \
+              ((uint32_t) sAlarm->AlarmTime.Seconds)                           | \
+              ((uint32_t)(sAlarm->AlarmTime.TimeFormat) << RTC_TR_PM_Pos)      | \
+              ((uint32_t)(sAlarm->AlarmDateWeekDay)     << RTC_ALRMAR_DU_Pos)  | \
+              ((uint32_t) sAlarm->AlarmDateWeekDaySel)                         | \
+              ((uint32_t) sAlarm->AlarmMask));
+  }
+
+  /* Store the Alarm subseconds configuration */
+  subsecondtmpreg = (uint32_t)((uint32_t)(sAlarm->AlarmTime.SubSeconds) | \
+                               (uint32_t)(sAlarm->AlarmSubSecondMask));
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  /* Configure the Alarm register */
+  if (sAlarm->Alarm == RTC_ALARM_A)
+  {
+    /* Disable the Alarm A */
+    __HAL_RTC_ALARMA_DISABLE(hrtc);
+
+    /* In case interrupt mode is used, the interrupt source must be disabled */
+    __HAL_RTC_ALARM_DISABLE_IT(hrtc, RTC_IT_ALRA);
+
+    /* Clear the Alarm flag */
+    __HAL_RTC_ALARM_CLEAR_FLAG(hrtc, RTC_FLAG_ALRAF);
+
+    /* Get tick */
+    tickstart = HAL_GetTick();
+
+    /* Wait till RTC ALRAWF flag is set and if timeout is reached exit */
+    while (__HAL_RTC_ALARM_GET_FLAG(hrtc, RTC_FLAG_ALRAWF) == 0U)
+    {
+      if ((HAL_GetTick() - tickstart) > RTC_TIMEOUT_VALUE)
+      {
+        /* Enable the write protection for RTC registers */
+        __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+        hrtc->State = HAL_RTC_STATE_TIMEOUT;
+
+        /* Process Unlocked */
+        __HAL_UNLOCK(hrtc);
+
+        return HAL_TIMEOUT;
+      }
+    }
+
+    hrtc->Instance->ALRMAR = (uint32_t)tmpreg;
+    /* Configure the Alarm A Subseconds register */
+    hrtc->Instance->ALRMASSR = subsecondtmpreg;
+    /* Configure the Alarm state: Enable Alarm */
+    __HAL_RTC_ALARMA_ENABLE(hrtc);
+  }
+  else
+  {
+    /* Disable the Alarm B */
+    __HAL_RTC_ALARMB_DISABLE(hrtc);
+
+    /* In case interrupt mode is used, the interrupt source must be disabled */
+    __HAL_RTC_ALARM_DISABLE_IT(hrtc, RTC_IT_ALRB);
+
+    /* Clear the Alarm flag */
+    __HAL_RTC_ALARM_CLEAR_FLAG(hrtc, RTC_FLAG_ALRBF);
+
+    /* Get tick */
+    tickstart = HAL_GetTick();
+
+    /* Wait till RTC ALRBWF flag is set and if timeout is reached exit */
+    while (__HAL_RTC_ALARM_GET_FLAG(hrtc, RTC_FLAG_ALRBWF) == 0U)
+    {
+      if ((HAL_GetTick() - tickstart) > RTC_TIMEOUT_VALUE)
+      {
+        /* Enable the write protection for RTC registers */
+        __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+        hrtc->State = HAL_RTC_STATE_TIMEOUT;
+
+        /* Process Unlocked */
+        __HAL_UNLOCK(hrtc);
+
+        return HAL_TIMEOUT;
+      }
+    }
+
+    hrtc->Instance->ALRMBR = (uint32_t)tmpreg;
+    /* Configure the Alarm B Subseconds register */
+    hrtc->Instance->ALRMBSSR = subsecondtmpreg;
+    /* Configure the Alarm state: Enable Alarm */
+    __HAL_RTC_ALARMB_ENABLE(hrtc);
+  }
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  /* Change RTC state back to READY */
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Sets the specified RTC Alarm with Interrupt.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  sAlarm Pointer to Alarm structure
+  * @param  Format Specifies the format of the entered parameters.
+  *          This parameter can be one of the following values:
+  *             @arg RTC_FORMAT_BIN: Binary data format
+  *             @arg RTC_FORMAT_BCD: BCD data format
+  * @note   The Alarm register can only be written when the corresponding Alarm
+  *         is disabled (Use the HAL_RTC_DeactivateAlarm()).
+  * @note   The HAL_RTC_SetTime() must be called before enabling the Alarm feature.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTC_SetAlarm_IT(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef *sAlarm, uint32_t Format)
+{
+  __IO uint32_t count  = RTC_TIMEOUT_VALUE * (SystemCoreClock / 32U / 1000U);
+       uint32_t tmpreg = 0U;
+       uint32_t subsecondtmpreg = 0U;
+
+  /* Check the parameters */
+  assert_param(IS_RTC_FORMAT(Format));
+  assert_param(IS_RTC_ALARM(sAlarm->Alarm));
+  assert_param(IS_RTC_ALARM_MASK(sAlarm->AlarmMask));
+  assert_param(IS_RTC_ALARM_DATE_WEEKDAY_SEL(sAlarm->AlarmDateWeekDaySel));
+  assert_param(IS_RTC_ALARM_SUB_SECOND_VALUE(sAlarm->AlarmTime.SubSeconds));
+  assert_param(IS_RTC_ALARM_SUB_SECOND_MASK(sAlarm->AlarmSubSecondMask));
+
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  /* Change RTC state to BUSY */
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Check the data format (binary or BCD) and store the Alarm time and date
+     configuration accordingly */
+  if (Format == RTC_FORMAT_BIN)
+  {
+    if ((hrtc->Instance->CR & RTC_CR_FMT) != 0U)
+    {
+      assert_param(IS_RTC_HOUR12(sAlarm->AlarmTime.Hours));
+      assert_param(IS_RTC_HOURFORMAT12(sAlarm->AlarmTime.TimeFormat));
+    }
+    else
+    {
+      sAlarm->AlarmTime.TimeFormat = 0x00U;
+      assert_param(IS_RTC_HOUR24(sAlarm->AlarmTime.Hours));
+    }
+    assert_param(IS_RTC_MINUTES(sAlarm->AlarmTime.Minutes));
+    assert_param(IS_RTC_SECONDS(sAlarm->AlarmTime.Seconds));
+
+    if (sAlarm->AlarmDateWeekDaySel == RTC_ALARMDATEWEEKDAYSEL_DATE)
+    {
+      assert_param(IS_RTC_ALARM_DATE_WEEKDAY_DATE(sAlarm->AlarmDateWeekDay));
+    }
+    else
+    {
+      assert_param(IS_RTC_ALARM_DATE_WEEKDAY_WEEKDAY(sAlarm->AlarmDateWeekDay));
+    }
+
+    tmpreg = (((uint32_t)RTC_ByteToBcd2(sAlarm->AlarmTime.Hours)   << RTC_ALRMAR_HU_Pos)  | \
+              ((uint32_t)RTC_ByteToBcd2(sAlarm->AlarmTime.Minutes) << RTC_ALRMAR_MNU_Pos) | \
+              ((uint32_t)RTC_ByteToBcd2(sAlarm->AlarmTime.Seconds))                       | \
+              ((uint32_t)(sAlarm->AlarmTime.TimeFormat)            << RTC_TR_PM_Pos)      | \
+              ((uint32_t)RTC_ByteToBcd2(sAlarm->AlarmDateWeekDay)  << RTC_ALRMAR_DU_Pos)  | \
+              ((uint32_t)sAlarm->AlarmDateWeekDaySel)                                     | \
+              ((uint32_t)sAlarm->AlarmMask));
+  }
+  else
+  {
+    if ((hrtc->Instance->CR & RTC_CR_FMT) != 0U)
+    {
+      assert_param(IS_RTC_HOUR12(RTC_Bcd2ToByte(sAlarm->AlarmTime.Hours)));
+      assert_param(IS_RTC_HOURFORMAT12(sAlarm->AlarmTime.TimeFormat));
+    }
+    else
+    {
+      sAlarm->AlarmTime.TimeFormat = 0x00U;
+      assert_param(IS_RTC_HOUR24(RTC_Bcd2ToByte(sAlarm->AlarmTime.Hours)));
+    }
+
+    assert_param(IS_RTC_MINUTES(RTC_Bcd2ToByte(sAlarm->AlarmTime.Minutes)));
+    assert_param(IS_RTC_SECONDS(RTC_Bcd2ToByte(sAlarm->AlarmTime.Seconds)));
+
+    if (sAlarm->AlarmDateWeekDaySel == RTC_ALARMDATEWEEKDAYSEL_DATE)
+    {
+      assert_param(IS_RTC_ALARM_DATE_WEEKDAY_DATE(RTC_Bcd2ToByte(sAlarm->AlarmDateWeekDay)));
+    }
+    else
+    {
+      assert_param(IS_RTC_ALARM_DATE_WEEKDAY_WEEKDAY(RTC_Bcd2ToByte(sAlarm->AlarmDateWeekDay)));
+    }
+
+    tmpreg = (((uint32_t)(sAlarm->AlarmTime.Hours)      << RTC_ALRMAR_HU_Pos)  | \
+              ((uint32_t)(sAlarm->AlarmTime.Minutes)    << RTC_ALRMAR_MNU_Pos) | \
+              ((uint32_t) sAlarm->AlarmTime.Seconds)                           | \
+              ((uint32_t)(sAlarm->AlarmTime.TimeFormat) << RTC_TR_PM_Pos)      | \
+              ((uint32_t)(sAlarm->AlarmDateWeekDay)     << RTC_ALRMAR_DU_Pos)  | \
+              ((uint32_t) sAlarm->AlarmDateWeekDaySel)                         | \
+              ((uint32_t) sAlarm->AlarmMask));
+  }
+
+  /* Store the Alarm subseconds configuration */
+  subsecondtmpreg = (uint32_t)((uint32_t)(sAlarm->AlarmTime.SubSeconds) | \
+                               (uint32_t)(sAlarm->AlarmSubSecondMask));
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  /* Configure the Alarm register */
+  if (sAlarm->Alarm == RTC_ALARM_A)
+  {
+    /* Disable the Alarm A */
+    __HAL_RTC_ALARMA_DISABLE(hrtc);
+
+    /* Clear the Alarm flag */
+    __HAL_RTC_ALARM_CLEAR_FLAG(hrtc, RTC_FLAG_ALRAF);
+
+    /* Wait till RTC ALRAWF flag is set and if timeout is reached exit */
+    do
+    {
+      count = count - 1U;
+      if (count == 0U)
+      {
+        /* Enable the write protection for RTC registers */
+        __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+        hrtc->State = HAL_RTC_STATE_TIMEOUT;
+
+        /* Process Unlocked */
+        __HAL_UNLOCK(hrtc);
+
+        return HAL_TIMEOUT;
+      }
+    } while (__HAL_RTC_ALARM_GET_FLAG(hrtc, RTC_FLAG_ALRAWF) == 0U);
+
+    hrtc->Instance->ALRMAR = (uint32_t)tmpreg;
+    /* Configure the Alarm A Subseconds register */
+    hrtc->Instance->ALRMASSR = subsecondtmpreg;
+    /* Configure the Alarm state: Enable Alarm */
+    __HAL_RTC_ALARMA_ENABLE(hrtc);
+    /* Configure the Alarm interrupt */
+    __HAL_RTC_ALARM_ENABLE_IT(hrtc, RTC_IT_ALRA);
+  }
+  else
+  {
+    /* Disable the Alarm B */
+    __HAL_RTC_ALARMB_DISABLE(hrtc);
+
+    /* Clear the Alarm flag */
+    __HAL_RTC_ALARM_CLEAR_FLAG(hrtc, RTC_FLAG_ALRBF);
+
+    /* Reload the counter */
+    count = RTC_TIMEOUT_VALUE * (SystemCoreClock / 32U / 1000U);
+
+    /* Wait till RTC ALRBWF flag is set and if timeout is reached exit */
+    do
+    {
+      count = count - 1U;
+      if (count == 0U)
+      {
+        /* Enable the write protection for RTC registers */
+        __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+        hrtc->State = HAL_RTC_STATE_TIMEOUT;
+
+        /* Process Unlocked */
+        __HAL_UNLOCK(hrtc);
+
+        return HAL_TIMEOUT;
+      }
+    } while (__HAL_RTC_ALARM_GET_FLAG(hrtc, RTC_FLAG_ALRBWF) == 0U);
+
+    hrtc->Instance->ALRMBR = (uint32_t)tmpreg;
+    /* Configure the Alarm B Subseconds register */
+    hrtc->Instance->ALRMBSSR = subsecondtmpreg;
+    /* Configure the Alarm state: Enable Alarm */
+    __HAL_RTC_ALARMB_ENABLE(hrtc);
+    /* Configure the Alarm interrupt */
+    __HAL_RTC_ALARM_ENABLE_IT(hrtc, RTC_IT_ALRB);
+  }
+
+  /* RTC Alarm Interrupt Configuration: EXTI configuration */
+  __HAL_RTC_ALARM_EXTI_ENABLE_IT();
+  __HAL_RTC_ALARM_EXTI_ENABLE_RISING_EDGE();
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  /* Change RTC state back to READY */
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Deactivates the specified RTC Alarm.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  Alarm Specifies the Alarm.
+  *          This parameter can be one of the following values:
+  *            @arg RTC_ALARM_A: Alarm A
+  *            @arg RTC_ALARM_B: Alarm B
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTC_DeactivateAlarm(RTC_HandleTypeDef *hrtc, uint32_t Alarm)
+{
+  uint32_t tickstart = 0U;
+
+  /* Check the parameters */
+  assert_param(IS_RTC_ALARM(Alarm));
+
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  if (Alarm == RTC_ALARM_A)
+  {
+    /* Disable Alarm A */
+    __HAL_RTC_ALARMA_DISABLE(hrtc);
+
+    /* In case interrupt mode is used, the interrupt source must be disabled */
+    __HAL_RTC_ALARM_DISABLE_IT(hrtc, RTC_IT_ALRA);
+
+    /* Get tick */
+    tickstart = HAL_GetTick();
+
+    /* Wait till RTC ALRxWF flag is set and if timeout is reached exit */
+    while (__HAL_RTC_ALARM_GET_FLAG(hrtc, RTC_FLAG_ALRAWF) == 0U)
+    {
+      if ((HAL_GetTick() - tickstart) > RTC_TIMEOUT_VALUE)
+      {
+        /* Enable the write protection for RTC registers */
+        __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+        hrtc->State = HAL_RTC_STATE_TIMEOUT;
+
+        /* Process Unlocked */
+        __HAL_UNLOCK(hrtc);
+
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+  else
+  {
+    /* Disable Alarm B */
+    __HAL_RTC_ALARMB_DISABLE(hrtc);
+
+    /* In case interrupt mode is used, the interrupt source must be disabled */
+    __HAL_RTC_ALARM_DISABLE_IT(hrtc, RTC_IT_ALRB);
+
+    /* Get tick */
+    tickstart = HAL_GetTick();
+
+    /* Wait till RTC ALRxWF flag is set and if timeout is reached exit */
+    while (__HAL_RTC_ALARM_GET_FLAG(hrtc, RTC_FLAG_ALRBWF) == 0U)
+    {
+      if ((HAL_GetTick() - tickstart) > RTC_TIMEOUT_VALUE)
+      {
+        /* Enable the write protection for RTC registers */
+        __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+        hrtc->State = HAL_RTC_STATE_TIMEOUT;
+
+        /* Process Unlocked */
+        __HAL_UNLOCK(hrtc);
+
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Gets the RTC Alarm value and masks.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  sAlarm Pointer to Date structure
+  * @param  Alarm Specifies the Alarm.
+  *          This parameter can be one of the following values:
+  *            @arg RTC_ALARM_A: Alarm A
+  *            @arg RTC_ALARM_B: Alarm B
+  * @param  Format Specifies the format of the entered parameters.
+  *          This parameter can be one of the following values:
+  *             @arg RTC_FORMAT_BIN: Binary data format
+  *             @arg RTC_FORMAT_BCD: BCD data format
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTC_GetAlarm(RTC_HandleTypeDef *hrtc, RTC_AlarmTypeDef *sAlarm, uint32_t Alarm, uint32_t Format)
+{
+  uint32_t tmpreg = 0U;
+  uint32_t subsecondtmpreg = 0U;
+
+  /* Check the parameters */
+  assert_param(IS_RTC_FORMAT(Format));
+  assert_param(IS_RTC_ALARM(Alarm));
+
+  if (Alarm == RTC_ALARM_A)
+  {
+    sAlarm->Alarm = RTC_ALARM_A;
+
+    tmpreg = (uint32_t)(hrtc->Instance->ALRMAR);
+    subsecondtmpreg = (uint32_t)((hrtc->Instance->ALRMASSR) & RTC_ALRMASSR_SS);
+  }
+  else
+  {
+    sAlarm->Alarm = RTC_ALARM_B;
+
+    tmpreg = (uint32_t)(hrtc->Instance->ALRMBR);
+    subsecondtmpreg = (uint32_t)((hrtc->Instance->ALRMBSSR) & RTC_ALRMBSSR_SS);
+  }
+
+  /* Fill the structure with the read parameters */
+  sAlarm->AlarmTime.Hours      = (uint8_t) ((tmpreg & (RTC_ALRMAR_HT  | RTC_ALRMAR_HU))  >> RTC_ALRMAR_HU_Pos);
+  sAlarm->AlarmTime.Minutes    = (uint8_t) ((tmpreg & (RTC_ALRMAR_MNT | RTC_ALRMAR_MNU)) >> RTC_ALRMAR_MNU_Pos);
+  sAlarm->AlarmTime.Seconds    = (uint8_t) ( tmpreg & (RTC_ALRMAR_ST  | RTC_ALRMAR_SU));
+  sAlarm->AlarmTime.TimeFormat = (uint8_t) ((tmpreg & RTC_ALRMAR_PM)                     >> RTC_TR_PM_Pos);
+  sAlarm->AlarmTime.SubSeconds = (uint32_t) subsecondtmpreg;
+  sAlarm->AlarmDateWeekDay     = (uint8_t) ((tmpreg & (RTC_ALRMAR_DT  | RTC_ALRMAR_DU))  >> RTC_ALRMAR_DU_Pos);
+  sAlarm->AlarmDateWeekDaySel  = (uint32_t) (tmpreg & RTC_ALRMAR_WDSEL);
+  sAlarm->AlarmMask            = (uint32_t) (tmpreg & RTC_ALARMMASK_ALL);
+
+  if (Format == RTC_FORMAT_BIN)
+  {
+    sAlarm->AlarmTime.Hours   = RTC_Bcd2ToByte(sAlarm->AlarmTime.Hours);
+    sAlarm->AlarmTime.Minutes = RTC_Bcd2ToByte(sAlarm->AlarmTime.Minutes);
+    sAlarm->AlarmTime.Seconds = RTC_Bcd2ToByte(sAlarm->AlarmTime.Seconds);
+    sAlarm->AlarmDateWeekDay  = RTC_Bcd2ToByte(sAlarm->AlarmDateWeekDay);
+  }
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Handles Alarm interrupt request.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @retval None
+  */
+void HAL_RTC_AlarmIRQHandler(RTC_HandleTypeDef *hrtc)
+{
+  /* Clear the EXTI's line Flag for RTC Alarm */
+  __HAL_RTC_ALARM_EXTI_CLEAR_FLAG();
+
+  /* Get the Alarm A interrupt source enable status */
+  if (__HAL_RTC_ALARM_GET_IT_SOURCE(hrtc, RTC_IT_ALRA) != 0U)
+  {
+    /* Get the pending status of the Alarm A Interrupt */
+    if (__HAL_RTC_ALARM_GET_FLAG(hrtc, RTC_FLAG_ALRAF) != 0U)
+    {
+      /* Clear the Alarm A interrupt pending bit */
+      __HAL_RTC_ALARM_CLEAR_FLAG(hrtc, RTC_FLAG_ALRAF);
+
+      /* Alarm A callback */
+#if (USE_HAL_RTC_REGISTER_CALLBACKS == 1)
+      hrtc->AlarmAEventCallback(hrtc);
+#else
+      HAL_RTC_AlarmAEventCallback(hrtc);
+#endif /* USE_HAL_RTC_REGISTER_CALLBACKS */
+    }
+  }
+
+  /* Get the Alarm B interrupt source enable status */
+  if (__HAL_RTC_ALARM_GET_IT_SOURCE(hrtc, RTC_IT_ALRB) != 0U)
+  {
+    /* Get the pending status of the Alarm B Interrupt */
+    if (__HAL_RTC_ALARM_GET_FLAG(hrtc, RTC_FLAG_ALRBF) != 0U)
+    {
+      /* Clear the Alarm B interrupt pending bit */
+      __HAL_RTC_ALARM_CLEAR_FLAG(hrtc, RTC_FLAG_ALRBF);
+
+      /* Alarm B callback */
+#if (USE_HAL_RTC_REGISTER_CALLBACKS == 1)
+      hrtc->AlarmBEventCallback(hrtc);
+#else
+      HAL_RTCEx_AlarmBEventCallback(hrtc);
+#endif /* USE_HAL_RTC_REGISTER_CALLBACKS */
+    }
+  }
+
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+}
+
+/**
+  * @brief  Alarm A callback.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @retval None
+  */
+__weak void HAL_RTC_AlarmAEventCallback(RTC_HandleTypeDef *hrtc)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hrtc);
+
+  /* NOTE: This function should not be modified, when the callback is needed,
+           the HAL_RTC_AlarmAEventCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Handles Alarm A Polling request.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  Timeout Timeout duration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTC_PollForAlarmAEvent(RTC_HandleTypeDef *hrtc, uint32_t Timeout)
+{
+  uint32_t tickstart = 0U;
+
+  /* Get tick */
+  tickstart = HAL_GetTick();
+
+  /* Wait till RTC ALRAF flag is set and if timeout is reached exit */
+  while (__HAL_RTC_ALARM_GET_FLAG(hrtc, RTC_FLAG_ALRAF) == 0U)
+  {
+    if (Timeout != HAL_MAX_DELAY)
+    {
+      if ((Timeout == 0U) || ((HAL_GetTick() - tickstart) > Timeout))
+      {
+        hrtc->State = HAL_RTC_STATE_TIMEOUT;
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+
+  /* Clear the Alarm flag */
+  __HAL_RTC_ALARM_CLEAR_FLAG(hrtc, RTC_FLAG_ALRAF);
+
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup RTC_Exported_Functions_Group4 Peripheral Control functions
+  * @brief    Peripheral Control functions
+  *
+@verbatim
+ ===============================================================================
+                     ##### Peripheral Control functions #####
+ ===============================================================================
+    [..]
+    This subsection provides functions allowing to
+      (+) Wait for RTC Time and Date Synchronization
+      (+) Manage RTC Summer or Winter time change
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Waits until the RTC Time and Date registers (RTC_TR and RTC_DR) are
+  *         synchronized with RTC APB clock.
+  * @note   The RTC Resynchronization mode is write protected, use the
+  *         __HAL_RTC_WRITEPROTECTION_DISABLE() before calling this function.
+  * @note   To read the calendar through the shadow registers after Calendar
+  *         initialization, calendar update or after wakeup from low power modes
+  *         the software must first clear the RSF flag.
+  *         The software must then wait until it is set again before reading
+  *         the calendar, which means that the calendar registers have been
+  *         correctly copied into the RTC_TR and RTC_DR shadow registers.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTC_WaitForSynchro(RTC_HandleTypeDef *hrtc)
+{
+  uint32_t tickstart = 0U;
+
+  /* Clear RSF flag, keep reserved bits at reset values (setting other flags has no effect) */
+  hrtc->Instance->ISR = ((uint32_t)(RTC_RSF_MASK & RTC_ISR_RESERVED_MASK));
+
+  /* Get tick */
+  tickstart = HAL_GetTick();
+
+  /* Wait the registers to be synchronised */
+  while ((hrtc->Instance->ISR & RTC_ISR_RSF) == 0U)
+  {
+    if ((HAL_GetTick() - tickstart) > RTC_TIMEOUT_VALUE)
+    {
+      return HAL_TIMEOUT;
+    }
+  }
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Daylight Saving Time, adds one hour to the calendar in one
+  *         single operation without going through the initialization procedure.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @retval None
+  */
+void HAL_RTC_DST_Add1Hour(RTC_HandleTypeDef *hrtc)
+{
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+  SET_BIT(hrtc->Instance->CR, RTC_CR_ADD1H);
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+}
+
+/**
+  * @brief  Daylight Saving Time, subtracts one hour from the calendar in one
+  *         single operation without going through the initialization procedure.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @retval None
+  */
+void HAL_RTC_DST_Sub1Hour(RTC_HandleTypeDef *hrtc)
+{
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+  SET_BIT(hrtc->Instance->CR, RTC_CR_SUB1H);
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+}
+
+/**
+  * @brief  Daylight Saving Time, sets the store operation bit.
+  * @note   It can be used by the software in order to memorize the DST status.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @retval None
+  */
+void HAL_RTC_DST_SetStoreOperation(RTC_HandleTypeDef *hrtc)
+{
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+  SET_BIT(hrtc->Instance->CR, RTC_CR_BKP);
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+}
+
+/**
+  * @brief  Daylight Saving Time, clears the store operation bit.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @retval None
+  */
+void HAL_RTC_DST_ClearStoreOperation(RTC_HandleTypeDef *hrtc)
+{
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+  CLEAR_BIT(hrtc->Instance->CR, RTC_CR_BKP);
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+}
+
+/**
+  * @brief  Daylight Saving Time, reads the store operation bit.
+  * @param  hrtc RTC handle
+  * @retval operation see RTC_StoreOperation_Definitions
+  */
+uint32_t HAL_RTC_DST_ReadStoreOperation(RTC_HandleTypeDef *hrtc)
+{
+  return READ_BIT(hrtc->Instance->CR, RTC_CR_BKP);
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup RTC_Exported_Functions_Group5 Peripheral State functions
+  * @brief    Peripheral State functions
+  *
+@verbatim
+ ===============================================================================
+                     ##### Peripheral State functions #####
+ ===============================================================================
+    [..]
+    This subsection provides functions allowing to
+      (+) Get RTC state
+
+@endverbatim
+  * @{
+  */
+/**
+  * @brief  Returns the RTC state.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @retval HAL state
+  */
+HAL_RTCStateTypeDef HAL_RTC_GetState(RTC_HandleTypeDef *hrtc)
+{
+  return hrtc->State;
+}
+
+/**
+  * @}
+  */
+
+
+/**
+  * @}
+  */
+
+/** @addtogroup RTC_Private_Functions
+  * @{
+  */
+
+/**
+  * @brief  Enters the RTC Initialization mode.
+  * @note   The RTC Initialization mode is write protected, use the
+  *         __HAL_RTC_WRITEPROTECTION_DISABLE() before calling this function.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef RTC_EnterInitMode(RTC_HandleTypeDef *hrtc)
+{
+  uint32_t tickstart = 0U;
+  HAL_StatusTypeDef status = HAL_OK;
+
+  /* Check that Initialization mode is not already set */
+  if (READ_BIT(hrtc->Instance->ISR, RTC_ISR_INITF) == 0U)
+  {
+    /* Set INIT bit to enter Initialization mode */
+    SET_BIT(hrtc->Instance->ISR, RTC_ISR_INIT);
+
+    /* Get tick */
+    tickstart = HAL_GetTick();
+
+    /* Wait till RTC is in INIT state and if timeout is reached exit */
+    while ((READ_BIT(hrtc->Instance->ISR, RTC_ISR_INITF) == 0U) && (status != HAL_ERROR))
+    {
+      if ((HAL_GetTick() - tickstart) > RTC_TIMEOUT_VALUE)
+      {
+        /* Set RTC state */
+        hrtc->State = HAL_RTC_STATE_ERROR;
+        status = HAL_ERROR;
+      }
+    }
+  }
+
+  return status;
+}
+
+/**
+  * @brief  Exits the RTC Initialization mode.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef RTC_ExitInitMode(RTC_HandleTypeDef *hrtc)
+{
+  HAL_StatusTypeDef status = HAL_OK;
+
+  /* Clear INIT bit to exit Initialization mode */
+  CLEAR_BIT(hrtc->Instance->ISR, RTC_ISR_INIT);
+
+  /* If CR_BYPSHAD bit = 0, wait for synchro */
+  if (READ_BIT(hrtc->Instance->CR, RTC_CR_BYPSHAD) == 0U)
+  {
+    if (HAL_RTC_WaitForSynchro(hrtc) != HAL_OK)
+    {
+      /* Set RTC state */
+      hrtc->State = HAL_RTC_STATE_ERROR;
+      status = HAL_ERROR;
+    }
+  }
+
+  return status;
+}
+
+/**
+  * @brief  Converts a 2-digit number from decimal to BCD format.
+  * @param  number decimal-formatted number (from 0 to 99) to be converted
+  * @retval Converted byte
+  */
+uint8_t RTC_ByteToBcd2(uint8_t number)
+{
+  uint32_t bcdhigh = 0U;
+
+  while (number >= 10U)
+  {
+    bcdhigh++;
+    number -= 10U;
+  }
+
+  return ((uint8_t)(bcdhigh << 4U) | number);
+}
+
+/**
+  * @brief  Converts a 2-digit number from BCD to decimal format.
+  * @param  number BCD-formatted number (from 00 to 99) to be converted
+  * @retval Converted word
+  */
+uint8_t RTC_Bcd2ToByte(uint8_t number)
+{
+  uint32_t tens = 0U;
+  tens = (((uint32_t)number & 0xF0U) >> 4U) * 10U;
+  return (uint8_t)(tens + ((uint32_t)number & 0x0FU));
+}
+
+/**
+  * @}
+  */
+
+#endif /* HAL_RTC_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */

--- a/lib/STM32F7xx_HAL_Driver/Src/stm32f7xx_hal_rtc_ex.c
+++ b/lib/STM32F7xx_HAL_Driver/Src/stm32f7xx_hal_rtc_ex.c
@@ -1,0 +1,2036 @@
+/**
+  ******************************************************************************
+  * @file    stm32f7xx_hal_rtc_ex.c
+  * @author  MCD Application Team
+  * @brief   Extended RTC HAL module driver.
+  *          This file provides firmware functions to manage the following
+  *          functionalities of the Real-Time Clock (RTC) Extended peripheral:
+  *           + RTC Timestamp functions
+  *           + RTC Tamper functions
+  *           + RTC Wakeup functions
+  *           + Extended Control functions
+  *           + Extended RTC features functions
+  *
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2017 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
+  @verbatim
+  ==============================================================================
+                        ##### How to use this driver #####
+  ==============================================================================
+  [..]
+    (+) Enable the RTC domain access.
+    (+) Configure the RTC Prescaler (Asynchronous and Synchronous) and RTC hour
+        format using the HAL_RTC_Init() function.
+
+  *** RTC Wakeup configuration ***
+  ================================
+  [..]
+    (+) To configure the RTC Wakeup Clock source and Counter use the
+        HAL_RTCEx_SetWakeUpTimer() function.
+        You can also configure the RTC Wakeup timer in interrupt mode using the
+        HAL_RTCEx_SetWakeUpTimer_IT() function.
+    (+) To read the RTC Wakeup Counter register, use the HAL_RTCEx_GetWakeUpTimer()
+        function.
+
+  *** Timestamp configuration ***
+  ===============================
+  [..]
+    (+) To configure the RTC Timestamp use the HAL_RTCEx_SetTimeStamp() function.
+        You can also configure the RTC Timestamp with interrupt mode using the
+        HAL_RTCEx_SetTimeStamp_IT() function.
+    (+) To read the RTC Timestamp Time and Date register, use the
+        HAL_RTCEx_GetTimeStamp() function.
+    (+) The Timestamp alternate function can be mapped either to RTC_AF1 (PC13),
+        RTC_AF2 (PI8), or RTC_AF3 (PC1) depending on the value of TSINSEL field
+        in RTC_OR register.
+        The corresponding pin is also selected by HAL_RTCEx_SetTimeStamp()
+        or HAL_RTCEx_SetTimeStamp_IT() functions.
+
+  *** Internal Timestamp configuration ***
+  ===============================
+  [..]
+    (+) To Enable the RTC internal Timestamp use the HAL_RTCEx_SetInternalTimeStamp()
+        function.
+    (+) To read the RTC Timestamp Time and Date register, use the HAL_RTCEx_GetTimeStamp()
+        function.
+
+  *** Tamper configuration ***
+  ============================
+  [..]
+    (+) To Enable the RTC Tamper and configure the Tamper filter count, trigger
+        Edge or Level according to the Tamper filter value (if equal to 0 Edge
+        else Level), sampling frequency, NoErase, MaskFlag, precharge or
+        discharge and Pull-UP use the HAL_RTCEx_SetTamper() function.
+        You can configure RTC Tamper in interrupt mode using HAL_RTCEx_SetTamper_IT()
+        function.
+    (+) The default configuration of the Tamper erases the backup registers.
+        To avoid this, enable the NoErase field on the RTC_TAMPCR register.
+    (+) The TAMPER1 alternate function is mapped to RTC_AF1 (PC13).
+    (+) The TAMPER2 alternate function is mapped to RTC_AF2 (PI8).
+    (+) The TAMPER3 alternate function is mapped to RTC_AF3 (PC1).
+
+  *** Backup Data Registers configuration ***
+  ===========================================
+  [..]
+    (+) To write to the RTC Backup Data registers, use the HAL_RTCEx_BKUPWrite()
+        function.
+    (+) To read the RTC Backup Data registers, use the HAL_RTCEx_BKUPRead()
+        function.
+
+  *** Smooth Digital Calibration configuration ***
+  ================================================
+  [..]
+    (+) RTC frequency can be digitally calibrated with a resolution of about
+        0.954 ppm with a range from -487.1 ppm to +488.5 ppm.
+        The correction of the frequency is performed using a series of small
+        adjustments (adding and/or subtracting individual RTCCLK pulses).
+    (+) The smooth digital calibration is performed during a cycle of about 2^20
+        RTCCLK pulses (or 32 seconds) when the input frequency is 32,768 Hz.
+        This cycle is maintained by a 20-bit counter clocked by RTCCLK.
+    (+) The smooth calibration register (RTC_CALR) specifies the number of RTCCLK
+        clock cycles to be masked during the 32-second cycle.
+    (+) The RTC Smooth Digital Calibration value and the corresponding calibration
+        cycle period (32s, 16s, or 8s) can be calibrated using the
+        HAL_RTCEx_SetSmoothCalib() function.
+
+  @endverbatim
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f7xx_hal.h"
+
+/** @addtogroup STM32F7xx_HAL_Driver
+  * @{
+  */
+
+/** @defgroup RTCEx RTCEx
+  * @brief    RTC Extended HAL module driver
+  * @{
+  */
+
+#ifdef HAL_RTC_MODULE_ENABLED
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* Exported functions --------------------------------------------------------*/
+
+/** @defgroup RTCEx_Exported_Functions RTCEx Exported Functions
+  * @{
+  */
+
+/** @defgroup RTCEx_Exported_Functions_Group1 RTC Timestamp and Tamper functions
+  * @brief    RTC Timestamp and Tamper functions
+  *
+@verbatim
+ ===============================================================================
+                 ##### RTC Timestamp and Tamper functions #####
+ ===============================================================================
+
+ [..] This section provides functions allowing to configure Timestamp feature
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Sets Timestamp.
+  * @note   This API must be called before enabling the Timestamp feature.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  RTC_TimeStampEdge Specifies the pin edge on which the Timestamp is
+  *         activated.
+  *          This parameter can be one of the following values:
+  *             @arg RTC_TIMESTAMPEDGE_RISING: the Timestamp event occurs on
+  *                                        the rising edge of the related pin.
+  *             @arg RTC_TIMESTAMPEDGE_FALLING: the Timestamp event occurs on
+  *                                        the falling edge of the related pin.
+  * @param  RTC_TimeStampPin Specifies the RTC Timestamp Pin.
+  *          This parameter can be one of the following values:
+  *             @arg RTC_TIMESTAMPPIN_DEFAULT: PC13 is selected as RTC Timestamp Pin.
+  *             @arg RTC_TIMESTAMPPIN_POS1: PI8 is selected as RTC Timestamp Pin.
+  *             @arg RTC_TIMESTAMPPIN_POS2: PC1 is selected as RTC Timestamp Pin.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_SetTimeStamp(RTC_HandleTypeDef *hrtc, uint32_t RTC_TimeStampEdge, uint32_t RTC_TimeStampPin)
+{
+  uint32_t tmpreg = 0U;
+
+  /* Check the parameters */
+  assert_param(IS_TIMESTAMP_EDGE(RTC_TimeStampEdge));
+  assert_param(IS_RTC_TIMESTAMP_PIN(RTC_TimeStampPin));
+
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  /* Change RTC state to BUSY */
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  hrtc->Instance->OR &= (uint32_t)~RTC_OR_TSINSEL;
+  hrtc->Instance->OR |= (uint32_t)(RTC_TimeStampPin);
+
+  /* Get the RTC_CR register and clear the bits to be configured */
+  tmpreg = (uint32_t)(hrtc->Instance->CR & (uint32_t)~(RTC_CR_TSEDGE | RTC_CR_TSE));
+
+  /* Configure the Timestamp TSEDGE bit */
+  tmpreg |= RTC_TimeStampEdge;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  /* Copy the desired configuration into the CR register */
+  hrtc->Instance->CR = (uint32_t)tmpreg;
+
+  /* Clear RTC Timestamp flag */
+  __HAL_RTC_TIMESTAMP_CLEAR_FLAG(hrtc, RTC_FLAG_TSF);
+
+  /* Clear RTC Timestamp overrun Flag */
+  __HAL_RTC_TIMESTAMP_CLEAR_FLAG(hrtc, RTC_FLAG_TSOVF);
+
+  /* Enable the Timestamp saving */
+  __HAL_RTC_TIMESTAMP_ENABLE(hrtc);
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  /* Change RTC state back to READY */
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Sets Timestamp with Interrupt.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @note   This API must be called before enabling the Timestamp feature.
+  * @param  RTC_TimeStampEdge Specifies the pin edge on which the Timestamp is
+  *         activated.
+  *          This parameter can be one of the following values:
+  *             @arg RTC_TIMESTAMPEDGE_RISING: the Timestamp event occurs on
+  *                                        the rising edge of the related pin.
+  *             @arg RTC_TIMESTAMPEDGE_FALLING: the Timestamp event occurs on
+  *                                        the falling edge of the related pin.
+  * @param  RTC_TimeStampPin Specifies the RTC Timestamp Pin.
+  *          This parameter can be one of the following values:
+  *             @arg RTC_TIMESTAMPPIN_DEFAULT: PC13 is selected as RTC Timestamp Pin.
+  *             @arg RTC_TIMESTAMPPIN_POS1: PI8 is selected as RTC Timestamp Pin.
+  *             @arg RTC_TIMESTAMPPIN_POS2: PC1 is selected as RTC Timestamp Pin.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_SetTimeStamp_IT(RTC_HandleTypeDef *hrtc, uint32_t RTC_TimeStampEdge, uint32_t RTC_TimeStampPin)
+{
+  uint32_t tmpreg = 0U;
+
+  /* Check the parameters */
+  assert_param(IS_TIMESTAMP_EDGE(RTC_TimeStampEdge));
+  assert_param(IS_RTC_TIMESTAMP_PIN(RTC_TimeStampPin));
+
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  /* Change RTC state to BUSY */
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  hrtc->Instance->OR &= (uint32_t)~RTC_OR_TSINSEL;
+  hrtc->Instance->OR |= (uint32_t)(RTC_TimeStampPin);
+
+  /* Get the RTC_CR register and clear the bits to be configured */
+  tmpreg = (uint32_t)(hrtc->Instance->CR & (uint32_t)~(RTC_CR_TSEDGE | RTC_CR_TSE));
+
+  /* Configure the Timestamp TSEDGE bit */
+  tmpreg |= RTC_TimeStampEdge;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  /* Copy the desired configuration into the CR register */
+  hrtc->Instance->CR = (uint32_t)tmpreg;
+
+  /* Clear RTC Timestamp flag */
+  __HAL_RTC_TIMESTAMP_CLEAR_FLAG(hrtc, RTC_FLAG_TSF);
+
+  /* Clear RTC Timestamp overrun Flag */
+  __HAL_RTC_TIMESTAMP_CLEAR_FLAG(hrtc, RTC_FLAG_TSOVF);
+
+  /* Enable the Timestamp saving */
+  __HAL_RTC_TIMESTAMP_ENABLE(hrtc);
+
+  /* Enable IT Timestamp */
+  __HAL_RTC_TIMESTAMP_ENABLE_IT(hrtc, RTC_IT_TS);
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  /* RTC Timestamp Interrupt Configuration: EXTI configuration */
+  __HAL_RTC_TAMPER_TIMESTAMP_EXTI_ENABLE_IT();
+  __HAL_RTC_TAMPER_TIMESTAMP_EXTI_ENABLE_RISING_EDGE();
+
+  /* Change RTC state back to READY */
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Deactivates Timestamp.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_DeactivateTimeStamp(RTC_HandleTypeDef *hrtc)
+{
+  uint32_t tmpreg = 0U;
+
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  /* In case of interrupt mode is used, the interrupt source must disabled */
+  __HAL_RTC_TIMESTAMP_DISABLE_IT(hrtc, RTC_IT_TS);
+
+  /* Get the RTC_CR register and clear the bits to be configured */
+  tmpreg = (uint32_t)(hrtc->Instance->CR & (uint32_t)~(RTC_CR_TSEDGE | RTC_CR_TSE));
+
+  /* Configure the Timestamp TSEDGE and Enable bits */
+  hrtc->Instance->CR = (uint32_t)tmpreg;
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Sets Internal Timestamp.
+  * @note   This API must be called before enabling the internal Timestamp feature.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_SetInternalTimeStamp(RTC_HandleTypeDef *hrtc)
+{
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  /* Configure the internal Timestamp Enable bits */
+  __HAL_RTC_INTERNAL_TIMESTAMP_ENABLE(hrtc);
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Deactivates internal Timestamp.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_DeactivateInternalTimeStamp(RTC_HandleTypeDef *hrtc)
+{
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  /* Configure the internal Timestamp Enable bits */
+  __HAL_RTC_INTERNAL_TIMESTAMP_DISABLE(hrtc);
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Gets the RTC Timestamp value.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  sTimeStamp Pointer to Time structure
+  * @param  sTimeStampDate Pointer to Date structure
+  * @param  Format specifies the format of the entered parameters.
+  *          This parameter can be one of the following values:
+  *             @arg RTC_FORMAT_BIN: Binary data format
+  *             @arg RTC_FORMAT_BCD: BCD data format
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_GetTimeStamp(RTC_HandleTypeDef *hrtc, RTC_TimeTypeDef *sTimeStamp, RTC_DateTypeDef *sTimeStampDate, uint32_t Format)
+{
+  uint32_t tmptime = 0U;
+  uint32_t tmpdate = 0U;
+
+  /* Check the parameters */
+  assert_param(IS_RTC_FORMAT(Format));
+
+  /* Get the Timestamp time and date registers values */
+  tmptime = (uint32_t)(hrtc->Instance->TSTR & RTC_TR_RESERVED_MASK);
+  tmpdate = (uint32_t)(hrtc->Instance->TSDR & RTC_DR_RESERVED_MASK);
+
+  /* Fill the Time structure fields with the read parameters */
+  sTimeStamp->Hours      = (uint8_t)((tmptime & (RTC_TSTR_HT  | RTC_TSTR_HU))  >> RTC_TSTR_HU_Pos);
+  sTimeStamp->Minutes    = (uint8_t)((tmptime & (RTC_TSTR_MNT | RTC_TSTR_MNU)) >> RTC_TSTR_MNU_Pos);
+  sTimeStamp->Seconds    = (uint8_t)((tmptime & (RTC_TSTR_ST  | RTC_TSTR_SU))  >> RTC_TSTR_SU_Pos);
+  sTimeStamp->TimeFormat = (uint8_t)((tmptime & (RTC_TSTR_PM))                 >> RTC_TSTR_PM_Pos);
+  sTimeStamp->SubSeconds = (uint32_t) hrtc->Instance->TSSSR;
+
+  /* Fill the Date structure fields with the read parameters */
+  sTimeStampDate->Year    = 0U;
+  sTimeStampDate->Month   = (uint8_t)((tmpdate & (RTC_TSDR_MT | RTC_TSDR_MU)) >> RTC_TSDR_MU_Pos);
+  sTimeStampDate->Date    = (uint8_t)((tmpdate & (RTC_TSDR_DT | RTC_TSDR_DU)) >> RTC_TSDR_DU_Pos);
+  sTimeStampDate->WeekDay = (uint8_t)((tmpdate & (RTC_TSDR_WDU))              >> RTC_TSDR_WDU_Pos);
+
+  /* Check the input parameters format */
+  if (Format == RTC_FORMAT_BIN)
+  {
+    /* Convert the Timestamp structure parameters to Binary format */
+    sTimeStamp->Hours   = (uint8_t)RTC_Bcd2ToByte(sTimeStamp->Hours);
+    sTimeStamp->Minutes = (uint8_t)RTC_Bcd2ToByte(sTimeStamp->Minutes);
+    sTimeStamp->Seconds = (uint8_t)RTC_Bcd2ToByte(sTimeStamp->Seconds);
+
+    /* Convert the DateTimeStamp structure parameters to Binary format */
+    sTimeStampDate->Month   = (uint8_t)RTC_Bcd2ToByte(sTimeStampDate->Month);
+    sTimeStampDate->Date    = (uint8_t)RTC_Bcd2ToByte(sTimeStampDate->Date);
+    sTimeStampDate->WeekDay = (uint8_t)RTC_Bcd2ToByte(sTimeStampDate->WeekDay);
+  }
+
+  /* Clear the internal Timestamp Flag */
+  __HAL_RTC_INTERNAL_TIMESTAMP_CLEAR_FLAG(hrtc, RTC_FLAG_ITSF);
+
+  /* Clear the Timestamp Flag */
+  __HAL_RTC_TIMESTAMP_CLEAR_FLAG(hrtc, RTC_FLAG_TSF);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Sets Tamper.
+  * @note   By calling this API the tamper global interrupt will be disabled and
+  *         the selected tamper's interrupt as well.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  sTamper Pointer to Tamper Structure.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_SetTamper(RTC_HandleTypeDef *hrtc, RTC_TamperTypeDef *sTamper)
+{
+  uint32_t tmpreg = 0U;
+
+  /* Check the parameters */
+  assert_param(IS_RTC_TAMPER(sTamper->Tamper));
+  assert_param(IS_RTC_TAMPER_TRIGGER(sTamper->Trigger));
+  assert_param(IS_RTC_TAMPER_ERASE_MODE(sTamper->NoErase));
+  assert_param(IS_RTC_TAMPER_MASKFLAG_STATE(sTamper->MaskFlag));
+  assert_param(IS_RTC_TAMPER_FILTER(sTamper->Filter));
+  assert_param(IS_RTC_TAMPER_FILTER_CONFIG_CORRECT(sTamper->Filter, sTamper->Trigger));
+  assert_param(IS_RTC_TAMPER_SAMPLING_FREQ(sTamper->SamplingFrequency));
+  assert_param(IS_RTC_TAMPER_PRECHARGE_DURATION(sTamper->PrechargeDuration));
+  assert_param(IS_RTC_TAMPER_PULLUP_STATE(sTamper->TamperPullUp));
+  assert_param(IS_RTC_TAMPER_TIMESTAMPONTAMPER_DETECTION(sTamper->TimeStampOnTamperDetection));
+
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Copy control register into temporary variable */
+  tmpreg = hrtc->Instance->TAMPCR;
+
+  /* Enable selected tamper */
+  tmpreg |= (sTamper->Tamper);
+
+  /* Configure the tamper trigger bit (this bit is just on the right of the
+       tamper enable bit, hence the one-time right shift before updating it) */
+  if (sTamper->Trigger == RTC_TAMPERTRIGGER_FALLINGEDGE)
+  {
+    /* Set the tamper trigger bit (case of falling edge or high level) */
+    tmpreg |= (uint32_t)(sTamper->Tamper << 1U);
+  }
+  else
+  {
+    /* Clear the tamper trigger bit (case of rising edge or low level) */
+    tmpreg &= (uint32_t)~(sTamper->Tamper << 1U);
+  }
+
+  /* Configure the backup registers erasure enabling bits */
+  if (sTamper->NoErase != RTC_TAMPER_ERASE_BACKUP_ENABLE)
+  {
+    if ((sTamper->Tamper & RTC_TAMPER_1) != 0U)
+    {
+      tmpreg |= (uint32_t)(RTC_TAMPCR_TAMP1NOERASE);
+    }
+    if ((sTamper->Tamper & RTC_TAMPER_2) != 0U)
+    {
+      tmpreg |= (uint32_t)(RTC_TAMPCR_TAMP2NOERASE);
+    }
+    if ((sTamper->Tamper & RTC_TAMPER_3) != 0U)
+    {
+      tmpreg |= (uint32_t)(RTC_TAMPCR_TAMP3NOERASE);
+    }
+  }
+  else
+  {
+    if ((sTamper->Tamper & RTC_TAMPER_1) != 0U)
+    {
+      tmpreg &= (uint32_t)~(RTC_TAMPCR_TAMP1NOERASE);
+    }
+    if ((sTamper->Tamper & RTC_TAMPER_2) != 0U)
+    {
+      tmpreg &= (uint32_t)~(RTC_TAMPCR_TAMP2NOERASE);
+    }
+    if ((sTamper->Tamper & RTC_TAMPER_3) != 0U)
+    {
+      tmpreg &= (uint32_t)~(RTC_TAMPCR_TAMP3NOERASE);
+    }
+  }
+
+  /* Configure the tamper flags masking bits */
+  if (sTamper->MaskFlag != RTC_TAMPERMASK_FLAG_DISABLE)
+  {
+    if ((sTamper->Tamper & RTC_TAMPER_1) != 0U)
+    {
+      tmpreg |= (uint32_t)(RTC_TAMPCR_TAMP1MF);
+    }
+    if ((sTamper->Tamper & RTC_TAMPER_2) != 0U)
+    {
+      tmpreg |= (uint32_t)(RTC_TAMPCR_TAMP2MF);
+    }
+    if ((sTamper->Tamper & RTC_TAMPER_3) != 0U)
+    {
+      tmpreg |= (uint32_t)(RTC_TAMPCR_TAMP3MF);
+    }
+  }
+  else
+  {
+    if ((sTamper->Tamper & RTC_TAMPER_1) != 0U)
+    {
+      tmpreg &= (uint32_t)~(RTC_TAMPCR_TAMP1MF);
+    }
+    if ((sTamper->Tamper & RTC_TAMPER_2) != 0U)
+    {
+      tmpreg &= (uint32_t)~(RTC_TAMPCR_TAMP2MF);
+    }
+    if ((sTamper->Tamper & RTC_TAMPER_3) != 0U)
+    {
+      tmpreg &= (uint32_t)~(RTC_TAMPCR_TAMP3MF);
+    }
+  }
+
+  /* Clear remaining fields before setting them */
+  tmpreg &= ~(RTC_TAMPERFILTER_MASK              | \
+              RTC_TAMPERSAMPLINGFREQ_RTCCLK_MASK | \
+              RTC_TAMPERPRECHARGEDURATION_MASK   | \
+              RTC_TAMPER_PULLUP_MASK             | \
+              RTC_TIMESTAMPONTAMPERDETECTION_MASK);
+
+  /* Set remaining parameters of desired configuration into temporary variable */
+  tmpreg |= ((uint32_t)sTamper->Filter            | \
+             (uint32_t)sTamper->SamplingFrequency | \
+             (uint32_t)sTamper->PrechargeDuration | \
+             (uint32_t)sTamper->TamperPullUp      | \
+             (uint32_t)sTamper->TimeStampOnTamperDetection);
+
+  /* Disable interrupt on selected tamper in case it is enabled */
+  if ((sTamper->Tamper & RTC_TAMPER_1) != 0U)
+  {
+    tmpreg &= (uint32_t)~RTC_IT_TAMP1;
+  }
+  if ((sTamper->Tamper & RTC_TAMPER_2) != 0U)
+  {
+    tmpreg &= (uint32_t)~RTC_IT_TAMP2;
+  }
+  if ((sTamper->Tamper & RTC_TAMPER_3) != 0U)
+  {
+    tmpreg &= (uint32_t)~RTC_IT_TAMP3;
+  }
+
+  /* Disable tamper global interrupt in case it is enabled */
+  tmpreg &= (uint32_t)~RTC_TAMPCR_TAMPIE;
+
+  /* Copy desired configuration into configuration register */
+  hrtc->Instance->TAMPCR = tmpreg;
+
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Sets Tamper with interrupt.
+  * @note   By setting the tamper global interrupt bit, interrupts will be
+  *         enabled for all tampers.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  sTamper Pointer to RTC Tamper.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_SetTamper_IT(RTC_HandleTypeDef *hrtc, RTC_TamperTypeDef *sTamper)
+{
+  uint32_t tmpreg = 0U;
+
+  /* Check the parameters */
+  assert_param(IS_RTC_TAMPER(sTamper->Tamper));
+  assert_param(IS_RTC_TAMPER_INTERRUPT(sTamper->Interrupt));
+  assert_param(IS_RTC_TAMPER_TRIGGER(sTamper->Trigger));
+  assert_param(IS_RTC_TAMPER_ERASE_MODE(sTamper->NoErase));
+  assert_param(IS_RTC_TAMPER_MASKFLAG_STATE(sTamper->MaskFlag));
+  assert_param(IS_RTC_TAMPER_FILTER(sTamper->Filter));
+  assert_param(IS_RTC_TAMPER_FILTER_CONFIG_CORRECT(sTamper->Filter, sTamper->Trigger));
+  assert_param(IS_RTC_TAMPER_SAMPLING_FREQ(sTamper->SamplingFrequency));
+  assert_param(IS_RTC_TAMPER_PRECHARGE_DURATION(sTamper->PrechargeDuration));
+  assert_param(IS_RTC_TAMPER_PULLUP_STATE(sTamper->TamperPullUp));
+  assert_param(IS_RTC_TAMPER_TIMESTAMPONTAMPER_DETECTION(sTamper->TimeStampOnTamperDetection));
+
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Copy control register into temporary variable */
+  tmpreg = hrtc->Instance->TAMPCR;
+
+  /* Enable selected tamper */
+  tmpreg |= (sTamper->Tamper);
+
+  /* Configure the tamper trigger bit (this bit is just on the right of the
+       tamper enable bit, hence the one-time right shift before updating it) */
+  if (sTamper->Trigger == RTC_TAMPERTRIGGER_FALLINGEDGE)
+  {
+    /* Set the tamper trigger bit (case of falling edge or high level) */
+    tmpreg |= (uint32_t)(sTamper->Tamper << 1U);
+  }
+  else
+  {
+    /* Clear the tamper trigger bit (case of rising edge or low level) */
+    tmpreg &= (uint32_t)~(sTamper->Tamper << 1U);
+  }
+
+  /* Configure the backup registers erasure enabling bits */
+  if (sTamper->NoErase != RTC_TAMPER_ERASE_BACKUP_ENABLE)
+  {
+    if ((sTamper->Tamper & RTC_TAMPER_1) != 0U)
+    {
+      tmpreg |= (uint32_t)(RTC_TAMPCR_TAMP1NOERASE);
+    }
+    if ((sTamper->Tamper & RTC_TAMPER_2) != 0U)
+    {
+      tmpreg |= (uint32_t)(RTC_TAMPCR_TAMP2NOERASE);
+    }
+    if ((sTamper->Tamper & RTC_TAMPER_3) != 0U)
+    {
+      tmpreg |= (uint32_t)(RTC_TAMPCR_TAMP3NOERASE);
+    }
+  }
+  else
+  {
+    if ((sTamper->Tamper & RTC_TAMPER_1) != 0U)
+    {
+      tmpreg &= (uint32_t)~(RTC_TAMPCR_TAMP1NOERASE);
+    }
+    if ((sTamper->Tamper & RTC_TAMPER_2) != 0U)
+    {
+      tmpreg &= (uint32_t)~(RTC_TAMPCR_TAMP2NOERASE);
+    }
+    if ((sTamper->Tamper & RTC_TAMPER_3) != 0U)
+    {
+      tmpreg &= (uint32_t)~(RTC_TAMPCR_TAMP3NOERASE);
+    }
+  }
+
+  /* Configure the tamper flags masking bits */
+  if (sTamper->MaskFlag != RTC_TAMPERMASK_FLAG_DISABLE)
+  {
+    if ((sTamper->Tamper & RTC_TAMPER_1) != 0U)
+    {
+      tmpreg |= (uint32_t)(RTC_TAMPCR_TAMP1MF);
+    }
+    if ((sTamper->Tamper & RTC_TAMPER_2) != 0U)
+    {
+      tmpreg |= (uint32_t)(RTC_TAMPCR_TAMP2MF);
+    }
+    if ((sTamper->Tamper & RTC_TAMPER_3) != 0U)
+    {
+      tmpreg |= (uint32_t)(RTC_TAMPCR_TAMP3MF);
+    }
+  }
+  else
+  {
+    if ((sTamper->Tamper & RTC_TAMPER_1) != 0U)
+    {
+      tmpreg &= (uint32_t)~(RTC_TAMPCR_TAMP1MF);
+    }
+    if ((sTamper->Tamper & RTC_TAMPER_2) != 0U)
+    {
+      tmpreg &= (uint32_t)~(RTC_TAMPCR_TAMP2MF);
+    }
+    if ((sTamper->Tamper & RTC_TAMPER_3) != 0U)
+    {
+      tmpreg &= (uint32_t)~(RTC_TAMPCR_TAMP3MF);
+    }
+  }
+
+  /* Clear remaining fields before setting them */
+  tmpreg &= ~(RTC_TAMPERFILTER_MASK              | \
+              RTC_TAMPERSAMPLINGFREQ_RTCCLK_MASK | \
+              RTC_TAMPERPRECHARGEDURATION_MASK   | \
+              RTC_TAMPER_PULLUP_MASK             | \
+              RTC_TIMESTAMPONTAMPERDETECTION_MASK);
+
+  /* Set remaining parameters of desired configuration into temporary variable */
+  tmpreg |= ((uint32_t)sTamper->Filter            | \
+             (uint32_t)sTamper->SamplingFrequency | \
+             (uint32_t)sTamper->PrechargeDuration | \
+             (uint32_t)sTamper->TamperPullUp      | \
+             (uint32_t)sTamper->TimeStampOnTamperDetection);
+
+  /* Enable interrupt on selected tamper */
+  tmpreg |= (uint32_t)sTamper->Interrupt;
+
+  /* Copy desired configuration into configuration register */
+  hrtc->Instance->TAMPCR = tmpreg;
+
+  /* RTC Tamper Interrupt Configuration: EXTI configuration */
+  __HAL_RTC_TAMPER_TIMESTAMP_EXTI_ENABLE_IT();
+  __HAL_RTC_TAMPER_TIMESTAMP_EXTI_ENABLE_RISING_EDGE();
+
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Deactivates Tamper.
+  * @note   By calling this API the tamper global interrupt will be disabled.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  Tamper Selected tamper pin.
+  *          This parameter can be any combination of the following values:
+  *            @arg RTC_TAMPER_1:  Tamper 1
+  *            @arg RTC_TAMPER_2:  Tamper 2
+  *            @arg RTC_TAMPER_3:  Tamper 3
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_DeactivateTamper(RTC_HandleTypeDef *hrtc, uint32_t Tamper)
+{
+  assert_param(IS_RTC_TAMPER(Tamper));
+
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Disable the selected Tamper pin */
+  hrtc->Instance->TAMPCR &= (uint32_t)~Tamper;
+
+  if ((Tamper & RTC_TAMPER_1) != 0U)
+  {
+    /* Disable the Tamper 1 interrupt */
+    hrtc->Instance->TAMPCR &= (uint32_t)~(RTC_IT_TAMP | RTC_IT_TAMP1);
+  }
+  if ((Tamper & RTC_TAMPER_2) != 0U)
+  {
+    /* Disable the Tamper 2 interrupt */
+    hrtc->Instance->TAMPCR &= (uint32_t)~(RTC_IT_TAMP | RTC_IT_TAMP2);
+  }
+  if ((Tamper & RTC_TAMPER_3) != 0U)
+  {
+    /* Disable the Tamper 3 interrupt */
+    hrtc->Instance->TAMPCR &= (uint32_t)~(RTC_IT_TAMP | RTC_IT_TAMP3);
+  }
+
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Handles Timestamp and Tamper interrupt request.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @retval None
+  */
+void HAL_RTCEx_TamperTimeStampIRQHandler(RTC_HandleTypeDef *hrtc)
+{
+  /* Clear the EXTI's Flag for RTC Timestamp and Tamper */
+  __HAL_RTC_TAMPER_TIMESTAMP_EXTI_CLEAR_FLAG();
+
+  /* Get the Timestamp interrupt source enable status */
+  if (__HAL_RTC_TIMESTAMP_GET_IT_SOURCE(hrtc, RTC_IT_TS) != 0U)
+  {
+    /* Get the pending status of the Timestamp Interrupt */
+    if (__HAL_RTC_TIMESTAMP_GET_FLAG(hrtc, RTC_FLAG_TSF) != 0U)
+    {
+      /* Timestamp callback */
+#if (USE_HAL_RTC_REGISTER_CALLBACKS == 1)
+      hrtc->TimeStampEventCallback(hrtc);
+#else
+      HAL_RTCEx_TimeStampEventCallback(hrtc);
+#endif /* USE_HAL_RTC_REGISTER_CALLBACKS */
+
+      /* Clear the Timestamp interrupt pending bit after returning from callback
+         as RTC_TSTR and RTC_TSDR registers are cleared when TSF bit is reset */
+      __HAL_RTC_TIMESTAMP_CLEAR_FLAG(hrtc, RTC_FLAG_TSF);
+    }
+  }
+
+  /* Get the Tamper 1 interrupt source enable status */
+  if (__HAL_RTC_TAMPER_GET_IT_SOURCE(hrtc, RTC_IT_TAMP | RTC_IT_TAMP1) != 0U)
+  {
+    /* Get the pending status of the Tamper 1 Interrupt */
+    if (__HAL_RTC_TAMPER_GET_FLAG(hrtc, RTC_FLAG_TAMP1F) != 0U)
+    {
+      /* Clear the Tamper interrupt pending bit */
+      __HAL_RTC_TAMPER_CLEAR_FLAG(hrtc, RTC_FLAG_TAMP1F);
+
+      /* Tamper callback */
+#if (USE_HAL_RTC_REGISTER_CALLBACKS == 1)
+      hrtc->Tamper1EventCallback(hrtc);
+#else
+      HAL_RTCEx_Tamper1EventCallback(hrtc);
+#endif /* USE_HAL_RTC_REGISTER_CALLBACKS */
+    }
+  }
+
+  /* Get the Tamper 2 interrupt source enable status */
+  if (__HAL_RTC_TAMPER_GET_IT_SOURCE(hrtc, RTC_IT_TAMP | RTC_IT_TAMP2) != 0U)
+  {
+    /* Get the pending status of the Tamper 2 Interrupt */
+    if (__HAL_RTC_TAMPER_GET_FLAG(hrtc, RTC_FLAG_TAMP2F) != 0U)
+    {
+      /* Clear the Tamper interrupt pending bit */
+      __HAL_RTC_TAMPER_CLEAR_FLAG(hrtc, RTC_FLAG_TAMP2F);
+
+      /* Tamper callback */
+#if (USE_HAL_RTC_REGISTER_CALLBACKS == 1)
+      hrtc->Tamper2EventCallback(hrtc);
+#else
+      HAL_RTCEx_Tamper2EventCallback(hrtc);
+#endif /* USE_HAL_RTC_REGISTER_CALLBACKS */
+    }
+  }
+
+  /* Get the Tamper 3 interrupt source enable status */
+  if (__HAL_RTC_TAMPER_GET_IT_SOURCE(hrtc, RTC_IT_TAMP | RTC_IT_TAMP3) != 0U)
+  {
+    /* Get the pending status of the Tamper 3 Interrupt */
+    if (__HAL_RTC_TAMPER_GET_FLAG(hrtc, RTC_FLAG_TAMP3F) != 0U)
+    {
+      /* Clear the Tamper interrupt pending bit */
+      __HAL_RTC_TAMPER_CLEAR_FLAG(hrtc, RTC_FLAG_TAMP3F);
+
+      /* Tamper callback */
+#if (USE_HAL_RTC_REGISTER_CALLBACKS == 1)
+      hrtc->Tamper3EventCallback(hrtc);
+#else
+      HAL_RTCEx_Tamper3EventCallback(hrtc);
+#endif /* USE_HAL_RTC_REGISTER_CALLBACKS */
+    }
+  }
+
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+}
+
+/**
+  * @brief  Timestamp callback.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @retval None
+  */
+__weak void HAL_RTCEx_TimeStampEventCallback(RTC_HandleTypeDef *hrtc)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hrtc);
+
+  /* NOTE: This function should not be modified, when the callback is needed,
+           the HAL_RTCEx_TimeStampEventCallback could be implemented in the user file
+  */
+}
+
+/**
+  * @brief  Tamper 1 callback.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @retval None
+  */
+__weak void HAL_RTCEx_Tamper1EventCallback(RTC_HandleTypeDef *hrtc)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hrtc);
+
+  /* NOTE: This function should not be modified, when the callback is needed,
+           the HAL_RTCEx_Tamper1EventCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Tamper 2 callback.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @retval None
+  */
+__weak void HAL_RTCEx_Tamper2EventCallback(RTC_HandleTypeDef *hrtc)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hrtc);
+
+  /* NOTE: This function should not be modified, when the callback is needed,
+           the HAL_RTCEx_Tamper2EventCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Tamper 3 callback.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @retval None
+  */
+__weak void HAL_RTCEx_Tamper3EventCallback(RTC_HandleTypeDef *hrtc)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hrtc);
+
+  /* NOTE: This function should not be modified, when the callback is needed,
+           the HAL_RTCEx_Tamper3EventCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Handles Timestamp polling request.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  Timeout Timeout duration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_PollForTimeStampEvent(RTC_HandleTypeDef *hrtc, uint32_t Timeout)
+{
+  uint32_t tickstart = 0U;
+
+  /* Get tick */
+  tickstart = HAL_GetTick();
+
+  while (__HAL_RTC_TIMESTAMP_GET_FLAG(hrtc, RTC_FLAG_TSF) == 0U)
+  {
+    if (Timeout != HAL_MAX_DELAY)
+    {
+      if ((Timeout == 0U) || ((HAL_GetTick() - tickstart) > Timeout))
+      {
+        hrtc->State = HAL_RTC_STATE_TIMEOUT;
+        return HAL_TIMEOUT;
+      }
+    }
+
+    if (__HAL_RTC_TIMESTAMP_GET_FLAG(hrtc, RTC_FLAG_TSOVF) != 0U)
+    {
+      /* Clear the Timestamp Overrun Flag */
+      __HAL_RTC_TIMESTAMP_CLEAR_FLAG(hrtc, RTC_FLAG_TSOVF);
+
+      /* Change Timestamp state */
+      hrtc->State = HAL_RTC_STATE_ERROR;
+
+      return HAL_ERROR;
+    }
+  }
+
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Handles Tamper 1 Polling.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  Timeout Timeout duration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_PollForTamper1Event(RTC_HandleTypeDef *hrtc, uint32_t Timeout)
+{
+  uint32_t tickstart = 0U;
+
+  /* Get tick */
+  tickstart = HAL_GetTick();
+
+  /* Get the status of the Interrupt */
+  while (__HAL_RTC_TAMPER_GET_FLAG(hrtc, RTC_FLAG_TAMP1F) == 0U)
+  {
+    if (Timeout != HAL_MAX_DELAY)
+    {
+      if ((Timeout == 0U) || ((HAL_GetTick() - tickstart) > Timeout))
+      {
+        hrtc->State = HAL_RTC_STATE_TIMEOUT;
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+
+  /* Clear the Tamper Flag */
+  __HAL_RTC_TAMPER_CLEAR_FLAG(hrtc, RTC_FLAG_TAMP1F);
+
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Handles Tamper 2 Polling.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  Timeout Timeout duration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_PollForTamper2Event(RTC_HandleTypeDef *hrtc, uint32_t Timeout)
+{
+  uint32_t tickstart = 0U;
+
+  /* Get tick */
+  tickstart = HAL_GetTick();
+
+  /* Get the status of the Interrupt */
+  while (__HAL_RTC_TAMPER_GET_FLAG(hrtc, RTC_FLAG_TAMP2F) == 0U)
+  {
+    if (Timeout != HAL_MAX_DELAY)
+    {
+      if ((Timeout == 0U) || ((HAL_GetTick() - tickstart) > Timeout))
+      {
+        hrtc->State = HAL_RTC_STATE_TIMEOUT;
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+
+  /* Clear the Tamper Flag */
+  __HAL_RTC_TAMPER_CLEAR_FLAG(hrtc, RTC_FLAG_TAMP2F);
+
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Handles Tamper 3 Polling.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  Timeout Timeout duration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_PollForTamper3Event(RTC_HandleTypeDef *hrtc, uint32_t Timeout)
+{
+  uint32_t tickstart = HAL_GetTick();
+
+  /* Get the status of the Interrupt */
+  while (__HAL_RTC_TAMPER_GET_FLAG(hrtc, RTC_FLAG_TAMP3F) == 0U)
+  {
+    if (Timeout != HAL_MAX_DELAY)
+    {
+      if ((Timeout == 0U) || ((HAL_GetTick() - tickstart) > Timeout))
+      {
+        hrtc->State = HAL_RTC_STATE_TIMEOUT;
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+
+  /* Clear the Tamper Flag */
+  __HAL_RTC_TAMPER_CLEAR_FLAG(hrtc, RTC_FLAG_TAMP3F);
+
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_Exported_Functions_Group2 RTC Wakeup functions
+  * @brief    RTC Wakeup functions
+  *
+@verbatim
+ ===============================================================================
+                        ##### RTC Wakeup functions #####
+ ===============================================================================
+
+ [..] This section provides functions allowing to configure Wakeup feature
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Sets wakeup timer.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  WakeUpCounter Wakeup counter
+  * @param  WakeUpClock Wakeup clock
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_SetWakeUpTimer(RTC_HandleTypeDef *hrtc, uint32_t WakeUpCounter, uint32_t WakeUpClock)
+{
+  uint32_t tickstart = 0U;
+
+  /* Check the parameters */
+  assert_param(IS_RTC_WAKEUP_CLOCK(WakeUpClock));
+  assert_param(IS_RTC_WAKEUP_COUNTER(WakeUpCounter));
+
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  /* Check RTC WUTWF flag is reset only when wakeup timer enabled*/
+  if ((hrtc->Instance->CR & RTC_CR_WUTE) != 0U)
+  {
+    tickstart = HAL_GetTick();
+
+    /* Wait till RTC WUTWF flag is reset and if timeout is reached exit */
+    while (__HAL_RTC_WAKEUPTIMER_GET_FLAG(hrtc, RTC_FLAG_WUTWF) != 0U)
+    {
+      if ((HAL_GetTick() - tickstart) > RTC_TIMEOUT_VALUE)
+      {
+        /* Enable the write protection for RTC registers */
+        __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+        hrtc->State = HAL_RTC_STATE_TIMEOUT;
+
+        /* Process Unlocked */
+        __HAL_UNLOCK(hrtc);
+
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+
+  /* Disable the Wakeup timer */
+  __HAL_RTC_WAKEUPTIMER_DISABLE(hrtc);
+
+  /* Clear the Wakeup flag */
+  __HAL_RTC_WAKEUPTIMER_CLEAR_FLAG(hrtc, RTC_FLAG_WUTF);
+
+  /* Get tick */
+  tickstart = HAL_GetTick();
+
+  /* Wait till RTC WUTWF flag is set and if timeout is reached exit */
+  while (__HAL_RTC_WAKEUPTIMER_GET_FLAG(hrtc, RTC_FLAG_WUTWF) == 0U)
+  {
+    if ((HAL_GetTick() - tickstart) > RTC_TIMEOUT_VALUE)
+    {
+      /* Enable the write protection for RTC registers */
+      __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+      hrtc->State = HAL_RTC_STATE_TIMEOUT;
+
+      /* Process Unlocked */
+      __HAL_UNLOCK(hrtc);
+
+      return HAL_TIMEOUT;
+    }
+  }
+
+  /* Clear the Wakeup Timer clock source bits in CR register */
+  hrtc->Instance->CR &= (uint32_t)~RTC_CR_WUCKSEL;
+
+  /* Configure the clock source */
+  hrtc->Instance->CR |= (uint32_t)WakeUpClock;
+
+  /* Configure the Wakeup Timer counter */
+  hrtc->Instance->WUTR = (uint32_t)WakeUpCounter;
+
+  /* Enable the Wakeup Timer */
+  __HAL_RTC_WAKEUPTIMER_ENABLE(hrtc);
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Sets wakeup timer with interrupt.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  WakeUpCounter Wakeup counter
+  * @param  WakeUpClock Wakeup clock
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_SetWakeUpTimer_IT(RTC_HandleTypeDef *hrtc, uint32_t WakeUpCounter, uint32_t WakeUpClock)
+{
+  __IO uint32_t count  = RTC_TIMEOUT_VALUE * (SystemCoreClock / 32U / 1000U);
+
+  /* Check the parameters */
+  assert_param(IS_RTC_WAKEUP_CLOCK(WakeUpClock));
+  assert_param(IS_RTC_WAKEUP_COUNTER(WakeUpCounter));
+
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  /* Check RTC WUTWF flag is reset only when wakeup timer enabled */
+  if ((hrtc->Instance->CR & RTC_CR_WUTE) != 0U)
+  {
+    /* Wait till RTC WUTWF flag is reset and if timeout is reached exit */
+    do
+    {
+      count = count - 1U;
+      if (count == 0U)
+      {
+        /* Enable the write protection for RTC registers */
+        __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+        hrtc->State = HAL_RTC_STATE_TIMEOUT;
+
+        /* Process Unlocked */
+        __HAL_UNLOCK(hrtc);
+
+        return HAL_TIMEOUT;
+      }
+    } while (__HAL_RTC_WAKEUPTIMER_GET_FLAG(hrtc, RTC_FLAG_WUTWF) != 0U);
+  }
+
+  /* Disable the Wakeup timer */
+  __HAL_RTC_WAKEUPTIMER_DISABLE(hrtc);
+
+  /* Clear the Wakeup flag */
+  __HAL_RTC_WAKEUPTIMER_CLEAR_FLAG(hrtc, RTC_FLAG_WUTF);
+
+  /* Reload the counter */
+  count = RTC_TIMEOUT_VALUE * (SystemCoreClock / 32U / 1000U);
+
+  /* Wait till RTC WUTWF flag is set and if timeout is reached exit */
+  do
+  {
+    count = count - 1U;
+    if (count == 0U)
+    {
+      /* Enable the write protection for RTC registers */
+      __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+      hrtc->State = HAL_RTC_STATE_TIMEOUT;
+
+      /* Process Unlocked */
+      __HAL_UNLOCK(hrtc);
+
+      return HAL_TIMEOUT;
+    }
+  } while (__HAL_RTC_WAKEUPTIMER_GET_FLAG(hrtc, RTC_FLAG_WUTWF) == 0U);
+
+  /* Clear the Wakeup Timer clock source bits in CR register */
+  hrtc->Instance->CR &= (uint32_t)~RTC_CR_WUCKSEL;
+
+  /* Configure the clock source */
+  hrtc->Instance->CR |= (uint32_t)WakeUpClock;
+
+  /* Configure the Wakeup Timer counter */
+  hrtc->Instance->WUTR = (uint32_t)WakeUpCounter;
+
+  /* RTC wakeup timer Interrupt Configuration: EXTI configuration */
+  __HAL_RTC_WAKEUPTIMER_EXTI_ENABLE_IT();
+  __HAL_RTC_WAKEUPTIMER_EXTI_ENABLE_RISING_EDGE();
+
+  /* Configure the interrupt in the RTC_CR register */
+  __HAL_RTC_WAKEUPTIMER_ENABLE_IT(hrtc, RTC_IT_WUT);
+
+  /* Enable the Wakeup Timer */
+  __HAL_RTC_WAKEUPTIMER_ENABLE(hrtc);
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Deactivates wakeup timer counter.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_DeactivateWakeUpTimer(RTC_HandleTypeDef *hrtc)
+{
+  uint32_t tickstart = 0U;
+
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  /* Disable the Wakeup Timer */
+  __HAL_RTC_WAKEUPTIMER_DISABLE(hrtc);
+
+  /* In case of interrupt mode is used, the interrupt source must disabled */
+  __HAL_RTC_WAKEUPTIMER_DISABLE_IT(hrtc, RTC_IT_WUT);
+
+  /* Get tick */
+  tickstart = HAL_GetTick();
+
+  /* Wait till RTC WUTWF flag is set and if timeout is reached exit */
+  while (__HAL_RTC_WAKEUPTIMER_GET_FLAG(hrtc, RTC_FLAG_WUTWF) == 0U)
+  {
+    if ((HAL_GetTick() - tickstart) > RTC_TIMEOUT_VALUE)
+    {
+      /* Enable the write protection for RTC registers */
+      __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+      hrtc->State = HAL_RTC_STATE_TIMEOUT;
+
+      /* Process Unlocked */
+      __HAL_UNLOCK(hrtc);
+
+      return HAL_TIMEOUT;
+    }
+  }
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Gets wakeup timer counter.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @retval Counter value
+  */
+uint32_t HAL_RTCEx_GetWakeUpTimer(RTC_HandleTypeDef *hrtc)
+{
+  /* Get the counter value */
+  return ((uint32_t)(hrtc->Instance->WUTR & RTC_WUTR_WUT));
+}
+
+/**
+  * @brief  Handles Wakeup Timer interrupt request.
+  * @note   Unlike alarm interrupt line (shared by Alarms A and B) or tamper
+  *         interrupt line (shared by timestamp and tampers) wakeup timer
+  *         interrupt line is exclusive to the wakeup timer.
+  *         There is no need in this case to check on the interrupt enable
+  *         status via __HAL_RTC_WAKEUPTIMER_GET_IT_SOURCE().
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @retval None
+  */
+void HAL_RTCEx_WakeUpTimerIRQHandler(RTC_HandleTypeDef *hrtc)
+{
+  /* Clear the EXTI's line Flag for RTC WakeUpTimer */
+  __HAL_RTC_WAKEUPTIMER_EXTI_CLEAR_FLAG();
+
+  /* Get the pending status of the Wakeup timer Interrupt */
+  if (__HAL_RTC_WAKEUPTIMER_GET_FLAG(hrtc, RTC_FLAG_WUTF) != 0U)
+  {
+    /* Clear the Wakeup timer interrupt pending bit */
+    __HAL_RTC_WAKEUPTIMER_CLEAR_FLAG(hrtc, RTC_FLAG_WUTF);
+
+    /* Wakeup timer callback */
+#if (USE_HAL_RTC_REGISTER_CALLBACKS == 1)
+    hrtc->WakeUpTimerEventCallback(hrtc);
+#else
+    HAL_RTCEx_WakeUpTimerEventCallback(hrtc);
+#endif /* USE_HAL_RTC_REGISTER_CALLBACKS */
+  }
+
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+}
+
+/**
+  * @brief  Wakeup Timer callback.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @retval None
+  */
+__weak void HAL_RTCEx_WakeUpTimerEventCallback(RTC_HandleTypeDef *hrtc)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hrtc);
+
+  /* NOTE: This function should not be modified, when the callback is needed,
+           the HAL_RTCEx_WakeUpTimerEventCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Handles Wakeup Timer Polling.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  Timeout Timeout duration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_PollForWakeUpTimerEvent(RTC_HandleTypeDef *hrtc, uint32_t Timeout)
+{
+  uint32_t tickstart = 0U;
+
+  /* Get tick */
+  tickstart = HAL_GetTick();
+
+  while (__HAL_RTC_WAKEUPTIMER_GET_FLAG(hrtc, RTC_FLAG_WUTF) == 0U)
+  {
+    if (Timeout != HAL_MAX_DELAY)
+    {
+      if ((Timeout == 0U) || ((HAL_GetTick() - tickstart) > Timeout))
+      {
+        hrtc->State = HAL_RTC_STATE_TIMEOUT;
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+
+  /* Clear the Wakeup timer Flag */
+  __HAL_RTC_WAKEUPTIMER_CLEAR_FLAG(hrtc, RTC_FLAG_WUTF);
+
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_Exported_Functions_Group3 Extended Peripheral Control functions
+  * @brief    Extended Peripheral Control functions
+  *
+@verbatim
+ ===============================================================================
+              ##### Extended Peripheral Control functions #####
+ ===============================================================================
+    [..]
+    This subsection provides functions allowing to
+      (+) Write a data in a specified RTC Backup data register
+      (+) Read a data in a specified RTC Backup data register
+      (+) Set the Smooth calibration parameters.
+      (+) Configure the Synchronization Shift Control Settings.
+      (+) Configure the Calibration Pinout (RTC_CALIB) Selection (1Hz or 512Hz).
+      (+) Deactivate the Calibration Pinout (RTC_CALIB) Selection (1Hz or 512Hz).
+      (+) Enable the RTC reference clock detection.
+      (+) Disable the RTC reference clock detection.
+      (+) Enable the Bypass Shadow feature.
+      (+) Disable the Bypass Shadow feature.
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Writes a data in a specified RTC Backup data register.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  BackupRegister RTC Backup data Register number.
+  *          This parameter can be: RTC_BKP_DRx (where x can be from 0 to 31)
+  *                                 to specify the register.
+  * @param  Data Data to be written in the specified RTC Backup data register.
+  * @retval None
+  */
+void HAL_RTCEx_BKUPWrite(RTC_HandleTypeDef *hrtc, uint32_t BackupRegister, uint32_t Data)
+{
+  uint32_t tmp = 0U;
+
+  /* Check the parameters */
+  assert_param(IS_RTC_BKP(BackupRegister));
+
+  tmp = (uint32_t) & (hrtc->Instance->BKP0R);
+  tmp += (BackupRegister * 4U);
+
+  /* Write the specified register */
+  *(__IO uint32_t *)tmp = (uint32_t)Data;
+}
+
+/**
+  * @brief  Reads data from the specified RTC Backup data Register.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  BackupRegister RTC Backup data Register number.
+  *          This parameter can be: RTC_BKP_DRx (where x can be from 0 to 31)
+  *                                 to specify the register.
+  * @retval Read value
+  */
+uint32_t HAL_RTCEx_BKUPRead(RTC_HandleTypeDef *hrtc, uint32_t BackupRegister)
+{
+  uint32_t tmp = 0U;
+
+  /* Check the parameters */
+  assert_param(IS_RTC_BKP(BackupRegister));
+
+  tmp = (uint32_t) & (hrtc->Instance->BKP0R);
+  tmp += (BackupRegister * 4U);
+
+  /* Read the specified register */
+  return (*(__IO uint32_t *)tmp);
+}
+
+/**
+  * @brief  Sets the Smooth calibration parameters.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  SmoothCalibPeriod Select the Smooth Calibration Period.
+  *          This parameter can be can be one of the following values:
+  *             @arg RTC_SMOOTHCALIB_PERIOD_32SEC: The smooth calibration period is 32s.
+  *             @arg RTC_SMOOTHCALIB_PERIOD_16SEC: The smooth calibration period is 16s.
+  *             @arg RTC_SMOOTHCALIB_PERIOD_8SEC: The smooth calibration period is 8s.
+  * @param  SmoothCalibPlusPulses Select to Set or reset the CALP bit.
+  *          This parameter can be one of the following values:
+  *             @arg RTC_SMOOTHCALIB_PLUSPULSES_SET: Add one RTCCLK pulse every 2*11 pulses.
+  *             @arg RTC_SMOOTHCALIB_PLUSPULSES_RESET: No RTCCLK pulses are added.
+  * @param  SmoothCalibMinusPulsesValue Select the value of CALM[8:0] bits.
+  *          This parameter can be one any value from 0 to 0x000001FF.
+  * @note   To deactivate the smooth calibration, the field SmoothCalibPlusPulses
+  *         must be equal to SMOOTHCALIB_PLUSPULSES_RESET and the field
+  *         SmoothCalibMinusPulsesValue must be equal to 0.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_SetSmoothCalib(RTC_HandleTypeDef *hrtc, uint32_t SmoothCalibPeriod, uint32_t SmoothCalibPlusPulses, uint32_t SmoothCalibMinusPulsesValue)
+{
+  uint32_t tickstart = 0U;
+
+  /* Check the parameters */
+  assert_param(IS_RTC_SMOOTH_CALIB_PERIOD(SmoothCalibPeriod));
+  assert_param(IS_RTC_SMOOTH_CALIB_PLUS(SmoothCalibPlusPulses));
+  assert_param(IS_RTC_SMOOTH_CALIB_MINUS(SmoothCalibMinusPulsesValue));
+
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  /* check if a calibration is pending*/
+  if ((hrtc->Instance->ISR & RTC_ISR_RECALPF) != 0U)
+  {
+    /* Get tick */
+    tickstart = HAL_GetTick();
+
+    /* check if a calibration is pending*/
+    while ((hrtc->Instance->ISR & RTC_ISR_RECALPF) != 0U)
+    {
+      if ((HAL_GetTick() - tickstart) > RTC_TIMEOUT_VALUE)
+      {
+        /* Enable the write protection for RTC registers */
+        __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+        /* Change RTC state */
+        hrtc->State = HAL_RTC_STATE_TIMEOUT;
+
+        /* Process Unlocked */
+        __HAL_UNLOCK(hrtc);
+
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+
+  /* Configure the Smooth calibration settings */
+  hrtc->Instance->CALR = (uint32_t)((uint32_t)SmoothCalibPeriod     | \
+                                    (uint32_t)SmoothCalibPlusPulses | \
+                                    (uint32_t)SmoothCalibMinusPulsesValue);
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Configures the Synchronization Shift Control Settings.
+  * @note   When REFCKON is set, firmware must not write to Shift control register.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  ShiftAdd1S Select to add or not 1 second to the time calendar.
+  *          This parameter can be one of the following values:
+  *             @arg RTC_SHIFTADD1S_SET: Add one second to the clock calendar.
+  *             @arg RTC_SHIFTADD1S_RESET: No effect.
+  * @param  ShiftSubFS Select the number of Second Fractions to substitute.
+  *          This parameter can be one any value from 0 to 0x7FFF.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_SetSynchroShift(RTC_HandleTypeDef *hrtc, uint32_t ShiftAdd1S, uint32_t ShiftSubFS)
+{
+  uint32_t tickstart = 0U;
+
+  /* Check the parameters */
+  assert_param(IS_RTC_SHIFT_ADD1S(ShiftAdd1S));
+  assert_param(IS_RTC_SHIFT_SUBFS(ShiftSubFS));
+
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  /* Get tick */
+  tickstart = HAL_GetTick();
+
+  /* Wait until the shift is completed */
+  while ((hrtc->Instance->ISR & RTC_ISR_SHPF) != 0U)
+  {
+    if ((HAL_GetTick() - tickstart) > RTC_TIMEOUT_VALUE)
+    {
+      /* Enable the write protection for RTC registers */
+      __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+      hrtc->State = HAL_RTC_STATE_TIMEOUT;
+
+      /* Process Unlocked */
+      __HAL_UNLOCK(hrtc);
+
+      return HAL_TIMEOUT;
+    }
+  }
+
+  /* Check if the reference clock detection is disabled */
+  if ((hrtc->Instance->CR & RTC_CR_REFCKON) == 0U)
+  {
+    /* Configure the Shift settings */
+    hrtc->Instance->SHIFTR = (uint32_t)(uint32_t)(ShiftSubFS) | (uint32_t)(ShiftAdd1S);
+
+    /* If  RTC_CR_BYPSHAD bit = 0, wait for synchro else this check is not needed */
+    if ((hrtc->Instance->CR & RTC_CR_BYPSHAD) == 0U)
+    {
+      if (HAL_RTC_WaitForSynchro(hrtc) != HAL_OK)
+      {
+        /* Enable the write protection for RTC registers */
+        __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+        hrtc->State = HAL_RTC_STATE_ERROR;
+
+        /* Process Unlocked */
+        __HAL_UNLOCK(hrtc);
+
+        return HAL_ERROR;
+      }
+    }
+  }
+  else
+  {
+    /* Enable the write protection for RTC registers */
+    __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+    /* Change RTC state */
+    hrtc->State = HAL_RTC_STATE_ERROR;
+
+    /* Process Unlocked */
+    __HAL_UNLOCK(hrtc);
+
+    return HAL_ERROR;
+  }
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Configures the Calibration Pinout (RTC_CALIB) Selection (1Hz or 512Hz).
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  CalibOutput Select the Calibration output Selection.
+  *          This parameter can be one of the following values:
+  *             @arg RTC_CALIBOUTPUT_512HZ: A signal has a regular waveform at 512Hz.
+  *             @arg RTC_CALIBOUTPUT_1HZ: A signal has a regular waveform at 1Hz.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_SetCalibrationOutPut(RTC_HandleTypeDef *hrtc, uint32_t CalibOutput)
+{
+  /* Check the parameters */
+  assert_param(IS_RTC_CALIB_OUTPUT(CalibOutput));
+
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  /* Clear flags before config */
+  hrtc->Instance->CR &= (uint32_t)~RTC_CR_COSEL;
+
+  /* Configure the RTC_CR register */
+  hrtc->Instance->CR |= (uint32_t)CalibOutput;
+
+  __HAL_RTC_CALIBRATION_OUTPUT_ENABLE(hrtc);
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Deactivates the Calibration Pinout (RTC_CALIB) Selection (1Hz or 512Hz).
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_DeactivateCalibrationOutPut(RTC_HandleTypeDef *hrtc)
+{
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  __HAL_RTC_CALIBRATION_OUTPUT_DISABLE(hrtc);
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Enables the RTC reference clock detection.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_SetRefClock(RTC_HandleTypeDef *hrtc)
+{
+  HAL_StatusTypeDef status;
+
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  /* Enter Initialization mode */
+  status = RTC_EnterInitMode(hrtc);
+
+  if (status == HAL_OK)
+  {
+    /* Enable the reference clock detection */
+    __HAL_RTC_CLOCKREF_DETECTION_ENABLE(hrtc);
+
+    /* Exit Initialization mode */
+    status = RTC_ExitInitMode(hrtc);
+  }
+
+  if (status == HAL_OK)
+  {
+    hrtc->State = HAL_RTC_STATE_READY;
+  }
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return status;
+}
+
+/**
+  * @brief  Disable the RTC reference clock detection.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_DeactivateRefClock(RTC_HandleTypeDef *hrtc)
+{
+  HAL_StatusTypeDef status;
+
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  /* Enter Initialization mode */
+  status = RTC_EnterInitMode(hrtc);
+
+  if (status == HAL_OK)
+  {
+    /* Disable the reference clock detection */
+    __HAL_RTC_CLOCKREF_DETECTION_DISABLE(hrtc);
+
+    /* Exit Initialization mode */
+    status = RTC_ExitInitMode(hrtc);
+  }
+
+  if (status == HAL_OK)
+  {
+    hrtc->State = HAL_RTC_STATE_READY;
+  }
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return status;
+}
+
+/**
+  * @brief  Enables the Bypass Shadow feature.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @note   When the Bypass Shadow is enabled the calendar value are taken
+  *         directly from the Calendar counter.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_EnableBypassShadow(RTC_HandleTypeDef *hrtc)
+{
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  /* Set the BYPSHAD bit */
+  hrtc->Instance->CR |= (uint8_t)RTC_CR_BYPSHAD;
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @brief  Disables the Bypass Shadow feature.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @note   When the Bypass Shadow is enabled the calendar value are taken
+  *         directly from the Calendar counter.
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_DisableBypassShadow(RTC_HandleTypeDef *hrtc)
+{
+  /* Process Locked */
+  __HAL_LOCK(hrtc);
+
+  hrtc->State = HAL_RTC_STATE_BUSY;
+
+  /* Disable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
+
+  /* Reset the BYPSHAD bit */
+  hrtc->Instance->CR &= (uint8_t)~RTC_CR_BYPSHAD;
+
+  /* Enable the write protection for RTC registers */
+  __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(hrtc);
+
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+/** @defgroup RTCEx_Exported_Functions_Group4 Extended features functions
+  * @brief    Extended features functions
+  *
+@verbatim
+ ===============================================================================
+                 ##### Extended features functions #####
+ ===============================================================================
+    [..]  This section provides functions allowing to:
+      (+) RTC Alarm B callback
+      (+) RTC Poll for Alarm B request
+
+@endverbatim
+  * @{
+  */
+
+/**
+  * @brief  Alarm B callback.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @retval None
+  */
+__weak void HAL_RTCEx_AlarmBEventCallback(RTC_HandleTypeDef *hrtc)
+{
+  /* Prevent unused argument(s) compilation warning */
+  UNUSED(hrtc);
+
+  /* NOTE: This function should not be modified, when the callback is needed,
+           the HAL_RTCEx_AlarmBEventCallback could be implemented in the user file
+   */
+}
+
+/**
+  * @brief  Handles Alarm B Polling request.
+  * @param  hrtc pointer to a RTC_HandleTypeDef structure that contains
+  *                the configuration information for RTC.
+  * @param  Timeout Timeout duration
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_RTCEx_PollForAlarmBEvent(RTC_HandleTypeDef *hrtc, uint32_t Timeout)
+{
+  uint32_t tickstart = 0U;
+
+  /* Get tick */
+  tickstart = HAL_GetTick();
+
+  /* Wait till RTC ALRBF flag is set and if timeout is reached exit */
+  while (__HAL_RTC_ALARM_GET_FLAG(hrtc, RTC_FLAG_ALRBF) == 0U)
+  {
+    if (Timeout != HAL_MAX_DELAY)
+    {
+      if ((Timeout == 0U) || ((HAL_GetTick() - tickstart) > Timeout))
+      {
+        hrtc->State = HAL_RTC_STATE_TIMEOUT;
+        return HAL_TIMEOUT;
+      }
+    }
+  }
+
+  /* Clear the Alarm flag */
+  __HAL_RTC_ALARM_CLEAR_FLAG(hrtc, RTC_FLAG_ALRBF);
+
+  /* Change RTC state */
+  hrtc->State = HAL_RTC_STATE_READY;
+
+  return HAL_OK;
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#endif /* HAL_RTC_MODULE_ENABLED */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */

--- a/lib/STM32F7xx_HAL_Driver/Src/stm32f7xx_hal_spi.c
+++ b/lib/STM32F7xx_HAL_Driver/Src/stm32f7xx_hal_spi.c
@@ -909,6 +909,7 @@ HAL_StatusTypeDef HAL_SPI_Transmit(SPI_HandleTypeDef *hspi, uint8_t *pData, uint
         if ((((HAL_GetTick() - tickstart) >=  Timeout) && (Timeout != HAL_MAX_DELAY)) || (Timeout == 0U))
         {
           errorcode = HAL_TIMEOUT;
+          hspi->State = HAL_SPI_STATE_READY;
           goto error;
         }
       }
@@ -958,6 +959,7 @@ HAL_StatusTypeDef HAL_SPI_Transmit(SPI_HandleTypeDef *hspi, uint8_t *pData, uint
         if ((((HAL_GetTick() - tickstart) >=  Timeout) && (Timeout != HAL_MAX_DELAY)) || (Timeout == 0U))
         {
           errorcode = HAL_TIMEOUT;
+          hspi->State = HAL_SPI_STATE_READY;
           goto error;
         }
       }
@@ -987,9 +989,12 @@ HAL_StatusTypeDef HAL_SPI_Transmit(SPI_HandleTypeDef *hspi, uint8_t *pData, uint
   {
     errorcode = HAL_ERROR;
   }
+  else
+  {
+    hspi->State = HAL_SPI_STATE_READY;
+  }
 
 error:
-  hspi->State = HAL_SPI_STATE_READY;
   /* Process Unlocked */
   __HAL_UNLOCK(hspi);
   return errorcode;
@@ -1014,6 +1019,12 @@ HAL_StatusTypeDef HAL_SPI_Receive(SPI_HandleTypeDef *hspi, uint8_t *pData, uint1
   uint32_t tickstart;
   HAL_StatusTypeDef errorcode = HAL_OK;
 
+  if (hspi->State != HAL_SPI_STATE_READY)
+  {
+    errorcode = HAL_BUSY;
+    goto error;
+  }
+
   if ((hspi->Init.Mode == SPI_MODE_MASTER) && (hspi->Init.Direction == SPI_DIRECTION_2LINES))
   {
     hspi->State = HAL_SPI_STATE_BUSY_RX;
@@ -1026,12 +1037,6 @@ HAL_StatusTypeDef HAL_SPI_Receive(SPI_HandleTypeDef *hspi, uint8_t *pData, uint1
 
   /* Init tickstart for timeout management*/
   tickstart = HAL_GetTick();
-
-  if (hspi->State != HAL_SPI_STATE_READY)
-  {
-    errorcode = HAL_BUSY;
-    goto error;
-  }
 
   if ((pData == NULL) || (Size == 0U))
   {
@@ -1110,6 +1115,7 @@ HAL_StatusTypeDef HAL_SPI_Receive(SPI_HandleTypeDef *hspi, uint8_t *pData, uint1
         if ((((HAL_GetTick() - tickstart) >=  Timeout) && (Timeout != HAL_MAX_DELAY)) || (Timeout == 0U))
         {
           errorcode = HAL_TIMEOUT;
+          hspi->State = HAL_SPI_STATE_READY;
           goto error;
         }
       }
@@ -1133,6 +1139,7 @@ HAL_StatusTypeDef HAL_SPI_Receive(SPI_HandleTypeDef *hspi, uint8_t *pData, uint1
         if ((((HAL_GetTick() - tickstart) >=  Timeout) && (Timeout != HAL_MAX_DELAY)) || (Timeout == 0U))
         {
           errorcode = HAL_TIMEOUT;
+          hspi->State = HAL_SPI_STATE_READY;
           goto error;
         }
       }
@@ -1227,9 +1234,12 @@ HAL_StatusTypeDef HAL_SPI_Receive(SPI_HandleTypeDef *hspi, uint8_t *pData, uint1
   {
     errorcode = HAL_ERROR;
   }
+  else
+  {
+    hspi->State = HAL_SPI_STATE_READY;
+  }
 
 error :
-  hspi->State = HAL_SPI_STATE_READY;
   __HAL_UNLOCK(hspi);
   return errorcode;
 }
@@ -1350,6 +1360,20 @@ HAL_StatusTypeDef HAL_SPI_TransmitReceive(SPI_HandleTypeDef *hspi, uint8_t *pTxD
       hspi->Instance->DR = *((uint16_t *)hspi->pTxBuffPtr);
       hspi->pTxBuffPtr += sizeof(uint16_t);
       hspi->TxXferCount--;
+
+#if (USE_SPI_CRC != 0U)
+      /* Enable CRC Transmission */
+      if ((hspi->TxXferCount == 0U) && (hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLE))
+      {
+        /* Set NSS Soft to received correctly the CRC on slave mode with NSS pulse activated */
+        if ((READ_BIT(spi_cr1, SPI_CR1_MSTR) == 0U) && (READ_BIT(spi_cr2, SPI_CR2_NSSP) == SPI_CR2_NSSP))
+        {
+          SET_BIT(hspi->Instance->CR1, SPI_CR1_SSM);
+        }
+        SET_BIT(hspi->Instance->CR1, SPI_CR1_CRCNEXT);
+      }
+#endif /* USE_SPI_CRC */
+
     }
     while ((hspi->TxXferCount > 0U) || (hspi->RxXferCount > 0U))
     {
@@ -1388,6 +1412,7 @@ HAL_StatusTypeDef HAL_SPI_TransmitReceive(SPI_HandleTypeDef *hspi, uint8_t *pTxD
       if (((HAL_GetTick() - tickstart) >=  Timeout) && (Timeout != HAL_MAX_DELAY))
       {
         errorcode = HAL_TIMEOUT;
+        hspi->State = HAL_SPI_STATE_READY;
         goto error;
       }
     }
@@ -1408,6 +1433,19 @@ HAL_StatusTypeDef HAL_SPI_TransmitReceive(SPI_HandleTypeDef *hspi, uint8_t *pTxD
         *(__IO uint8_t *)&hspi->Instance->DR = (*hspi->pTxBuffPtr);
         hspi->pTxBuffPtr++;
         hspi->TxXferCount--;
+
+#if (USE_SPI_CRC != 0U)
+        /* Enable CRC Transmission */
+        if ((hspi->TxXferCount == 0U) && (hspi->Init.CRCCalculation == SPI_CRCCALCULATION_ENABLE))
+        {
+          /* Set NSS Soft to received correctly the CRC on slave mode with NSS pulse activated */
+          if ((READ_BIT(spi_cr1, SPI_CR1_MSTR) == 0U) && (READ_BIT(spi_cr2, SPI_CR2_NSSP) == SPI_CR2_NSSP))
+          {
+            SET_BIT(hspi->Instance->CR1, SPI_CR1_SSM);
+          }
+          SET_BIT(hspi->Instance->CR1, SPI_CR1_CRCNEXT);
+        }
+#endif /* USE_SPI_CRC */
       }
     }
     while ((hspi->TxXferCount > 0U) || (hspi->RxXferCount > 0U))
@@ -1470,6 +1508,7 @@ HAL_StatusTypeDef HAL_SPI_TransmitReceive(SPI_HandleTypeDef *hspi, uint8_t *pTxD
       if ((((HAL_GetTick() - tickstart) >=  Timeout) && ((Timeout != HAL_MAX_DELAY))) || (Timeout == 0U))
       {
         errorcode = HAL_TIMEOUT;
+        hspi->State = HAL_SPI_STATE_READY;
         goto error;
       }
     }
@@ -1539,8 +1578,16 @@ HAL_StatusTypeDef HAL_SPI_TransmitReceive(SPI_HandleTypeDef *hspi, uint8_t *pTxD
     hspi->ErrorCode = HAL_SPI_ERROR_FLAG;
   }
 
+  if (hspi->ErrorCode != HAL_SPI_ERROR_NONE)
+  {
+    errorcode = HAL_ERROR;
+  }
+  else
+  {
+    hspi->State = HAL_SPI_STATE_READY;
+  }
+  
 error :
-  hspi->State = HAL_SPI_STATE_READY;
   __HAL_UNLOCK(hspi);
   return errorcode;
 }
@@ -1560,8 +1607,6 @@ HAL_StatusTypeDef HAL_SPI_Transmit_IT(SPI_HandleTypeDef *hspi, uint8_t *pData, u
   /* Check Direction parameter */
   assert_param(IS_SPI_DIRECTION_2LINES_OR_1LINE(hspi->Init.Direction));
 
-  /* Process Locked */
-  __HAL_LOCK(hspi);
 
   if ((pData == NULL) || (Size == 0U))
   {
@@ -1574,6 +1619,9 @@ HAL_StatusTypeDef HAL_SPI_Transmit_IT(SPI_HandleTypeDef *hspi, uint8_t *pData, u
     errorcode = HAL_BUSY;
     goto error;
   }
+
+  /* Process Locked */
+  __HAL_LOCK(hspi);
 
   /* Set the transaction information */
   hspi->State       = HAL_SPI_STATE_BUSY_TX;
@@ -1614,10 +1662,6 @@ HAL_StatusTypeDef HAL_SPI_Transmit_IT(SPI_HandleTypeDef *hspi, uint8_t *pData, u
   }
 #endif /* USE_SPI_CRC */
 
-  /* Enable TXE and ERR interrupt */
-  __HAL_SPI_ENABLE_IT(hspi, (SPI_IT_TXE | SPI_IT_ERR));
-
-
   /* Check if the SPI is already enabled */
   if ((hspi->Instance->CR1 & SPI_CR1_SPE) != SPI_CR1_SPE)
   {
@@ -1625,8 +1669,12 @@ HAL_StatusTypeDef HAL_SPI_Transmit_IT(SPI_HandleTypeDef *hspi, uint8_t *pData, u
     __HAL_SPI_ENABLE(hspi);
   }
 
-error :
+  /* Process Unlocked */
   __HAL_UNLOCK(hspi);
+  /* Enable TXE and ERR interrupt */
+  __HAL_SPI_ENABLE_IT(hspi, (SPI_IT_TXE | SPI_IT_ERR));
+
+error :
   return errorcode;
 }
 
@@ -1642,15 +1690,6 @@ HAL_StatusTypeDef HAL_SPI_Receive_IT(SPI_HandleTypeDef *hspi, uint8_t *pData, ui
 {
   HAL_StatusTypeDef errorcode = HAL_OK;
 
-  if ((hspi->Init.Direction == SPI_DIRECTION_2LINES) && (hspi->Init.Mode == SPI_MODE_MASTER))
-  {
-    hspi->State = HAL_SPI_STATE_BUSY_RX;
-    /* Call transmit-receive function to send Dummy data on Tx line and generate clock on CLK line */
-    return HAL_SPI_TransmitReceive_IT(hspi, pData, pData, Size);
-  }
-
-  /* Process Locked */
-  __HAL_LOCK(hspi);
 
   if (hspi->State != HAL_SPI_STATE_READY)
   {
@@ -1658,11 +1697,22 @@ HAL_StatusTypeDef HAL_SPI_Receive_IT(SPI_HandleTypeDef *hspi, uint8_t *pData, ui
     goto error;
   }
 
+  if ((hspi->Init.Direction == SPI_DIRECTION_2LINES) && (hspi->Init.Mode == SPI_MODE_MASTER))
+  {
+    hspi->State = HAL_SPI_STATE_BUSY_RX;
+    /* Call transmit-receive function to send Dummy data on Tx line and generate clock on CLK line */
+    return HAL_SPI_TransmitReceive_IT(hspi, pData, pData, Size);
+  }
+
+
   if ((pData == NULL) || (Size == 0U))
   {
     errorcode = HAL_ERROR;
     goto error;
   }
+
+  /* Process Locked */
+  __HAL_LOCK(hspi);
 
   /* Set the transaction information */
   hspi->State       = HAL_SPI_STATE_BUSY_RX;
@@ -1716,9 +1766,6 @@ HAL_StatusTypeDef HAL_SPI_Receive_IT(SPI_HandleTypeDef *hspi, uint8_t *pData, ui
   }
 #endif /* USE_SPI_CRC */
 
-  /* Enable TXE and ERR interrupt */
-  __HAL_SPI_ENABLE_IT(hspi, (SPI_IT_RXNE | SPI_IT_ERR));
-
   /* Note : The SPI must be enabled after unlocking current process
             to avoid the risk of SPI interrupt handle execution before current
             process unlock */
@@ -1730,9 +1777,12 @@ HAL_StatusTypeDef HAL_SPI_Receive_IT(SPI_HandleTypeDef *hspi, uint8_t *pData, ui
     __HAL_SPI_ENABLE(hspi);
   }
 
-error :
   /* Process Unlocked */
   __HAL_UNLOCK(hspi);
+  /* Enable RXNE and ERR interrupt */
+  __HAL_SPI_ENABLE_IT(hspi, (SPI_IT_RXNE | SPI_IT_ERR));
+
+error :
   return errorcode;
 }
 
@@ -1754,9 +1804,6 @@ HAL_StatusTypeDef HAL_SPI_TransmitReceive_IT(SPI_HandleTypeDef *hspi, uint8_t *p
   /* Check Direction parameter */
   assert_param(IS_SPI_DIRECTION_2LINES(hspi->Init.Direction));
 
-  /* Process locked */
-  __HAL_LOCK(hspi);
-
   /* Init temporary variables */
   tmp_state           = hspi->State;
   tmp_mode            = hspi->Init.Mode;
@@ -1773,6 +1820,9 @@ HAL_StatusTypeDef HAL_SPI_TransmitReceive_IT(SPI_HandleTypeDef *hspi, uint8_t *p
     errorcode = HAL_ERROR;
     goto error;
   }
+
+  /* Process locked */
+  __HAL_LOCK(hspi);
 
   /* Don't overwrite in case of HAL_SPI_STATE_BUSY_RX */
   if (hspi->State != HAL_SPI_STATE_BUSY_RX)
@@ -1830,8 +1880,6 @@ HAL_StatusTypeDef HAL_SPI_TransmitReceive_IT(SPI_HandleTypeDef *hspi, uint8_t *p
     SET_BIT(hspi->Instance->CR2, SPI_RXFIFO_THRESHOLD);
   }
 
-  /* Enable TXE, RXNE and ERR interrupt */
-  __HAL_SPI_ENABLE_IT(hspi, (SPI_IT_TXE | SPI_IT_RXNE | SPI_IT_ERR));
 
   /* Check if the SPI is already enabled */
   if ((hspi->Instance->CR1 & SPI_CR1_SPE) != SPI_CR1_SPE)
@@ -1840,9 +1888,12 @@ HAL_StatusTypeDef HAL_SPI_TransmitReceive_IT(SPI_HandleTypeDef *hspi, uint8_t *p
     __HAL_SPI_ENABLE(hspi);
   }
 
-error :
   /* Process Unlocked */
   __HAL_UNLOCK(hspi);
+  /* Enable TXE, RXNE and ERR interrupt */
+  __HAL_SPI_ENABLE_IT(hspi, (SPI_IT_TXE | SPI_IT_RXNE | SPI_IT_ERR));
+
+error :
   return errorcode;
 }
 
@@ -1946,7 +1997,6 @@ HAL_StatusTypeDef HAL_SPI_Transmit_DMA(SPI_HandleTypeDef *hspi, uint8_t *pData, 
     SET_BIT(hspi->ErrorCode, HAL_SPI_ERROR_DMA);
     errorcode = HAL_ERROR;
 
-    hspi->State = HAL_SPI_STATE_READY;
     goto error;
   }
 
@@ -1986,6 +2036,12 @@ HAL_StatusTypeDef HAL_SPI_Receive_DMA(SPI_HandleTypeDef *hspi, uint8_t *pData, u
   /* Check rx dma handle */
   assert_param(IS_SPI_DMA_HANDLE(hspi->hdmarx));
 
+  if (hspi->State != HAL_SPI_STATE_READY)
+  {
+    errorcode = HAL_BUSY;
+    goto error;
+  }
+
   if ((hspi->Init.Direction == SPI_DIRECTION_2LINES) && (hspi->Init.Mode == SPI_MODE_MASTER))
   {
     hspi->State = HAL_SPI_STATE_BUSY_RX;
@@ -1999,12 +2055,6 @@ HAL_StatusTypeDef HAL_SPI_Receive_DMA(SPI_HandleTypeDef *hspi, uint8_t *pData, u
 
   /* Process Locked */
   __HAL_LOCK(hspi);
-
-  if (hspi->State != HAL_SPI_STATE_READY)
-  {
-    errorcode = HAL_BUSY;
-    goto error;
-  }
 
   if ((pData == NULL) || (Size == 0U))
   {
@@ -2091,7 +2141,6 @@ HAL_StatusTypeDef HAL_SPI_Receive_DMA(SPI_HandleTypeDef *hspi, uint8_t *pData, u
     SET_BIT(hspi->ErrorCode, HAL_SPI_ERROR_DMA);
     errorcode = HAL_ERROR;
 
-    hspi->State = HAL_SPI_STATE_READY;
     goto error;
   }
 
@@ -2259,7 +2308,6 @@ HAL_StatusTypeDef HAL_SPI_TransmitReceive_DMA(SPI_HandleTypeDef *hspi, uint8_t *
     SET_BIT(hspi->ErrorCode, HAL_SPI_ERROR_DMA);
     errorcode = HAL_ERROR;
 
-    hspi->State = HAL_SPI_STATE_READY;
     goto error;
   }
 
@@ -2281,7 +2329,6 @@ HAL_StatusTypeDef HAL_SPI_TransmitReceive_DMA(SPI_HandleTypeDef *hspi, uint8_t *
     SET_BIT(hspi->ErrorCode, HAL_SPI_ERROR_DMA);
     errorcode = HAL_ERROR;
 
-    hspi->State = HAL_SPI_STATE_READY;
     goto error;
   }
 

--- a/lib/STM32F7xx_HAL_Driver/Src/stm32f7xx_hal_spi_ex.c
+++ b/lib/STM32F7xx_HAL_Driver/Src/stm32f7xx_hal_spi_ex.c
@@ -76,7 +76,7 @@
   *               the configuration information for the specified SPI module.
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_SPIEx_FlushRxFifo(SPI_HandleTypeDef *hspi)
+HAL_StatusTypeDef HAL_SPIEx_FlushRxFifo(const SPI_HandleTypeDef *hspi)
 {
   __IO uint32_t tmpreg;
   uint8_t  count = 0U;

--- a/lib/STM32F7xx_HAL_Driver/Src/stm32f7xx_hal_tim.c
+++ b/lib/STM32F7xx_HAL_Driver/Src/stm32f7xx_hal_tim.c
@@ -888,7 +888,7 @@ HAL_StatusTypeDef HAL_TIM_OC_Start_IT(TIM_HandleTypeDef *htim, uint32_t Channel)
   uint32_t tmpsmcr;
 
   /* Check the parameters */
-  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+  assert_param(IS_TIM_CCX_CHANNEL(htim->Instance, Channel));
 
   /* Check the TIM channel state */
   if (TIM_CHANNEL_STATE_GET(htim, Channel) != HAL_TIM_CHANNEL_STATE_READY)
@@ -980,7 +980,7 @@ HAL_StatusTypeDef HAL_TIM_OC_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Channel)
   HAL_StatusTypeDef status = HAL_OK;
 
   /* Check the parameters */
-  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+  assert_param(IS_TIM_CCX_CHANNEL(htim->Instance, Channel));
 
   switch (Channel)
   {
@@ -1059,7 +1059,7 @@ HAL_StatusTypeDef HAL_TIM_OC_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel
   uint32_t tmpsmcr;
 
   /* Check the parameters */
-  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+  assert_param(IS_TIM_CCX_CHANNEL(htim->Instance, Channel));
 
   /* Set the TIM channel state */
   if (TIM_CHANNEL_STATE_GET(htim, Channel) == HAL_TIM_CHANNEL_STATE_BUSY)
@@ -1221,7 +1221,7 @@ HAL_StatusTypeDef HAL_TIM_OC_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Channel)
   HAL_StatusTypeDef status = HAL_OK;
 
   /* Check the parameters */
-  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+  assert_param(IS_TIM_CCX_CHANNEL(htim->Instance, Channel));
 
   switch (Channel)
   {
@@ -1557,7 +1557,7 @@ HAL_StatusTypeDef HAL_TIM_PWM_Start_IT(TIM_HandleTypeDef *htim, uint32_t Channel
   uint32_t tmpsmcr;
 
   /* Check the parameters */
-  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+  assert_param(IS_TIM_CCX_CHANNEL(htim->Instance, Channel));
 
   /* Check the TIM channel state */
   if (TIM_CHANNEL_STATE_GET(htim, Channel) != HAL_TIM_CHANNEL_STATE_READY)
@@ -1649,7 +1649,7 @@ HAL_StatusTypeDef HAL_TIM_PWM_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Channel)
   HAL_StatusTypeDef status = HAL_OK;
 
   /* Check the parameters */
-  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+  assert_param(IS_TIM_CCX_CHANNEL(htim->Instance, Channel));
 
   switch (Channel)
   {
@@ -1728,7 +1728,7 @@ HAL_StatusTypeDef HAL_TIM_PWM_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channe
   uint32_t tmpsmcr;
 
   /* Check the parameters */
-  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+  assert_param(IS_TIM_CCX_CHANNEL(htim->Instance, Channel));
 
   /* Set the TIM channel state */
   if (TIM_CHANNEL_STATE_GET(htim, Channel) == HAL_TIM_CHANNEL_STATE_BUSY)
@@ -1889,7 +1889,7 @@ HAL_StatusTypeDef HAL_TIM_PWM_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Channel
   HAL_StatusTypeDef status = HAL_OK;
 
   /* Check the parameters */
-  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+  assert_param(IS_TIM_CCX_CHANNEL(htim->Instance, Channel));
 
   switch (Channel)
   {
@@ -2133,7 +2133,7 @@ HAL_StatusTypeDef HAL_TIM_IC_Start(TIM_HandleTypeDef *htim, uint32_t Channel)
   HAL_TIM_ChannelStateTypeDef complementary_channel_state = TIM_CHANNEL_N_STATE_GET(htim, Channel);
 
   /* Check the parameters */
-  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+  assert_param(IS_TIM_CCX_CHANNEL(htim->Instance, Channel));
 
   /* Check the TIM channel state */
   if ((channel_state != HAL_TIM_CHANNEL_STATE_READY)
@@ -2181,7 +2181,7 @@ HAL_StatusTypeDef HAL_TIM_IC_Start(TIM_HandleTypeDef *htim, uint32_t Channel)
 HAL_StatusTypeDef HAL_TIM_IC_Stop(TIM_HandleTypeDef *htim, uint32_t Channel)
 {
   /* Check the parameters */
-  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+  assert_param(IS_TIM_CCX_CHANNEL(htim->Instance, Channel));
 
   /* Disable the Input Capture channel */
   TIM_CCxChannelCmd(htim->Instance, Channel, TIM_CCx_DISABLE);
@@ -2217,7 +2217,7 @@ HAL_StatusTypeDef HAL_TIM_IC_Start_IT(TIM_HandleTypeDef *htim, uint32_t Channel)
   HAL_TIM_ChannelStateTypeDef complementary_channel_state = TIM_CHANNEL_N_STATE_GET(htim, Channel);
 
   /* Check the parameters */
-  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+  assert_param(IS_TIM_CCX_CHANNEL(htim->Instance, Channel));
 
   /* Check the TIM channel state */
   if ((channel_state != HAL_TIM_CHANNEL_STATE_READY)
@@ -2305,7 +2305,7 @@ HAL_StatusTypeDef HAL_TIM_IC_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Channel)
   HAL_StatusTypeDef status = HAL_OK;
 
   /* Check the parameters */
-  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+  assert_param(IS_TIM_CCX_CHANNEL(htim->Instance, Channel));
 
   switch (Channel)
   {
@@ -2381,7 +2381,7 @@ HAL_StatusTypeDef HAL_TIM_IC_Start_DMA(TIM_HandleTypeDef *htim, uint32_t Channel
   HAL_TIM_ChannelStateTypeDef complementary_channel_state = TIM_CHANNEL_N_STATE_GET(htim, Channel);
 
   /* Check the parameters */
-  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+  assert_param(IS_TIM_CCX_CHANNEL(htim->Instance, Channel));
   assert_param(IS_TIM_DMA_CC_INSTANCE(htim->Instance));
 
   /* Set the TIM channel state */
@@ -2536,7 +2536,7 @@ HAL_StatusTypeDef HAL_TIM_IC_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Channel)
   HAL_StatusTypeDef status = HAL_OK;
 
   /* Check the parameters */
-  assert_param(IS_TIM_CCX_INSTANCE(htim->Instance, Channel));
+  assert_param(IS_TIM_CCX_CHANNEL(htim->Instance, Channel));
   assert_param(IS_TIM_DMA_CC_INSTANCE(htim->Instance));
 
   /* Disable the Input Capture channel */
@@ -3027,7 +3027,7 @@ HAL_StatusTypeDef HAL_TIM_OnePulse_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Out
   * @param  sConfig TIM Encoder Interface configuration structure
   * @retval HAL status
   */
-HAL_StatusTypeDef HAL_TIM_Encoder_Init(TIM_HandleTypeDef *htim,  TIM_Encoder_InitTypeDef *sConfig)
+HAL_StatusTypeDef HAL_TIM_Encoder_Init(TIM_HandleTypeDef *htim, const TIM_Encoder_InitTypeDef *sConfig)
 {
   uint32_t tmpsmcr;
   uint32_t tmpccmr1;
@@ -3833,13 +3833,16 @@ HAL_StatusTypeDef HAL_TIM_Encoder_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Cha
   */
 void HAL_TIM_IRQHandler(TIM_HandleTypeDef *htim)
 {
+  uint32_t itsource = htim->Instance->DIER;
+  uint32_t itflag   = htim->Instance->SR;
+
   /* Capture compare 1 event */
-  if (__HAL_TIM_GET_FLAG(htim, TIM_FLAG_CC1) != RESET)
+  if ((itflag & (TIM_FLAG_CC1)) == (TIM_FLAG_CC1))
   {
-    if (__HAL_TIM_GET_IT_SOURCE(htim, TIM_IT_CC1) != RESET)
+    if ((itsource & (TIM_IT_CC1)) == (TIM_IT_CC1))
     {
       {
-        __HAL_TIM_CLEAR_IT(htim, TIM_IT_CC1);
+        __HAL_TIM_CLEAR_FLAG(htim, TIM_FLAG_CC1);
         htim->Channel = HAL_TIM_ACTIVE_CHANNEL_1;
 
         /* Input capture event */
@@ -3867,11 +3870,11 @@ void HAL_TIM_IRQHandler(TIM_HandleTypeDef *htim)
     }
   }
   /* Capture compare 2 event */
-  if (__HAL_TIM_GET_FLAG(htim, TIM_FLAG_CC2) != RESET)
+  if ((itflag & (TIM_FLAG_CC2)) == (TIM_FLAG_CC2))
   {
-    if (__HAL_TIM_GET_IT_SOURCE(htim, TIM_IT_CC2) != RESET)
+    if ((itsource & (TIM_IT_CC2)) == (TIM_IT_CC2))
     {
-      __HAL_TIM_CLEAR_IT(htim, TIM_IT_CC2);
+      __HAL_TIM_CLEAR_FLAG(htim, TIM_FLAG_CC2);
       htim->Channel = HAL_TIM_ACTIVE_CHANNEL_2;
       /* Input capture event */
       if ((htim->Instance->CCMR1 & TIM_CCMR1_CC2S) != 0x00U)
@@ -3897,11 +3900,11 @@ void HAL_TIM_IRQHandler(TIM_HandleTypeDef *htim)
     }
   }
   /* Capture compare 3 event */
-  if (__HAL_TIM_GET_FLAG(htim, TIM_FLAG_CC3) != RESET)
+  if ((itflag & (TIM_FLAG_CC3)) == (TIM_FLAG_CC3))
   {
-    if (__HAL_TIM_GET_IT_SOURCE(htim, TIM_IT_CC3) != RESET)
+    if ((itsource & (TIM_IT_CC3)) == (TIM_IT_CC3))
     {
-      __HAL_TIM_CLEAR_IT(htim, TIM_IT_CC3);
+      __HAL_TIM_CLEAR_FLAG(htim, TIM_FLAG_CC3);
       htim->Channel = HAL_TIM_ACTIVE_CHANNEL_3;
       /* Input capture event */
       if ((htim->Instance->CCMR2 & TIM_CCMR2_CC3S) != 0x00U)
@@ -3927,11 +3930,11 @@ void HAL_TIM_IRQHandler(TIM_HandleTypeDef *htim)
     }
   }
   /* Capture compare 4 event */
-  if (__HAL_TIM_GET_FLAG(htim, TIM_FLAG_CC4) != RESET)
+  if ((itflag & (TIM_FLAG_CC4)) == (TIM_FLAG_CC4))
   {
-    if (__HAL_TIM_GET_IT_SOURCE(htim, TIM_IT_CC4) != RESET)
+    if ((itsource & (TIM_IT_CC4)) == (TIM_IT_CC4))
     {
-      __HAL_TIM_CLEAR_IT(htim, TIM_IT_CC4);
+      __HAL_TIM_CLEAR_FLAG(htim, TIM_FLAG_CC4);
       htim->Channel = HAL_TIM_ACTIVE_CHANNEL_4;
       /* Input capture event */
       if ((htim->Instance->CCMR2 & TIM_CCMR2_CC4S) != 0x00U)
@@ -3957,11 +3960,11 @@ void HAL_TIM_IRQHandler(TIM_HandleTypeDef *htim)
     }
   }
   /* TIM Update event */
-  if (__HAL_TIM_GET_FLAG(htim, TIM_FLAG_UPDATE) != RESET)
+  if ((itflag & (TIM_FLAG_UPDATE)) == (TIM_FLAG_UPDATE))
   {
-    if (__HAL_TIM_GET_IT_SOURCE(htim, TIM_IT_UPDATE) != RESET)
+    if ((itsource & (TIM_IT_UPDATE)) == (TIM_IT_UPDATE))
     {
-      __HAL_TIM_CLEAR_IT(htim, TIM_IT_UPDATE);
+      __HAL_TIM_CLEAR_FLAG(htim, TIM_FLAG_UPDATE);
 #if (USE_HAL_TIM_REGISTER_CALLBACKS == 1)
       htim->PeriodElapsedCallback(htim);
 #else
@@ -3970,11 +3973,12 @@ void HAL_TIM_IRQHandler(TIM_HandleTypeDef *htim)
     }
   }
   /* TIM Break input event */
-  if (__HAL_TIM_GET_FLAG(htim, TIM_FLAG_BREAK) != RESET)
+  if (((itflag & (TIM_FLAG_BREAK)) == (TIM_FLAG_BREAK)) || \
+      ((itflag & (TIM_FLAG_SYSTEM_BREAK)) == (TIM_FLAG_SYSTEM_BREAK)))
   {
-    if (__HAL_TIM_GET_IT_SOURCE(htim, TIM_IT_BREAK) != RESET)
+    if ((itsource & (TIM_IT_BREAK)) == (TIM_IT_BREAK))
     {
-      __HAL_TIM_CLEAR_IT(htim, TIM_IT_BREAK);
+      __HAL_TIM_CLEAR_FLAG(htim, TIM_FLAG_BREAK | TIM_FLAG_SYSTEM_BREAK);
 #if (USE_HAL_TIM_REGISTER_CALLBACKS == 1)
       htim->BreakCallback(htim);
 #else
@@ -3983,9 +3987,9 @@ void HAL_TIM_IRQHandler(TIM_HandleTypeDef *htim)
     }
   }
   /* TIM Break2 input event */
-  if (__HAL_TIM_GET_FLAG(htim, TIM_FLAG_BREAK2) != RESET)
+  if ((itflag & (TIM_FLAG_BREAK2)) == (TIM_FLAG_BREAK2))
   {
-    if (__HAL_TIM_GET_IT_SOURCE(htim, TIM_IT_BREAK) != RESET)
+    if ((itsource & (TIM_IT_BREAK)) == (TIM_IT_BREAK))
     {
       __HAL_TIM_CLEAR_FLAG(htim, TIM_FLAG_BREAK2);
 #if (USE_HAL_TIM_REGISTER_CALLBACKS == 1)
@@ -3996,11 +4000,11 @@ void HAL_TIM_IRQHandler(TIM_HandleTypeDef *htim)
     }
   }
   /* TIM Trigger detection event */
-  if (__HAL_TIM_GET_FLAG(htim, TIM_FLAG_TRIGGER) != RESET)
+  if ((itflag & (TIM_FLAG_TRIGGER)) == (TIM_FLAG_TRIGGER))
   {
-    if (__HAL_TIM_GET_IT_SOURCE(htim, TIM_IT_TRIGGER) != RESET)
+    if ((itsource & (TIM_IT_TRIGGER)) == (TIM_IT_TRIGGER))
     {
-      __HAL_TIM_CLEAR_IT(htim, TIM_IT_TRIGGER);
+      __HAL_TIM_CLEAR_FLAG(htim, TIM_FLAG_TRIGGER);
 #if (USE_HAL_TIM_REGISTER_CALLBACKS == 1)
       htim->TriggerCallback(htim);
 #else
@@ -4009,11 +4013,11 @@ void HAL_TIM_IRQHandler(TIM_HandleTypeDef *htim)
     }
   }
   /* TIM commutation event */
-  if (__HAL_TIM_GET_FLAG(htim, TIM_FLAG_COM) != RESET)
+  if ((itflag & (TIM_FLAG_COM)) == (TIM_FLAG_COM))
   {
-    if (__HAL_TIM_GET_IT_SOURCE(htim, TIM_IT_COM) != RESET)
+    if ((itsource & (TIM_IT_COM)) == (TIM_IT_COM))
     {
-      __HAL_TIM_CLEAR_IT(htim, TIM_FLAG_COM);
+      __HAL_TIM_CLEAR_FLAG(htim, TIM_FLAG_COM);
 #if (USE_HAL_TIM_REGISTER_CALLBACKS == 1)
       htim->CommutationCallback(htim);
 #else
@@ -4565,7 +4569,8 @@ HAL_StatusTypeDef HAL_TIM_OnePulse_ConfigChannel(TIM_HandleTypeDef *htim,  TIM_O
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_TIM_DMABurst_WriteStart(TIM_HandleTypeDef *htim, uint32_t BurstBaseAddress,
-                                              uint32_t BurstRequestSrc, const uint32_t *BurstBuffer, uint32_t  BurstLength)
+                                              uint32_t BurstRequestSrc, const uint32_t *BurstBuffer,
+                                              uint32_t  BurstLength)
 {
   HAL_StatusTypeDef status;
 
@@ -5982,8 +5987,6 @@ HAL_StatusTypeDef HAL_TIM_RegisterCallback(TIM_HandleTypeDef *htim, HAL_TIM_Call
   {
     return HAL_ERROR;
   }
-  /* Process locked */
-  __HAL_LOCK(htim);
 
   if (htim->State == HAL_TIM_STATE_READY)
   {
@@ -6179,9 +6182,6 @@ HAL_StatusTypeDef HAL_TIM_RegisterCallback(TIM_HandleTypeDef *htim, HAL_TIM_Call
     status = HAL_ERROR;
   }
 
-  /* Release Lock */
-  __HAL_UNLOCK(htim);
-
   return status;
 }
 
@@ -6224,9 +6224,6 @@ HAL_StatusTypeDef HAL_TIM_RegisterCallback(TIM_HandleTypeDef *htim, HAL_TIM_Call
 HAL_StatusTypeDef HAL_TIM_UnRegisterCallback(TIM_HandleTypeDef *htim, HAL_TIM_CallbackIDTypeDef CallbackID)
 {
   HAL_StatusTypeDef status = HAL_OK;
-
-  /* Process locked */
-  __HAL_LOCK(htim);
 
   if (htim->State == HAL_TIM_STATE_READY)
   {
@@ -6463,9 +6460,6 @@ HAL_StatusTypeDef HAL_TIM_UnRegisterCallback(TIM_HandleTypeDef *htim, HAL_TIM_Ca
     /* Return error status */
     status = HAL_ERROR;
   }
-
-  /* Release Lock */
-  __HAL_UNLOCK(htim);
 
   return status;
 }
@@ -6973,6 +6967,13 @@ void TIM_Base_SetConfig(TIM_TypeDef *TIMx, const TIM_Base_InitTypeDef *Structure
   /* Generate an update event to reload the Prescaler
      and the repetition counter (only for advanced timer) value immediately */
   TIMx->EGR = TIM_EGR_UG;
+
+  /* Check if the update flag is set after the Update Generation, if so clear the UIF flag */
+  if (HAL_IS_BIT_SET(TIMx->SR, TIM_FLAG_UPDATE))
+  {
+    /* Clear the update flag */
+    CLEAR_BIT(TIMx->SR, TIM_FLAG_UPDATE);
+  }
 }
 
 /**
@@ -6987,11 +6988,12 @@ static void TIM_OC1_SetConfig(TIM_TypeDef *TIMx, const TIM_OC_InitTypeDef *OC_Co
   uint32_t tmpccer;
   uint32_t tmpcr2;
 
+  /* Get the TIMx CCER register value */
+  tmpccer = TIMx->CCER;
+
   /* Disable the Channel 1: Reset the CC1E Bit */
   TIMx->CCER &= ~TIM_CCER_CC1E;
 
-  /* Get the TIMx CCER register value */
-  tmpccer = TIMx->CCER;
   /* Get the TIMx CR2 register value */
   tmpcr2 =  TIMx->CR2;
 
@@ -7062,11 +7064,12 @@ void TIM_OC2_SetConfig(TIM_TypeDef *TIMx, const TIM_OC_InitTypeDef *OC_Config)
   uint32_t tmpccer;
   uint32_t tmpcr2;
 
+  /* Get the TIMx CCER register value */
+  tmpccer = TIMx->CCER;
+
   /* Disable the Channel 2: Reset the CC2E Bit */
   TIMx->CCER &= ~TIM_CCER_CC2E;
 
-  /* Get the TIMx CCER register value */
-  tmpccer = TIMx->CCER;
   /* Get the TIMx CR2 register value */
   tmpcr2 =  TIMx->CR2;
 
@@ -7095,7 +7098,6 @@ void TIM_OC2_SetConfig(TIM_TypeDef *TIMx, const TIM_OC_InitTypeDef *OC_Config)
     tmpccer |= (OC_Config->OCNPolarity << 4U);
     /* Reset the Output N State */
     tmpccer &= ~TIM_CCER_CC2NE;
-
   }
 
   if (IS_TIM_BREAK_INSTANCE(TIMx))
@@ -7138,11 +7140,12 @@ static void TIM_OC3_SetConfig(TIM_TypeDef *TIMx, const TIM_OC_InitTypeDef *OC_Co
   uint32_t tmpccer;
   uint32_t tmpcr2;
 
+  /* Get the TIMx CCER register value */
+  tmpccer = TIMx->CCER;
+
   /* Disable the Channel 3: Reset the CC2E Bit */
   TIMx->CCER &= ~TIM_CCER_CC3E;
 
-  /* Get the TIMx CCER register value */
-  tmpccer = TIMx->CCER;
   /* Get the TIMx CR2 register value */
   tmpcr2 =  TIMx->CR2;
 
@@ -7212,11 +7215,12 @@ static void TIM_OC4_SetConfig(TIM_TypeDef *TIMx, const TIM_OC_InitTypeDef *OC_Co
   uint32_t tmpccer;
   uint32_t tmpcr2;
 
+  /* Get the TIMx CCER register value */
+  tmpccer = TIMx->CCER;
+
   /* Disable the Channel 4: Reset the CC4E Bit */
   TIMx->CCER &= ~TIM_CCER_CC4E;
 
-  /* Get the TIMx CCER register value */
-  tmpccer = TIMx->CCER;
   /* Get the TIMx CR2 register value */
   tmpcr2 =  TIMx->CR2;
 
@@ -7273,11 +7277,12 @@ static void TIM_OC5_SetConfig(TIM_TypeDef *TIMx,
   uint32_t tmpccer;
   uint32_t tmpcr2;
 
+  /* Get the TIMx CCER register value */
+  tmpccer = TIMx->CCER;
+
   /* Disable the output: Reset the CCxE Bit */
   TIMx->CCER &= ~TIM_CCER_CC5E;
 
-  /* Get the TIMx CCER register value */
-  tmpccer = TIMx->CCER;
   /* Get the TIMx CR2 register value */
   tmpcr2 =  TIMx->CR2;
   /* Get the TIMx CCMR1 register value */
@@ -7326,11 +7331,12 @@ static void TIM_OC6_SetConfig(TIM_TypeDef *TIMx,
   uint32_t tmpccer;
   uint32_t tmpcr2;
 
+  /* Get the TIMx CCER register value */
+  tmpccer = TIMx->CCER;
+
   /* Disable the output: Reset the CCxE Bit */
   TIMx->CCER &= ~TIM_CCER_CC6E;
 
-  /* Get the TIMx CCER register value */
-  tmpccer = TIMx->CCER;
   /* Get the TIMx CR2 register value */
   tmpcr2 =  TIMx->CR2;
   /* Get the TIMx CCMR1 register value */
@@ -7514,9 +7520,9 @@ void TIM_TI1_SetConfig(TIM_TypeDef *TIMx, uint32_t TIM_ICPolarity, uint32_t TIM_
   uint32_t tmpccer;
 
   /* Disable the Channel 1: Reset the CC1E Bit */
+  tmpccer = TIMx->CCER;
   TIMx->CCER &= ~TIM_CCER_CC1E;
   tmpccmr1 = TIMx->CCMR1;
-  tmpccer = TIMx->CCER;
 
   /* Select the Input */
   if (IS_TIM_CC2_INSTANCE(TIMx) != RESET)
@@ -7604,9 +7610,9 @@ static void TIM_TI2_SetConfig(TIM_TypeDef *TIMx, uint32_t TIM_ICPolarity, uint32
   uint32_t tmpccer;
 
   /* Disable the Channel 2: Reset the CC2E Bit */
+  tmpccer = TIMx->CCER;
   TIMx->CCER &= ~TIM_CCER_CC2E;
   tmpccmr1 = TIMx->CCMR1;
-  tmpccer = TIMx->CCER;
 
   /* Select the Input */
   tmpccmr1 &= ~TIM_CCMR1_CC2S;
@@ -7643,9 +7649,9 @@ static void TIM_TI2_ConfigInputStage(TIM_TypeDef *TIMx, uint32_t TIM_ICPolarity,
   uint32_t tmpccer;
 
   /* Disable the Channel 2: Reset the CC2E Bit */
+  tmpccer = TIMx->CCER;
   TIMx->CCER &= ~TIM_CCER_CC2E;
   tmpccmr1 = TIMx->CCMR1;
-  tmpccer = TIMx->CCER;
 
   /* Set the filter */
   tmpccmr1 &= ~TIM_CCMR1_IC2F;
@@ -7687,9 +7693,9 @@ static void TIM_TI3_SetConfig(TIM_TypeDef *TIMx, uint32_t TIM_ICPolarity, uint32
   uint32_t tmpccer;
 
   /* Disable the Channel 3: Reset the CC3E Bit */
+  tmpccer = TIMx->CCER;
   TIMx->CCER &= ~TIM_CCER_CC3E;
   tmpccmr2 = TIMx->CCMR2;
-  tmpccer = TIMx->CCER;
 
   /* Select the Input */
   tmpccmr2 &= ~TIM_CCMR2_CC3S;
@@ -7735,9 +7741,9 @@ static void TIM_TI4_SetConfig(TIM_TypeDef *TIMx, uint32_t TIM_ICPolarity, uint32
   uint32_t tmpccer;
 
   /* Disable the Channel 4: Reset the CC4E Bit */
+  tmpccer = TIMx->CCER;
   TIMx->CCER &= ~TIM_CCER_CC4E;
   tmpccmr2 = TIMx->CCMR2;
-  tmpccer = TIMx->CCER;
 
   /* Select the Input */
   tmpccmr2 &= ~TIM_CCMR2_CC4S;

--- a/lib/STM32F7xx_HAL_Driver/Src/stm32f7xx_hal_tim_ex.c
+++ b/lib/STM32F7xx_HAL_Driver/Src/stm32f7xx_hal_tim_ex.c
@@ -836,7 +836,7 @@ HAL_StatusTypeDef HAL_TIMEx_OCN_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Channe
 
     /* Disable the TIM Break interrupt (only if no more channel is active) */
     tmpccer = htim->Instance->CCER;
-    if ((tmpccer & (TIM_CCER_CC1NE | TIM_CCER_CC2NE | TIM_CCER_CC3NE)) == (uint32_t)RESET)
+    if ((tmpccer & TIM_CCER_CCxNE_MASK) == (uint32_t)RESET)
     {
       __HAL_TIM_DISABLE_IT(htim, TIM_IT_BREAK);
     }
@@ -1082,17 +1082,6 @@ HAL_StatusTypeDef HAL_TIMEx_OCN_Stop_DMA(TIM_HandleTypeDef *htim, uint32_t Chann
     (+) Stop the Complementary PWM and disable interrupts.
     (+) Start the Complementary PWM and enable DMA transfers.
     (+) Stop the Complementary PWM and disable DMA transfers.
-    (+) Start the Complementary Input Capture measurement.
-    (+) Stop the Complementary Input Capture.
-    (+) Start the Complementary Input Capture and enable interrupts.
-    (+) Stop the Complementary Input Capture and disable interrupts.
-    (+) Start the Complementary Input Capture and enable DMA transfers.
-    (+) Stop the Complementary Input Capture and disable DMA transfers.
-    (+) Start the Complementary One Pulse generation.
-    (+) Stop the Complementary One Pulse.
-    (+) Start the Complementary One Pulse and enable interrupts.
-    (+) Stop the Complementary One Pulse and disable interrupts.
-
 @endverbatim
   * @{
   */
@@ -1318,7 +1307,7 @@ HAL_StatusTypeDef HAL_TIMEx_PWMN_Stop_IT(TIM_HandleTypeDef *htim, uint32_t Chann
 
     /* Disable the TIM Break interrupt (only if no more channel is active) */
     tmpccer = htim->Instance->CCER;
-    if ((tmpccer & (TIM_CCER_CC1NE | TIM_CCER_CC2NE | TIM_CCER_CC3NE)) == (uint32_t)RESET)
+    if ((tmpccer & TIM_CCER_CCxNE_MASK) == (uint32_t)RESET)
     {
       __HAL_TIM_DISABLE_IT(htim, TIM_IT_BREAK);
     }
@@ -2105,7 +2094,6 @@ HAL_StatusTypeDef HAL_TIMEx_ConfigBreakDeadTime(TIM_HandleTypeDef *htim,
 HAL_StatusTypeDef HAL_TIMEx_ConfigBreakInput(TIM_HandleTypeDef *htim,
                                              uint32_t BreakInput,
                                              const TIMEx_BreakInputConfigTypeDef *sBreakInputConfig)
-
 {
   HAL_StatusTypeDef status = HAL_OK;
   uint32_t tmporx;
@@ -2315,7 +2303,7 @@ HAL_StatusTypeDef HAL_TIMEx_GroupChannel5(TIM_HandleTypeDef *htim, uint32_t Chan
   */
 
 /**
-  * @brief  Hall commutation changed callback in non-blocking mode
+  * @brief  Commutation callback in non-blocking mode
   * @param  htim TIM handle
   * @retval None
   */
@@ -2329,7 +2317,7 @@ __weak void HAL_TIMEx_CommutCallback(TIM_HandleTypeDef *htim)
    */
 }
 /**
-  * @brief  Hall commutation changed half complete callback in non-blocking mode
+  * @brief  Commutation half complete callback in non-blocking mode
   * @param  htim TIM handle
   * @retval None
   */
@@ -2344,7 +2332,7 @@ __weak void HAL_TIMEx_CommutHalfCpltCallback(TIM_HandleTypeDef *htim)
 }
 
 /**
-  * @brief  Hall Break detection callback in non-blocking mode
+  * @brief  Break detection callback in non-blocking mode
   * @param  htim TIM handle
   * @retval None
   */
@@ -2359,7 +2347,7 @@ __weak void HAL_TIMEx_BreakCallback(TIM_HandleTypeDef *htim)
 }
 
 /**
-  * @brief  Hall Break2 detection callback in non blocking mode
+  * @brief  Break2 detection callback in non blocking mode
   * @param  htim: TIM handle
   * @retval None
   */
@@ -2510,15 +2498,6 @@ static void TIM_DMADelayPulseNCplt(DMA_HandleTypeDef *hdma)
       TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_3, HAL_TIM_CHANNEL_STATE_READY);
     }
   }
-  else if (hdma == htim->hdma[TIM_DMA_ID_CC4])
-  {
-    htim->Channel = HAL_TIM_ACTIVE_CHANNEL_4;
-
-    if (hdma->Init.Mode == DMA_NORMAL)
-    {
-      TIM_CHANNEL_N_STATE_SET(htim, TIM_CHANNEL_4, HAL_TIM_CHANNEL_STATE_READY);
-    }
-  }
   else
   {
     /* nothing to do */
@@ -2587,13 +2566,13 @@ static void TIM_CCxNChannelCmd(TIM_TypeDef *TIMx, uint32_t Channel, uint32_t Cha
 {
   uint32_t tmp;
 
-  tmp = TIM_CCER_CC1NE << (Channel & 0x1FU); /* 0x1FU = 31 bits max shift */
+  tmp = TIM_CCER_CC1NE << (Channel & 0xFU); /* 0xFU = 15 bits max shift */
 
   /* Reset the CCxNE Bit */
   TIMx->CCER &=  ~tmp;
 
   /* Set or reset the CCxNE Bit */
-  TIMx->CCER |= (uint32_t)(ChannelNState << (Channel & 0x1FU)); /* 0x1FU = 31 bits max shift */
+  TIMx->CCER |= (uint32_t)(ChannelNState << (Channel & 0xFU)); /* 0xFU = 15 bits max shift */
 }
 /**
   * @}

--- a/src/core/newlib_lock_glue.c
+++ b/src/core/newlib_lock_glue.c
@@ -1,0 +1,423 @@
+/**
+  ******************************************************************************
+  * @file      newlib_lock_glue.c
+  * @author    STMicroelectronics
+  * @brief     Implementation of newlib lock interface
+  *
+  * @details   This file implements locking glue necessary to protect C library
+  *            functions and initialization of local static objects in C++.
+  *            Lock strategies are defined in stm32_lock.h that implements
+  *            different level of thread-safety.
+  *
+  *            For more information about which C functions need which of these
+  *            low level functions, please consult the newlib libc manual,
+  *            see https://sourceware.org/newlib/libc.html
+  *
+  *            For more information about the one-time construction API for C++,
+  *            see https://itanium-cxx-abi.github.io/cxx-abi/abi.html#once-ctor
+  *
+  ******************************************************************************
+  * @attention
+  *
+  * Copyright (c) 2024 STMicroelectronics.
+  * All rights reserved.
+  *
+  * This software is licensed under terms that can be found in the LICENSE file
+  * in the root directory of this software component.
+  * If no LICENSE file comes with this software, it is provided AS-IS.
+  *
+  ******************************************************************************
+  */
+
+#if !defined (__GNUC__) || defined (__CC_ARM)
+#error "newlib_lock_glue.c" should be used with GNU Compilers only
+#endif /* !defined (__GNUC__) || defined (__CC_ARM) */
+
+/* Includes ------------------------------------------------------------------*/
+#include <cmsis_compiler.h>
+
+/* Private functions ---------------------------------------------------------*/
+
+/**
+  * @brief Global Error_Handler
+  */
+__WEAK void Error_Handler(void)
+{
+  /* Not used if it exists in project */
+  while (1);
+}
+
+#ifdef __SINGLE_THREAD__
+#warning C library is in single-threaded mode. Please take care when using C library functions in threaded contexts
+#else
+
+/* Includes ------------------------------------------------------------------*/
+#include <newlib.h>
+#include <stdatomic.h>
+#include "stm32_lock.h"
+
+/**
+  * @defgroup _newlib_lock_functions newlib library locks
+  * @see https://sourceware.org/newlib/libc.html
+  * @{
+  */
+
+#if __NEWLIB__ >= 3 && defined (_RETARGETABLE_LOCKING)
+#include <errno.h>
+#include <stdlib.h>
+#include <sys/lock.h>
+
+/* Private macros ------------------------------------------------------------*/
+/** See struct __lock definition */
+#define STM32_LOCK_PARAMETER(lock) (&(lock)->lock_data)
+
+/* Private variables ---------------------------------------------------------*/
+struct __lock
+{
+  LockingData_t lock_data; /**< The STM32 lock instance */
+};
+
+/** Implementing mutex from <a href="https://sourceware.org/git/?p=newlib-cygwin.git;a=blob_plain;f=newlib/libc/misc/lock.c">newlib/libc/misc/lock.c</a> */
+struct __lock __lock___sinit_recursive_mutex = { LOCKING_DATA_INIT };
+
+/** Implementing mutex from <a href="https://sourceware.org/git/?p=newlib-cygwin.git;a=blob_plain;f=newlib/libc/misc/lock.c">newlib/libc/misc/lock.c</a> */
+struct __lock __lock___sfp_recursive_mutex = { LOCKING_DATA_INIT };
+
+/** Implementing mutex from <a href="https://sourceware.org/git/?p=newlib-cygwin.git;a=blob_plain;f=newlib/libc/misc/lock.c">newlib/libc/misc/lock.c</a> */
+struct __lock __lock___atexit_recursive_mutex = { LOCKING_DATA_INIT };
+
+/** Implementing mutex from <a href="https://sourceware.org/git/?p=newlib-cygwin.git;a=blob_plain;f=newlib/libc/misc/lock.c">newlib/libc/misc/lock.c</a> */
+struct __lock __lock___at_quick_exit_mutex = { LOCKING_DATA_INIT };
+
+/** Implementing mutex from <a href="https://sourceware.org/git/?p=newlib-cygwin.git;a=blob_plain;f=newlib/libc/misc/lock.c">newlib/libc/misc/lock.c</a> */
+struct __lock __lock___malloc_recursive_mutex = { LOCKING_DATA_INIT };
+
+/** Implementing mutex from <a href="https://sourceware.org/git/?p=newlib-cygwin.git;a=blob_plain;f=newlib/libc/misc/lock.c">newlib/libc/misc/lock.c</a> */
+struct __lock __lock___env_recursive_mutex = { LOCKING_DATA_INIT };
+
+/** Implementing mutex from <a href="https://sourceware.org/git/?p=newlib-cygwin.git;a=blob_plain;f=newlib/libc/misc/lock.c">newlib/libc/misc/lock.c</a> */
+struct __lock __lock___tz_mutex = { LOCKING_DATA_INIT };
+
+/** Implementing mutex from <a href="https://sourceware.org/git/?p=newlib-cygwin.git;a=blob_plain;f=newlib/libc/misc/lock.c">newlib/libc/misc/lock.c</a> */
+struct __lock __lock___dd_hash_mutex = { LOCKING_DATA_INIT };
+
+/** Implementing mutex from <a href="https://sourceware.org/git/?p=newlib-cygwin.git;a=blob_plain;f=newlib/libc/misc/lock.c">newlib/libc/misc/lock.c</a> */
+struct __lock __lock___arc4random_mutex = { LOCKING_DATA_INIT };
+
+/* Private functions ---------------------------------------------------------*/
+
+/**
+  * @brief Initialize lock
+  * @param lock The lock
+  */
+void __retarget_lock_init(_LOCK_T *lock)
+{
+  __retarget_lock_init_recursive(lock);
+}
+
+/**
+  * @brief Initialize recursive lock
+  * @param lock The lock
+  */
+void __retarget_lock_init_recursive(_LOCK_T *lock)
+{
+  if (lock == NULL)
+  {
+    errno = EINVAL;
+    return;
+  }
+
+  *lock = (_LOCK_T)malloc(sizeof(struct __lock));
+  if (*lock != NULL)
+  {
+    stm32_lock_init(STM32_LOCK_PARAMETER(*lock));
+    return;
+  }
+
+  /* Unable to allocate memory */
+  STM32_LOCK_BLOCK();
+}
+
+/**
+  * @brief Close lock
+  * @param lock The lock
+  */
+void __retarget_lock_close(_LOCK_T lock)
+{
+  __retarget_lock_close_recursive(lock);
+}
+
+/**
+  * @brief Close recursive lock
+  * @param lock The lock
+  */
+void __retarget_lock_close_recursive(_LOCK_T lock)
+{
+  free(lock);
+}
+
+/**
+  * @brief Acquire lock
+  * @param lock The lock
+  */
+void __retarget_lock_acquire(_LOCK_T lock)
+{
+  STM32_LOCK_BLOCK_IF_NULL_ARGUMENT(lock);
+  stm32_lock_acquire(STM32_LOCK_PARAMETER(lock));
+}
+
+/**
+  * @brief Acquire recursive lock
+  * @param lock The lock
+  */
+void __retarget_lock_acquire_recursive(_LOCK_T lock)
+{
+  STM32_LOCK_BLOCK_IF_NULL_ARGUMENT(lock);
+  stm32_lock_acquire(STM32_LOCK_PARAMETER(lock));
+}
+
+/**
+  * @brief Try acquire lock
+  * @param lock The lock
+  * @return 0 always
+  */
+int __retarget_lock_try_acquire(_LOCK_T lock)
+{
+  __retarget_lock_acquire(lock);
+  return 0;
+}
+
+/**
+  * @brief Try acquire recursive lock
+  * @param lock The lock
+  * @return 0 always
+  */
+int __retarget_lock_try_acquire_recursive(_LOCK_T lock)
+{
+  __retarget_lock_acquire_recursive(lock);
+  return 0;
+}
+
+/**
+  * @brief Release lock
+  * @param lock The lock
+  */
+void __retarget_lock_release(_LOCK_T lock)
+{
+  STM32_LOCK_BLOCK_IF_NULL_ARGUMENT(lock);
+  stm32_lock_release(STM32_LOCK_PARAMETER(lock));
+}
+
+/**
+  * @brief Release recursive lock
+  * @param lock The lock
+  */
+void __retarget_lock_release_recursive(_LOCK_T lock)
+{
+  STM32_LOCK_BLOCK_IF_NULL_ARGUMENT(lock);
+  stm32_lock_release(STM32_LOCK_PARAMETER(lock));
+}
+
+#else
+#warning This makes malloc, env, and TZ calls thread-safe, not the entire newlib
+
+/* Includes ------------------------------------------------------------------*/
+#include <reent.h>
+
+/* Private variables ---------------------------------------------------------*/
+/** Mutex used in __malloc_lock and __malloc_unlock */
+static LockingData_t __lock___malloc_recursive_mutex = LOCKING_DATA_INIT;
+
+/** Mutex used in __env_lock and __env_unlock */
+static LockingData_t __lock___env_recursive_mutex = LOCKING_DATA_INIT;
+
+/** Mutex used in __tz_lock and __tz_unlock */
+static LockingData_t __lock___tz_mutex = LOCKING_DATA_INIT;
+
+/* Private functions ---------------------------------------------------------*/
+
+#if __STD_C
+
+/**
+  * @brief Acquire malloc lock
+  * @param reent The reentrance struct
+  */
+void __malloc_lock(struct _reent *reent)
+{
+  STM32_LOCK_UNUSED(reent);
+  stm32_lock_acquire(&__lock___malloc_recursive_mutex);
+}
+
+/**
+  * @brief Release malloc lock
+  * @param reent The reentrance struct
+  */
+void __malloc_unlock(struct _reent *reent)
+{
+  STM32_LOCK_UNUSED(reent);
+  stm32_lock_release(&__lock___malloc_recursive_mutex);
+}
+
+#else
+
+/**
+  * @brief Acquire malloc lock
+  */
+void __malloc_lock()
+{
+  stm32_lock_acquire(&__lock___malloc_recursive_mutex);
+}
+
+/**
+  * @brief Release malloc lock
+  */
+void __malloc_unlock()
+{
+  stm32_lock_release(&__lock___malloc_recursive_mutex);
+}
+#endif /* __STD_C */
+
+/**
+  * @brief Acquire env lock
+  * @param reent The reentrance struct
+  */
+void __env_lock(struct _reent *reent)
+{
+  STM32_LOCK_UNUSED(reent);
+  stm32_lock_acquire(&__lock___env_recursive_mutex);
+}
+
+/**
+  * @brief Release env lock
+  * @param reent The reentrance struct
+  */
+void __env_unlock(struct _reent *reent)
+{
+  STM32_LOCK_UNUSED(reent);
+  stm32_lock_release(&__lock___env_recursive_mutex);
+}
+
+/**
+  * @brief Acquire tz lock
+  */
+void __tz_lock()
+{
+  stm32_lock_acquire(&__lock___tz_mutex);
+}
+
+/**
+  * @brief Release tz lock
+  */
+void __tz_unlock()
+{
+  stm32_lock_release(&__lock___tz_mutex);
+}
+
+#endif /* __NEWLIB__ >= 3 && defined (_RETARGETABLE_LOCKING) */
+
+/**
+  * @}
+  */
+
+
+/**
+  * @defgroup __cxa_guard_ GNU C++ one-time construction API
+  * @see https://itanium-cxx-abi.github.io/cxx-abi/abi.html#once-ctor
+  *
+  * When building for C++, please make sure that <tt>-fno-threadsafe-statics</tt> is not passed to the compiler
+  * @{
+  */
+
+/* Private typedef -----------------------------------------------------------*/
+/** The guard object is created by the C++ compiler and is 32 bit for ARM EABI. */
+typedef struct
+{
+  atomic_uchar initialized; /**< Indicate if object is initialized */
+  uint8_t acquired; /**< Ensure non-recursive lock */
+  uint16_t unused; /**< Padding */
+} __attribute__((packed)) CxaGuardObject_t;
+
+/* Private variables ---------------------------------------------------------*/
+/** Mutex used in __cxa_guard_acquire, __cxa_guard_release and __cxa_guard_abort */
+static LockingData_t __cxa_guard_mutex = LOCKING_DATA_INIT;
+
+/* Private functions ---------------------------------------------------------*/
+
+/**
+  * @brief Acquire __cxa_guard mutex
+  * @param guard_object Guard object
+  * @return 0 if object is initialized, else initialization of object required
+  */
+int __cxa_guard_acquire(CxaGuardObject_t *guard_object)
+{
+  STM32_LOCK_BLOCK_IF_NULL_ARGUMENT(guard_object);
+
+  if (atomic_load(&guard_object->initialized) == 0)
+  {
+    /* Object needs initialization, lock threading context */
+    stm32_lock_acquire(&__cxa_guard_mutex);
+    if (atomic_load(&guard_object->initialized) == 0)
+    {
+      /* Object needs initialization */
+      if (guard_object->acquired)
+      {
+        /* Object initialization already in progress */
+        STM32_LOCK_BLOCK();
+      }
+
+      /* Lock acquired */
+      guard_object->acquired = 1;
+      return 1;
+    }
+    else
+    {
+      /* Object initialized in another thread */
+      stm32_lock_release(&__cxa_guard_mutex);
+    }
+  }
+
+  /* Object already initialized */
+  return 0;
+}
+
+/**
+  * @brief Abort __cxa_guard mutex
+  * @param guard_object Guard object
+  */
+void __cxa_guard_abort(CxaGuardObject_t *guard_object)
+{
+  STM32_LOCK_BLOCK_IF_NULL_ARGUMENT(guard_object);
+
+  if (guard_object->acquired)
+  {
+    /* Release lock */
+    guard_object->acquired = 0;
+    stm32_lock_release(&__cxa_guard_mutex);
+  }
+  else
+  {
+    /* Trying to release non-acquired lock */
+    STM32_LOCK_BLOCK();
+  }
+}
+
+/**
+  * @brief Release __cxa_guard mutex
+  * @param guard_object Guard object
+  */
+void __cxa_guard_release(CxaGuardObject_t *guard_object)
+{
+  STM32_LOCK_BLOCK_IF_NULL_ARGUMENT(guard_object);
+
+  /* Object initialized */
+  atomic_store(&guard_object->initialized, 1);
+
+  /* Release lock */
+  __cxa_guard_abort(guard_object);
+}
+
+/**
+  * @}
+  */
+
+#endif /* __SINGLE_THREAD__ */

--- a/src/core/startup_stm32f767zitx.s
+++ b/src/core/startup_stm32f767zitx.s
@@ -60,6 +60,9 @@ defined in linker script */
 Reset_Handler:  
   ldr   sp, =_estack      /* set stack pointer */
 
+/* Call the clock system initialization function.*/
+  bl  SystemInit   
+
 /* Copy the data segment initializers from flash to SRAM */  
   ldr r0, =_sdata
   ldr r1, =_edata
@@ -90,9 +93,7 @@ FillZerobss:
 LoopFillZerobss:
   cmp r2, r4
   bcc FillZerobss
-
-/* Call the clock system initialization function.*/
-  bl  SystemInit   
+  
 /* Call static constructors */
     bl __libc_init_array
 /* Call the application's entry point.*/

--- a/src/core/stm32f7xx_hal_msp.c
+++ b/src/core/stm32f7xx_hal_msp.c
@@ -1,3 +1,4 @@
+
 /* USER CODE BEGIN Header */
 /**
   ******************************************************************************
@@ -20,7 +21,6 @@
 
 /* Includes ------------------------------------------------------------------*/
 #include "main.h"
-
 /* USER CODE BEGIN Includes */
 
 /* USER CODE END Includes */
@@ -63,6 +63,7 @@
   */
 void HAL_MspInit(void)
 {
+
   /* USER CODE BEGIN MspInit 0 */
 
   /* USER CODE END MspInit 0 */
@@ -100,10 +101,10 @@ void HAL_ADC_MspInit(ADC_HandleTypeDef* hadc)
     /**ADC1 GPIO Configuration
     PA1     ------> ADC1_IN1
     */
-    GPIO_InitStruct.Pin = GPIO_PIN_1;
+    GPIO_InitStruct.Pin = V_LV_Pin;
     GPIO_InitStruct.Mode = GPIO_MODE_ANALOG;
     GPIO_InitStruct.Pull = GPIO_NOPULL;
-    HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
+    HAL_GPIO_Init(V_LV_GPIO_Port, &GPIO_InitStruct);
 
   /* USER CODE BEGIN ADC1_MspInit 1 */
 
@@ -121,10 +122,10 @@ void HAL_ADC_MspInit(ADC_HandleTypeDef* hadc)
     /**ADC2 GPIO Configuration
     PA2     ------> ADC2_IN2
     */
-    GPIO_InitStruct.Pin = GPIO_PIN_2;
+    GPIO_InitStruct.Pin = THROTTLE_POSITION_Pin;
     GPIO_InitStruct.Mode = GPIO_MODE_ANALOG;
     GPIO_InitStruct.Pull = GPIO_NOPULL;
-    HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);
+    HAL_GPIO_Init(THROTTLE_POSITION_GPIO_Port, &GPIO_InitStruct);
 
   /* USER CODE BEGIN ADC2_MspInit 1 */
 
@@ -152,7 +153,7 @@ void HAL_ADC_MspDeInit(ADC_HandleTypeDef* hadc)
     /**ADC1 GPIO Configuration
     PA1     ------> ADC1_IN1
     */
-    HAL_GPIO_DeInit(GPIOA, GPIO_PIN_1);
+    HAL_GPIO_DeInit(V_LV_GPIO_Port, V_LV_Pin);
 
   /* USER CODE BEGIN ADC1_MspDeInit 1 */
 
@@ -169,7 +170,7 @@ void HAL_ADC_MspDeInit(ADC_HandleTypeDef* hadc)
     /**ADC2 GPIO Configuration
     PA2     ------> ADC2_IN2
     */
-    HAL_GPIO_DeInit(GPIOA, GPIO_PIN_2);
+    HAL_GPIO_DeInit(THROTTLE_POSITION_GPIO_Port, THROTTLE_POSITION_Pin);
 
   /* USER CODE BEGIN ADC2_MspDeInit 1 */
 
@@ -207,9 +208,15 @@ void HAL_CAN_MspInit(CAN_HandleTypeDef* hcan)
     GPIO_InitStruct.Alternate = GPIO_AF9_CAN1;
     HAL_GPIO_Init(GPIOB, &GPIO_InitStruct);
 
+    /* CAN1 interrupt Init */
+    HAL_NVIC_SetPriority(CAN1_RX0_IRQn, 5, 0);
+    HAL_NVIC_EnableIRQ(CAN1_RX0_IRQn);
+    HAL_NVIC_SetPriority(CAN1_RX1_IRQn, 5, 0);
+    HAL_NVIC_EnableIRQ(CAN1_RX1_IRQn);
   /* USER CODE BEGIN CAN1_MspInit 1 */
 
   /* USER CODE END CAN1_MspInit 1 */
+
   }
 
 }
@@ -236,9 +243,68 @@ void HAL_CAN_MspDeInit(CAN_HandleTypeDef* hcan)
     */
     HAL_GPIO_DeInit(GPIOB, GPIO_PIN_8|GPIO_PIN_9);
 
+    /* CAN1 interrupt DeInit */
+    HAL_NVIC_DisableIRQ(CAN1_RX0_IRQn);
+    HAL_NVIC_DisableIRQ(CAN1_RX1_IRQn);
   /* USER CODE BEGIN CAN1_MspDeInit 1 */
 
   /* USER CODE END CAN1_MspDeInit 1 */
+  }
+
+}
+
+/**
+* @brief RTC MSP Initialization
+* This function configures the hardware resources used in this example
+* @param hrtc: RTC handle pointer
+* @retval None
+*/
+void HAL_RTC_MspInit(RTC_HandleTypeDef* hrtc)
+{
+  RCC_PeriphCLKInitTypeDef PeriphClkInitStruct = {0};
+  if(hrtc->Instance==RTC)
+  {
+  /* USER CODE BEGIN RTC_MspInit 0 */
+
+  /* USER CODE END RTC_MspInit 0 */
+
+  /** Initializes the peripherals clock
+  */
+    PeriphClkInitStruct.PeriphClockSelection = RCC_PERIPHCLK_RTC;
+    PeriphClkInitStruct.RTCClockSelection = RCC_RTCCLKSOURCE_LSI;
+    if (HAL_RCCEx_PeriphCLKConfig(&PeriphClkInitStruct) != HAL_OK)
+    {
+      Error_Handler();
+    }
+
+    /* Peripheral clock enable */
+    __HAL_RCC_RTC_ENABLE();
+  /* USER CODE BEGIN RTC_MspInit 1 */
+
+  /* USER CODE END RTC_MspInit 1 */
+
+  }
+
+}
+
+/**
+* @brief RTC MSP De-Initialization
+* This function freeze the hardware resources used in this example
+* @param hrtc: RTC handle pointer
+* @retval None
+*/
+void HAL_RTC_MspDeInit(RTC_HandleTypeDef* hrtc)
+{
+  if(hrtc->Instance==RTC)
+  {
+  /* USER CODE BEGIN RTC_MspDeInit 0 */
+
+  /* USER CODE END RTC_MspDeInit 0 */
+    /* Peripheral clock disable */
+    __HAL_RCC_RTC_DISABLE();
+  /* USER CODE BEGIN RTC_MspDeInit 1 */
+
+  /* USER CODE END RTC_MspDeInit 1 */
   }
 
 }
@@ -263,9 +329,10 @@ void HAL_SPI_MspInit(SPI_HandleTypeDef* hspi)
     __HAL_RCC_GPIOA_CLK_ENABLE();
     /**SPI1 GPIO Configuration
     PA5     ------> SPI1_SCK
+    PA6     ------> SPI1_MISO
     PA7     ------> SPI1_MOSI
     */
-    GPIO_InitStruct.Pin = GPIO_PIN_5|GPIO_PIN_7;
+    GPIO_InitStruct.Pin = GPIO_PIN_5|GPIO_PIN_6|GPIO_PIN_7;
     GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
     GPIO_InitStruct.Pull = GPIO_NOPULL;
     GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
@@ -275,6 +342,7 @@ void HAL_SPI_MspInit(SPI_HandleTypeDef* hspi)
   /* USER CODE BEGIN SPI1_MspInit 1 */
 
   /* USER CODE END SPI1_MspInit 1 */
+
   }
 
 }
@@ -297,9 +365,10 @@ void HAL_SPI_MspDeInit(SPI_HandleTypeDef* hspi)
 
     /**SPI1 GPIO Configuration
     PA5     ------> SPI1_SCK
+    PA6     ------> SPI1_MISO
     PA7     ------> SPI1_MOSI
     */
-    HAL_GPIO_DeInit(GPIOA, GPIO_PIN_5|GPIO_PIN_7);
+    HAL_GPIO_DeInit(GPIOA, GPIO_PIN_5|GPIO_PIN_6|GPIO_PIN_7);
 
   /* USER CODE BEGIN SPI1_MspDeInit 1 */
 

--- a/src/core/stm32f7xx_hal_timebase_tim.c
+++ b/src/core/stm32f7xx_hal_timebase_tim.c
@@ -49,10 +49,8 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority)
 
   /* Enable TIM1 clock */
   __HAL_RCC_TIM1_CLK_ENABLE();
-
   /* Get clock configuration */
   HAL_RCC_GetClockConfig(&clkconfig, &pFLatency);
-
   /* Compute TIM1 clock */
       uwTimclock = 2*HAL_RCC_GetPCLK2Freq();
 

--- a/src/core/stm32f7xx_it.c
+++ b/src/core/stm32f7xx_it.c
@@ -55,6 +55,7 @@
 /* USER CODE END 0 */
 
 /* External variables --------------------------------------------------------*/
+extern CAN_HandleTypeDef hcan1;
 extern TIM_HandleTypeDef htim1;
 
 /* USER CODE BEGIN EV */
@@ -158,6 +159,34 @@ void DebugMon_Handler(void)
 /* For the available peripheral interrupt handler names,                      */
 /* please refer to the startup file (startup_stm32f7xx.s).                    */
 /******************************************************************************/
+
+/**
+  * @brief This function handles CAN1 RX0 interrupts.
+  */
+void CAN1_RX0_IRQHandler(void)
+{
+  /* USER CODE BEGIN CAN1_RX0_IRQn 0 */
+
+  /* USER CODE END CAN1_RX0_IRQn 0 */
+  HAL_CAN_IRQHandler(&hcan1);
+  /* USER CODE BEGIN CAN1_RX0_IRQn 1 */
+
+  /* USER CODE END CAN1_RX0_IRQn 1 */
+}
+
+/**
+  * @brief This function handles CAN1 RX1 interrupt.
+  */
+void CAN1_RX1_IRQHandler(void)
+{
+  /* USER CODE BEGIN CAN1_RX1_IRQn 0 */
+
+  /* USER CODE END CAN1_RX1_IRQn 0 */
+  HAL_CAN_IRQHandler(&hcan1);
+  /* USER CODE BEGIN CAN1_RX1_IRQn 1 */
+
+  /* USER CODE END CAN1_RX1_IRQn 1 */
+}
 
 /**
   * @brief This function handles TIM1 update interrupt and TIM10 global interrupt.

--- a/src/core/syscalls.c
+++ b/src/core/syscalls.c
@@ -10,7 +10,7 @@
  ******************************************************************************
  * @attention
  *
- * Copyright (c) 2020-2023 STMicroelectronics.
+ * Copyright (c) 2020-2024 STMicroelectronics.
  * All rights reserved.
  *
  * This software is licensed under terms that can be found in the LICENSE file

--- a/src/core/sysmem.c
+++ b/src/core/sysmem.c
@@ -10,7 +10,7 @@
  ******************************************************************************
  * @attention
  *
- * Copyright (c) 2023 STMicroelectronics.
+ * Copyright (c) 2024 STMicroelectronics.
  * All rights reserved.
  *
  * This software is licensed under terms that can be found in the LICENSE file


### PR DESCRIPTION
Rewrote CAN receive code to use interrupts instead of polling, Increased control loop rate, Keeping inverters enabled at 0 torque - prevents startup delay and makes moving from 0 throttle significantly smoother.

Enabled FPU and thread safe RTOS functions.